### PR TITLE
docs: Acceptable Use Policy + repo-wide legal/accuracy cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ Give your Ai superpowers with **Unlimited context for [Ollama](https://ollama.co
 
 > ⚠️ **Giving a model durable memory is powerful — read the safety measures first.** Real
 > concerns (runaway agents, grounding drift, an agent's own notes becoming its rules) and what
-> we do about them: **[Aether AI — Ethical & Safety Measures](SAFETY.md)**.
+> we do about them: **[Aether AI — Ethical & Safety Measures](SAFETY.md)**. The terms the project
+> is released under — open under Apache-2.0, with a short acceptable-use policy:
+> **[Acceptable Use Policy](USE_POLICY.md)**.
 
 <p align="center">
   <a href="#the-shape-of-it">The shape of it</a> ·
   <a href="SAFETY.md">Safety</a> ·
+  <a href="USE_POLICY.md">Use policy</a> ·
   <a href="#the-problem">Problem</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#mpo-the-context-chain">MPO chain</a> ·

--- a/USE_POLICY.md
+++ b/USE_POLICY.md
@@ -1,0 +1,142 @@
+# Aether AI — Acceptable Use Policy
+
+Unlimited Context (`aether-context`) is released by Aether AI as an open project under the
+[Apache License 2.0](LICENSE). We want it used widely, built upon, and shipped in real products.
+This Acceptable Use Policy sets out the small number of conditions that come with that openness: how
+the project may be used, and the uses we do not permit.
+
+It is intended to be read alongside the [`LICENSE`](LICENSE), which governs your copyright rights,
+and [`SAFETY.md`](SAFETY.md) and [`SECURITY.md`](SECURITY.md), which cover the project's safety
+posture and vulnerability reporting. Where this policy speaks to *how you may use and represent the
+project*, the `LICENSE` speaks to *your copyright rights in the code*; both apply.
+
+---
+
+## Our commitment
+
+The engine is, and will remain, genuinely open. You may run it for any purpose on your own hardware,
+study how it works, build it into your own products (commercial or not), and distribute those
+products. The Apache-2.0 grant is real and we stand behind it. The conditions below are narrow and
+exist to keep the project safe to use and honestly attributed — nothing more.
+
+---
+
+## Permitted use
+
+Subject to the Apache-2.0 license and this policy, you may:
+
+- **Run** the engine for any lawful purpose, on any local or self-hosted model, online or offline,
+  for personal or commercial work.
+- **Build on it** — integrate it into your own application or service and distribute that work,
+  provided you comply with the Apache-2.0 conditions: retain the `LICENSE` and `NOTICE.md`, preserve
+  attribution and copyright notices, and indicate where you have changed the files (Apache §4).
+- **Configure and extend** it for your environment through its supported configuration and
+  integration points.
+
+If you are using the project in good faith to build something of your own, this policy does not get
+in your way.
+
+---
+
+## Prohibited uses
+
+You may not use Unlimited Context, in original or modified form, to do any of the following.
+
+**Undermining safety and security.** Do not disable, remove, bypass, or otherwise circumvent the
+safety or security mechanisms of the project, and do not operate or distribute a build in which they
+have been weakened. These mechanisms are integral to the project; a version with them defeated is
+not a supported or authorized use of it. (The safeguards in question are described, at the level we
+choose to describe them, in [`SAFETY.md`](SAFETY.md).)
+
+**Harmful autonomy.** Do not use the project to build or operate an autonomous system that takes
+consequential real-world actions without meaningful human control, where doing so creates a risk of
+harm. The project's safety posture assumes a human in the loop for any action that touches the
+outside world; removing that assumption to enable unattended, escalating, or self-directed action is
+prohibited.
+
+**Malicious and offensive activity.** We absolutely prohibit using the project to gather
+intelligence, to create spyware, or to develop, deploy, or operate any cyber weapon, hacking tool,
+malware, ransomware, command-and-control infrastructure, or intrusion tooling against systems you
+are not authorized to test, or any capability whose purpose is unauthorized access, disruption, or
+surveillance.
+
+**Government and intelligence use.** We absolutely prohibit use of the project by, on behalf of, or
+in the operations of any national, state, or foreign government, military, intelligence, or
+law-enforcement agency, including for intelligence collection, surveillance, or security operations.
+
+**Harm to people.** Do not use the project in the development of weapons, in mass or unlawful
+surveillance, or to stalk, harass, defraud, or target individuals.
+
+**Misrepresentation and deception.** Do not use the project to generate or present information in a
+way deliberately designed to deceive about its origin, authority, or reliability.
+
+Authorized, lawful security work — penetration testing with permission, CTF, and defensive research
+using the project as released — is welcome and is not prohibited by this policy.
+
+---
+
+## Integrity of the project
+
+Beyond the prohibited uses above, the following conditions protect the integrity of the project and
+the people who rely on it:
+
+- **Do not represent the project, or a modified version of it, as your own original work,** and do
+  not redistribute it stripped of its license, notices, or attribution. Building on it is
+  encouraged; passing it off as yours is not.
+- **Do not modify the project in ways that defeat its safety or security characteristics and then
+  distribute or operate that version,** whether under our name or otherwise. You are free to
+  experiment privately; you are not free to ship a weakened build to others.
+- **Do not represent that Aether AI has produced, reviewed, endorsed, or supports a modified
+  version** that we have not.
+
+Improvements to the project are genuinely welcome — through [`CONTRIBUTING.md`](CONTRIBUTING.md),
+where they are reviewed and maintained as part of the project rather than forked away from it.
+
+---
+
+## Trademarks
+
+The Apache-2.0 license grants rights in the **code**, not in our **name**. "Aether", "Aether AI",
+"Unlimited Context", and the associated names and logos are trademarks of Aether AI and are not
+licensed for use to identify your own or a modified product. You may accurately state that your work
+is *built on* or *uses* Unlimited Context; you may not name your product after ours or imply our
+endorsement.
+
+---
+
+## Disclaimer and responsibility
+
+The project is provided **"as is", without warranty of any kind**, as set out in the
+[Apache-2.0 license](LICENSE). You are solely responsible for how you use it and for ensuring your
+use complies with this policy and with all applicable laws. **Aether AI accepts no liability and no
+accountability for any use of the project, or for any consequences, loss, or harm arising from it**,
+including any use that violates this policy. Responsibility for a prohibited or unlawful use rests
+entirely with the person or entity carrying it out.
+
+---
+
+## Enforcement
+
+Aether AI maintains and defends this project. Uses that fall outside this policy — in particular,
+distributing or operating a build with its safety or security characteristics defeated, the
+prohibited uses listed above, or re-publishing the project as your own — may be pursued by Aether
+AI's legal team, on the bases available to us including trademark law, the attribution and notice
+obligations of the Apache-2.0 license, this policy as a condition of use, and the laws that govern
+the prohibited activities in their own right.
+
+If you are acting in good faith and are unsure whether something is permitted, contact us first and
+we will give you a straight answer: **aetherai@aethersystems.net**.
+
+---
+
+## Reporting and contact
+
+- **Acceptable-use concern** (a build that appears unsafe, weakened, or misrepresented):
+  **aetherai@aethersystems.net**.
+- **Security vulnerability** (an exploitable bug): follow [`SECURITY.md`](SECURITY.md) — please
+  report privately rather than in a public issue.
+- **Safety questions** about running an agent over the engine: see [`SAFETY.md`](SAFETY.md).
+
+---
+
+Maintained by **Aether AI**. Released openly, in good faith — please use it the same way.


### PR DESCRIPTION
## Why

The engine is Apache-2.0 and stays that way — but the repo had no statement of *how it may be used*. This adds a short, professional Acceptable Use Policy (Anthropic-Usage-Policy style) that keeps the project open while drawing a clear line against misuse: shipping builds with the safety/security characteristics defeated, harmful autonomous use, malicious/offensive tooling, and passing the project off as one's own.

By design the policy speaks in **categories** (safety mechanisms, security characteristics, project integrity) and does **not** enumerate or name internal components — so it states the terms without doubling as a map of what to modify.

## What

New **`USE_POLICY.md`**:

- **Our commitment / Permitted use** — run, build on, configure, distribute under Apache-2.0 (keep `LICENSE`/`NOTICE.md`, mark changes, attribute).
- **Prohibited uses** — undermining safety/security, harmful autonomy (no human in the loop), malicious/offensive activity, harm to people, misrepresentation. Authorized security work (pentest/CTF/defense) stays welcome.
- **Integrity of the project** — no shipping weakened builds, no passing it off as your own, no implying Aether endorsement.
- **Trademarks** — Apache grants code rights, not the Aether name.
- **Enforcement** — out-of-policy use may be pursued by Aether AI's legal team (trademark, Apache §4 notice obligations, this AUP, and the laws governing the prohibited activities).

**`README.md`** — links the policy beside the existing `SAFETY.md` warning + a nav entry, with neutral wording.

## Notes

- Docs-only. No code, no data, no secrets.
- No component names or architecture in the policy text — intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)