### PR TITLE
docs(README): move the proof to the top — chart, datasets, 3 headline results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Give your Ai superpowers with **Unlimited context for [Ollama](https://ollama.co
 
 <p align="center">
   <a href="#the-shape-of-it">The shape of it</a> ·
+  <a href="#the-proof">Proof</a> ·
   <a href="SAFETY.md">Safety</a> ·
   <a href="USE_POLICY.md">Use policy</a> ·
   <a href="#the-problem">Problem</a> ·
@@ -57,6 +58,52 @@ Four steps, start to reach:
 4. **Reach 1,000×+ further** — overflow is encoded to the pool and the exact slice is recovered the moment the model needs it.
 
 That's it. A 5 GB pool gives a small model ~1.16B tokens of reach — about **9,000×** a 128K window — on your own machine, offline.
+
+</div>
+
+---
+
+## The proof
+
+Not a synthetic micro-benchmark — a **real, paid, end-to-end run.** A reasoning model
+(`deepseek-v4-pro`, via OpenRouter) driven through a **40-turn agent session that overflows its
+window** (2,000-token window, 60 real `microsoft/vscode` issues), measured **engine off vs on** —
+one live run, **$0.19**, 2026-06-14.
+
+- **The model stops forgetting.** Recall of early facts after they fall out of the window:
+  **0.15 → 1.00.** The baseline drifts and forgets; the engine holds every early fact — zero drift.
+- **Failure turns into success on the real work.** Tasks completed correctly: **3 / 20 → 20 / 20.**
+  The job is only done right *with* the engine.
+- **Cheaper, not just better.** **−24%** total cost, **−54%** in the back half — the engine sends a
+  compact recalled slice instead of dragging the whole transcript into every call.
+
+<p align="center">
+  <img alt="Cumulative cost and recall coherence vs turn — engine off vs on" width="780"
+       src="docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/api_eval_plot.png">
+</p>
+
+| Metric | Off (baseline) | On (engine) | Change |
+|---|:---:|:---:|:---:|
+| **Recall coherence** (early facts still correct) | 0.15 | **1.00** | **6.7×** |
+| **Work outcome** (tasks done right) | 3 / 20 | **20 / 20** | **3 → 20** |
+| **Cost — full session** | $0.0711 | **$0.0542** | **−24%** |
+| **Cost — back half (recall phase)** | $0.00117/turn | **$0.00053/turn** | **−54%** |
+
+**Committed data:** [full write-up](docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md) ·
+[raw artifacts](docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/) (`api_eval_results.json`,
+`api_eval_series.csv`, `api_eval_plot.png`, `RESULTS.md`) · reproduce with
+`python -m bench.api_eval --model deepseek/deepseek-v4-pro --repo microsoft/vscode --arms off,on,on_chain --plot`
+
+<sub>**Scope, honestly:** this measures the **engine** (retrieve-on-overflow memory), not the MPO
+chain — on this single-fact recall task the chain **ties** plain recall (both 1.00); its multi-slice
+edge is **synthetic-only so far** (`bench/chain_recall.py`: connected-context recall 0.15 → 0.78),
+with the live `thread` run **pending**, not yet claimed. The 2,000-token window is deliberately tiny
+to force overflow, so a realistic window shows a smaller (still real) gain. N = 20 recall turns,
+single run.</sub>
+
+---
+
+<div align="center">
 
 ## The problem
 
@@ -241,22 +288,7 @@ That's the whole thing. One small model, one command, a billion tokens of reach 
 
 ## Honest about the word "unlimited"
 
-"Unlimited" means **reach, not attention.** Your model keeps its native window — we make it *reach* a billion-token pool in slices, via fast retrieval. The whole thing rides on retrieval **hit rate**; when it's high (and the loader is built to keep it high), the pool feels like one seamless context.
-
-## Benchmark — measured, on a real model
-
-A live run on **`deepseek/deepseek-v4-pro`** (via OpenRouter), driving an agent through **60 real GitHub issues** over a **40-turn session that overflows the model's window** — engine **on** vs **off** (off = no engine, same model, transcript truncated to the window). Full write-up: [`docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md`](docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md).
-
-| Metric | Off (baseline) | On (engine) | Change |
-|---|:---:|:---:|:---:|
-| **Recall coherence** (early facts still correct) | 0.15 | **1.00** | **6.7×** |
-| **Work outcome** (tasks done right) | 3 / 20 | **20 / 20** | **3 → 20** |
-| **Cost — full session** | $0.0711 | **$0.0542** | **−24%** |
-| **Cost — back half (recall phase)** | $0.00117/turn | **$0.00053/turn** | **−54%** |
-
-What the engine provided, in one session: it **held coherence flat at 1.00 while the baseline drifted to 0.15** (early issues fell out of the window and were lost), turned a **3/20 failing run into 20/20**, and did it for **~25% less money overall — over half off in the back half**, where the baseline drags a bloated transcript into every call and the engine sends a compact recalled window. Total spend for the whole benchmark: **$0.19**. Committed raw artifacts: [`docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/`](docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/) (`api_eval_results.json`, `api_eval_series.csv`, `api_eval_plot.png`, `RESULTS.md`).
-
-<sub>**Scope, honestly:** this measures the **engine** (retrieve-on-overflow memory), not the MPO chain — on this single-fact recall task the MPO chain **ties** plain recall (both 1.00). The MPO's multi-slice edge is **synthetic-only so far** (`bench/chain_recall.py`: connected-context recall 0.15 → 0.78); the live `thread` run that would confirm it is **pending** — not yet claimed. Magnitude scales with the overflow ratio: the 2000-token window is deliberately tiny to force overflow, so a realistic window shows a smaller (still real) gain. N=20 recall turns, single run. Reproduce: `python -m bench.api_eval --model deepseek/deepseek-v4-pro --repo microsoft/vscode --arms off,on,on_chain --plot`.</sub>
+"Unlimited" means **reach, not attention.** Your model keeps its native window — we make it *reach* a billion-token pool in slices, via fast retrieval. The whole thing rides on retrieval **hit rate**; when it's high (and the loader is built to keep it high), the pool feels like one seamless context. The measured proof of all this is up top — see [The proof](#the-proof).
 
 ## Citation
 


### PR DESCRIPTION
Puts the measured evidence **at the top** of the README (right after "The shape of it"), where it leads instead of sitting near the Citation footer.

## What

A **The proof** section up top, focused on the three results from the committed live run (`deepseek-v4-pro`, 40-turn window-overflow session, engine off vs on, 2026-06-14):

- **Stops forgetting** — recall coherence **0.15 → 1.00** (zero drift)
- **Failure → success** — tasks correct **3/20 → 20/20**
- **Cheaper** — **−24%** total, **−54%** in the recall back-half

Includes:
- the **committed chart** embedded (`docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/api_eval_plot.png`)
- the precise off-vs-on results table
- links to the **committed datasets** (`api_eval_results.json`, `api_eval_series.csv`, `RESULTS.md`) + the write-up + reproduce command
- the **honest-scope caveat** (engine vs MPO chain, deliberately tiny window to force overflow, single run) — carried over, not dropped

## Cleanup
- Removed the duplicate bottom **Benchmark** section (added in #19) — consolidated into the top **The proof** so there's one source of truth; the "Honest about unlimited" section now points up to it.
- Added a **Proof** nav link.

## Notes
- README-only. Charts/datasets are already committed on `main` (from #19); this surfaces them at the top. Div tags balanced 7/7; image + dataset paths verified present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)