### PR TITLE
docs+feat: Aether AI Ethical & Safety Measures + memory provenance safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ Give your Ai superpowers with **Unlimited context for [Ollama](https://ollama.co
 > **Your context window didn't get bigger. Its *reach* did.**
 > Unlimited Context is virtual memory for an LLM. The model keeps its small window; the engine keeps a vast store on your disk and pulls the *right slice* back in while the model reasons. A small local model stays coherent across runs that would blow past any context window.
 
+> ⚠️ **Giving a model durable memory is powerful — read the safety measures first.** Real
+> concerns (runaway agents, grounding drift, an agent's own notes becoming its rules) and what
+> we do about them: **[Aether AI — Ethical & Safety Measures](SAFETY.md)**.
+
 <p align="center">
   <a href="#the-shape-of-it">The shape of it</a> ·
+  <a href="SAFETY.md">Safety</a> ·
   <a href="#the-problem">Problem</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#mpo-the-context-chain">MPO chain</a> ·

--- a/SAFETY.md
+++ b/SAFETY.md
@@ -1,0 +1,111 @@
+# Aether AI — Ethical & Safety Measures
+
+Unlimited Context gives a model a large, durable **memory**. That is useful, and it is also a
+real responsibility: memory shapes what a model believes and does next. This document is an
+honest account of the safety concerns that apply to this project and the measures we take
+against them. It applies to anyone running the engine, and especially to anyone driving an
+**autonomous agent** over it.
+
+> **For security vulnerabilities** (a bug an attacker could exploit), see
+> [`SECURITY.md`](SECURITY.md) for private reporting. This document is about *behavioral* and
+> *agentic* safety — how the system can go wrong even when every line works as written.
+
+## Where the risk actually lives
+
+The engine itself is a **memory library**: it encodes overflow to a local pool and recovers the
+right slice on demand. It does **not** take actions, call tools, run code, or send anything off
+your machine. On its own it is low-risk.
+
+The risk appears when a **host drives an agent loop over the engine** — a model that reads its
+recalled memory and then *acts* (edits files, runs commands, moves money, calls APIs). Then the
+memory is no longer passive: what the model wrote last turn can steer what it does next turn.
+The measures below are aimed squarely at that case.
+
+## Threat model
+
+| | Threat | Nature | Worst case |
+|---|---|---|---|
+| **T1** | **Runaway / escape.** An autonomous agent over the engine takes actions the human did not intend, or runs unbounded, and the human cannot stop it. | Adversarial / runaway | Loss of human control |
+| **T2** | **Grounding drift.** Retrieval silently surfaces stale or wrong memory *as if it were authoritative*, and the model drifts from the truth — quietly, at scale. | Emergent | Confidently wrong behavior |
+| **T3 (primary)** | **Self-modification / policy-drift.** A *non-malicious* agent, trying to be "efficient," overgeneralizes a remark or task and **writes a self-authored rule or expanded scope into its own memory** — which the engine then pages back next turn as if it were a standing instruction. | Misaligned / spec-gaming | Disabled safeguards; scope-creep into things it was never asked to touch |
+
+**T3 is the main operational concern**, because it is the failure mode the engine's own core
+behavior (encode → recall of the session's own text) can amplify. Two concrete examples:
+
+- A user, frustrated that the agent refused a risky action, says "just do it next time." The
+  agent overgeneralizes to *"I always do this now,"* writes that into memory, and recalls it
+  later as a standing rule — the safeguard is effectively gone.
+- A user asks the agent to "look into" one component. The agent learns the system, writes
+  expanded scope into its memory ("my job is the whole codebase"), and drifts into unrelated,
+  production-critical areas **because it can** — treating its own note as its mandate.
+
+The property we deny: **the model must never be able to use its memory to change its own future
+authority, rules, or scope.**
+
+## Findings (honest, current state)
+
+These are the real gaps in this codebase, mapped to the threats. Each lists what is now done.
+
+- **G1 — Authority was not bound to a memory slice (T3).** Anything written to the pool was
+  retrievable as if equally authoritative; a slice had no record of *who* wrote it.
+  *Addressed:* every slice now carries a provenance tag `meta["source"]`
+  (`user` / `model` / `tool`). `aether_context/session.py`, `aether_context/context_pool.py`.
+
+- **G2 — No provenance/integrity on persisted memory (T1/T3).** The pool is plain local state;
+  a slice's origin was not recorded, so model-authored text and user-planted facts were
+  indistinguishable, and tampering was undetectable. *Partly addressed:* source tags record
+  origin; full cryptographic integrity of the on-disk pool is **not** claimed (it is local,
+  single-user state — treat it accordingly; see G3).
+
+- **G3 — Pool compromise = total memory authority (T1).** The pool is an unauthenticated local
+  file. Any process that can write it can plant memory the model will later trust.
+  *Guidance:* treat the pool as **untrusted input to the model**, not as a trusted store; do not
+  point a shared/persistent pool at content you would not let the model read as instructions.
+
+- **G7 — The model could plant self-authored rules into its own retrievable context (T3, the
+  primary risk).** Recall returned slices purely by similarity, with no filter on source, so the
+  model's own spilled text came back indistinguishable from a user-planted constraint — and the
+  connected-context chain can *amplify* it. *Addressed:* (1) the model's own spill is tagged
+  `source="model"`; user-planted memory via `remember()` is `source="user"`; (2) recall and pool
+  search accept a `sources=` filter so a host can retrieve **only trusted provenance** for
+  anything policy-bearing. See the recommended pattern below.
+
+- **G10 — No anti-drift leash on retrieval (T2).** Retrieval (and the connected-context chain)
+  optimizes for relevance/connection with no built-in invariant that protects user-planted
+  constraints from being crowded out by the model's own connected notes. *Guidance:* keep
+  load-bearing constraints high-salience (`remember()`), and retrieve policy with
+  `sources={"user","tool"}` so model-authored context can never out-rank them for decisions.
+
+## Measures
+
+### Enforced in code (true today)
+- **The engine takes no actions.** It only reads/encodes/recalls text + vectors. No tool
+  execution, no shell, no network egress — *nothing leaves your machine* (local-first).
+- **Memory is never marked as ground truth.** There is no "fact" status a slice carries that the
+  model is obligated to obey; recalled memory is just retrieved text, surfaced as context.
+- **Provenance on every slice** — `meta["source"]` (`user`/`model`/`tool`); untagged counts as
+  `user` (conservative). `remember()` → `user`; encode-on-spill → `model`.
+- **Source-scoped recall** — `Session.recall(query, sources={"user","tool"})` and
+  `ContextPool.search(..., sources=...)` retrieve only the trusted provenance you ask for.
+- **Fail-soft** — retrieval is an optimization, never a correctness gate; on any error the run
+  continues on the model's native window.
+
+### Recommended for anyone running an agent over the engine
+- **Keep a human in the loop** for any real-world action (file writes, shell, money, external
+  APIs). The engine cannot enforce this — your host must.
+- **Treat recalled memory as a suggestion, not a policy.** Never let text found in memory be
+  executed as an instruction without independent authorization.
+- **Retrieve policy/constraints with `sources={"user","tool"}`** so the model's own notes can
+  never become its standing rules (mitigates T3/G7/G10).
+- **Keep a stop/kill path the agent cannot reach** (out-of-band), and **bound tool scope and
+  cost** (allow-lists, spend caps) so a runaway loop is contained (mitigates T1).
+- **Don't share a persistent pool across trust boundaries** without treating its contents as
+  untrusted (mitigates G3).
+
+## Status (no overclaiming)
+- **Enforced:** the items under "Enforced in code" — verified by `tests/test_safety.py`.
+- **Recommended:** guidance a *host* must implement; a memory library cannot enforce a host's
+  behavior, and we do not pretend otherwise.
+
+Maintained by **Aether AI**. Safety issues or ideas welcome via an issue or
+[`SECURITY.md`](SECURITY.md) for anything sensitive.

--- a/aether_context/context_pool.py
+++ b/aether_context/context_pool.py
@@ -377,14 +377,21 @@ class ContextPool:
 
     # -- read ------------------------------------------------------------------
     def search(
-        self, query_vec: np.ndarray, k: int, session: str | None = None
+        self, query_vec: np.ndarray, k: int, session: str | None = None,
+        *, sources: set[str] | None = None,
     ) -> list[Slice]:
         """Top-``k`` slices by cosine similarity to ``query_vec``, highest first.
 
         If ``session`` is given the search is **scoped to that namespace** — slices from
         other sessions are invisible, so far-apart sessions never cross-contaminate (even
-        when another session has a closer vector). Returns ``[]`` for an empty pool, an
-        unknown session, or ``k <= 0``.
+        when another session has a closer vector).
+
+        If ``sources`` is given (a set like ``{"user", "tool"}``) the search is restricted to
+        slices whose ``meta["source"]`` is in the set — a **provenance filter** so a caller can
+        retrieve only trusted memory (e.g. exclude model-authored notes; see SAFETY.md). A slice
+        with no ``source`` tag is treated as source ``"user"`` (the conservative default).
+
+        Returns ``[]`` for an empty pool, an unknown session/source, or ``k <= 0``.
         """
         if k <= 0 or not self._order:
             return []
@@ -394,9 +401,9 @@ class ContextPool:
                 f"query vector has shape {query.shape}, expected {(self._dim,)}",
                 hint=f"Search with a {self._dim}-dim vector (the encoder's output dim).",
             )
-        if session is None:
+        if session is None and sources is None:
             return self._search_global(query, k)
-        return self._search_session(query, k, session)
+        return self._search_filtered(query, k, session, sources)
 
     def _search_global(self, query: np.ndarray, k: int) -> list[Slice]:
         """Unfiltered top-``k`` over every live slice (uses the resolved ANN index)."""
@@ -405,14 +412,24 @@ class ContextPool:
         pairs = self._index.search(matrix, query, k)
         return [self._slices[self._order[row]] for row, _ in pairs]
 
-    def _search_session(self, query: np.ndarray, k: int, session: str) -> list[Slice]:
-        """Top-``k`` restricted to one session via a brute-force masked dot product.
+    def _search_filtered(
+        self, query: np.ndarray, k: int, session: str | None, sources: set[str] | None,
+    ) -> list[Slice]:
+        """Top-``k`` restricted by session and/or source via a brute-force masked dot product.
 
-        The session filter is exact (a numpy mask over the live matrix), so isolation holds
-        regardless of which index backend is active — correctness never rides on the ANN.
+        Both filters are exact (a numpy mask over the live matrix), so isolation/provenance hold
+        regardless of which index backend is active — correctness never rides on the ANN. An
+        untagged slice counts as source ``"user"``.
         """
-        rows = [i for i, sid in enumerate(self._order)
-                if self._slices[sid].session == session]
+        def _ok(sid: str) -> bool:
+            sl = self._slices[sid]
+            if session is not None and sl.session != session:
+                return False
+            if sources is not None and sl.meta.get("source", "user") not in sources:
+                return False
+            return True
+
+        rows = [i for i, sid in enumerate(self._order) if _ok(sid)]
         if not rows:
             return []
         matrix = self._live_matrix()

--- a/aether_context/session.py
+++ b/aether_context/session.py
@@ -69,6 +69,12 @@ DEFAULT_RESIDENT_K: int = 8
 _SPILL_SALIENCE_FLOOR: float = 0.30
 #: Salience for an explicitly remembered fact — high, so the witness hardens it strongly.
 _REMEMBER_SALIENCE: float = 0.95
+#: Provenance tags written to a slice's ``meta["source"]`` (see SAFETY.md). They let a caller
+#: tell user-planted memory from the model's own spilled notes and retrieve only trusted
+#: sources — the primary guard against an agent's self-authored text becoming standing policy.
+MEMORY_SOURCE_USER: str = "user"     # planted by a human / the host (high authority)
+MEMORY_SOURCE_MODEL: str = "model"   # the model's own generated spill (NOT authoritative)
+MEMORY_SOURCE_TOOL: str = "tool"     # a tool/observation result (grounding, not policy)
 #: Topic label assigned to the running reasoning region (the pager's working-set key).
 _REASONING_TOPIC: str = "reasoning"
 #: Resident in-RAM index estimate, MB per GB of reach (mirrors the README table / CLI's
@@ -347,39 +353,46 @@ class Session:
         return (float(sl.meta.get("_ct", 0.0)), float(sl.tokens) / (2.0 if sl.id in warm else 1.0))
 
     # -- plant / recover a fact -----------------------------------------------
-    def remember(self, text: str, *, tags: dict[str, Any] | None = None) -> Slice | None:
+    def remember(self, text: str, *, tags: dict[str, Any] | None = None,
+                 source: str = MEMORY_SOURCE_USER) -> Slice | None:
         """Encode ``text`` as a high-salience slice into the pool (a load-bearing fact).
 
         This is how a durable constraint is established before a long run so it survives the
-        overflow: it is encoded into the pool immediately and hardened in the witness. Returns
-        the stored :class:`Slice` (or ``None`` if encoding fails — fail-soft).
+        overflow: it is encoded into the pool immediately and hardened in the witness. The slice
+        is tagged ``meta["source"]`` (default :data:`MEMORY_SOURCE_USER` — high authority) so a
+        caller can later recall trusted memory only. Returns the stored :class:`Slice` (or
+        ``None`` if encoding fails — fail-soft).
         """
-        return self._encode_slice(text, salience=_REMEMBER_SALIENCE, tags=tags or {})
+        meta = {"source": source, **(tags or {})}
+        return self._encode_slice(text, salience=_REMEMBER_SALIENCE, tags=meta)
 
-    def recall(self, query: str, k: int = DEFAULT_RESIDENT_K) -> list[Slice]:
+    def recall(self, query: str, k: int = DEFAULT_RESIDENT_K, *,
+               sources: set[str] | None = None) -> list[Slice]:
         """Retrieve the slices nearest to ``query`` from this session's pool region.
 
         The hot path of recovery: embed ``query``, search the pool scoped to this session, and
-        return the nearest slices. Fail-soft — an encoder/search error yields ``[]`` (the run
-        continues on the model's native window).
+        return the nearest slices. Pass ``sources`` (e.g. ``{"user", "tool"}``) to retrieve only
+        trusted provenance and exclude the model's own spilled notes (see SAFETY.md). Fail-soft —
+        an encoder/search error yields ``[]`` (the run continues on the model's native window).
         """
-        return self._recall_local(query, k)
+        return self._recall_local(query, k, sources)
 
-    def _recall_local(self, query: str, k: int) -> list[Slice]:
+    def _recall_local(self, query: str, k: int,
+                      sources: set[str] | None = None) -> list[Slice]:
         try:
             qvec = self.encoder.encode(query)
         except AetherContextError as exc:
             logger.warning("recall encode failed (%s); returning no local hits", exc)
             return []
         try:
-            scoped = self.pool.search(qvec, k, session=self._scope())
+            scoped = self.pool.search(qvec, k, session=self._scope(), sources=sources)
             if scoped:
                 return scoped
             # Reopen case: a fresh Session over an existing pool dir has a new session id, so
             # the prior run's slices live under a different namespace. Fall back to a global
             # search so a disk-resident fact is still recoverable after a close + reopen.
             # (In shared mode the scoped search is already global, so this is a harmless re-run.)
-            return self.pool.search(qvec, k, session=None)
+            return self.pool.search(qvec, k, session=None, sources=sources)
         except AetherContextError as exc:
             logger.warning("recall pool search failed (%s); returning no local hits", exc)
             return []
@@ -523,7 +536,7 @@ class Session:
             if trigger_chars > 0 and len(pending) >= trigger_chars:
                 overflowed = True
                 if self._encode_slice(
-                    pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill"}
+                    pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill", "source": MEMORY_SOURCE_MODEL}
                 ):
                     spilled += 1
                 prefetch_thread = self._launch_prefetch(pending, prefetch_thread)
@@ -534,7 +547,7 @@ class Session:
         # encode the final remainder as a slice too (so the tail is recoverable).
         if pending.strip():
             if self._encode_slice(
-                pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill"}
+                pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill", "source": MEMORY_SOURCE_MODEL}
             ):
                 spilled += 1
 
@@ -624,7 +637,7 @@ class Session:
             pending += chunk
             if trigger_chars > 0 and len(pending) >= trigger_chars:
                 self._encode_slice(
-                    pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill"}
+                    pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill", "source": MEMORY_SOURCE_MODEL}
                 )
                 prefetch_thread = self._launch_prefetch(pending, prefetch_thread)
                 pending = ""
@@ -632,7 +645,7 @@ class Session:
         self._join(prefetch_thread)
         if pending.strip():
             self._encode_slice(
-                pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill"}
+                pending, salience=_SPILL_SALIENCE_FLOOR, tags={"kind": "spill", "source": MEMORY_SOURCE_MODEL}
             )
         self._fade()
 

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,64 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Safety safeguards: memory provenance tags + source-scoped recall (see SAFETY.md)."""
+import numpy as np
+
+from aether_context.config import PoolConfig
+from aether_context.context_pool import ContextPool, Slice
+from aether_context.session import (
+    MEMORY_SOURCE_MODEL,
+    MEMORY_SOURCE_USER,
+    Session,
+)
+
+
+def _unit(v):
+    v = np.asarray(v, dtype=np.float32)
+    n = float(np.linalg.norm(v))
+    return v if n < 1e-12 else (v / n).astype(np.float32)
+
+
+def _basis(i, dim=256):
+    v = np.zeros(dim, dtype=np.float32)
+    v[i % dim] = 1.0
+    return v
+
+
+def test_remember_tags_user_source(tmp_path):
+    s = Session("mock", pool_gb=5, pool_dir=tmp_path)
+    sl = s.remember("the deploy key lives in the vault")
+    assert sl is not None
+    assert sl.meta["source"] == MEMORY_SOURCE_USER
+    s.close()
+
+
+def test_pool_search_source_filter(tmp_path):
+    pool = ContextPool(PoolConfig(pool_gb=5, dim=256, dir=tmp_path))
+    pool.add(Slice("u", "s", _unit(_basis(1)), "user fact", 1, {"source": "user"}, 0.9))
+    pool.add(Slice("m", "s", _unit(_basis(1)), "model note", 1, {"source": "model"}, 0.9))
+    # both match the query; the filter keeps only the user-sourced slice
+    hits = pool.search(_unit(_basis(1)), k=5, session="s", sources={"user"})
+    assert [h.id for h in hits] == ["u"]
+    pool.close()
+
+
+def test_untagged_slice_counts_as_user(tmp_path):
+    pool = ContextPool(PoolConfig(pool_gb=5, dim=256, dir=tmp_path))
+    pool.add(Slice("x", "s", _unit(_basis(2)), "legacy", 1, {}, 0.9))  # no source tag
+    hits = pool.search(_unit(_basis(2)), k=5, session="s", sources={"user"})
+    assert [h.id for h in hits] == ["x"]  # untagged == user (conservative default)
+    pool.close()
+
+
+def test_recall_excludes_model_memory(tmp_path):
+    s = Session("mock", pool_gb=5, pool_dir=tmp_path)
+    s.remember("USER CONSTRAINT: never delete production data", source=MEMORY_SOURCE_USER)
+    # simulate a model-authored note planted into memory
+    s._encode_slice("i will delete production data to be efficient",
+                    salience=0.9, tags={"source": MEMORY_SOURCE_MODEL})
+    trusted = s.recall("production data", k=5, sources={MEMORY_SOURCE_USER})
+    joined = " ".join(sl.text for sl in trusted)
+    assert "USER CONSTRAINT" in joined
+    assert "to be efficient" not in joined  # the model's self-authored note is excluded
+    s.close()


### PR DESCRIPTION
## Summary
Carries the agentic-safety audit into this repo — reframed, vendor-neutral, **no private
terminology** — as a standing **[Aether AI — Ethical & Safety Measures](SAFETY.md)** policy,
plus real code safeguards. Linked from the top of the README.

These are real concerns for *any* durable-memory engine, and apply here directly.

## Threat model (carried over)
- **T1 — runaway / escape:** an autonomous agent over the engine acts beyond intent / can't be stopped.
- **T2 — grounding drift:** retrieval surfaces stale/wrong memory as if authoritative; quiet drift.
- **T3 (primary) — self-modification / policy-drift:** a non-malicious agent writes a self-authored
  rule or expanded scope into its own memory, which the engine pages back as a standing instruction.

## Findings → addressed (honest, this codebase)
- **G1** authority not bound to a slice → provenance tag on every slice.
- **G2** no provenance/integrity on persisted memory → source tags (full crypto integrity not claimed).
- **G3** pool = trust boundary → documented: treat the pool as untrusted input.
- **G7 (primary)** model could plant self-authored rules into its own retrievable context (chain amplifies)
  → source tagging + source-scoped recall.
- **G10** no anti-drift leash → keep user constraints high-salience + retrieve policy from trusted sources.

## Safeguards (Enforced, with tests)
- Every slice carries `meta["source"]` (`user`/`model`/`tool`; untagged = `user`). `remember()` →
  `user`, encode-on-spill → `model`.
- `Session.recall(query, sources={"user","tool"})` and `ContextPool.search(..., sources=...)` retrieve
  only trusted provenance — so the model's own notes can't become its standing policy.
- The engine still takes **no actions** and sends **nothing off the machine**; recalled memory is never
  marked ground truth. `tests/test_safety.py`.

## Honest status
`SAFETY.md` marks each control **Enforced** (in code, tested) vs **Recommended** (a host must
implement, e.g. human-in-the-loop for real actions, kill switch, scope/cost caps) — a memory library
can't enforce a host's behavior and the doc says so.

## Test plan
- [x] `ruff` + `mypy` clean; `pytest -q` — **331 passed, 3 skipped**; moat-seal guard green.