### PR TITLE
Claude Code for local — Ollama-wrapped terminal + custom agents + commands + multi-agent (A+B+C+D)

### DIFF
--- a/aether_agent/__init__.py
+++ b/aether_agent/__init__.py
@@ -8,7 +8,7 @@ autonomy/checkpoint kernel + escalation hatch. Default model: Qwen3-Coder 30B
 (Apache-2.0), pulled via Ollama — never bundled.
 """
 
-__all__ = ["run_agent", "AgentResult"]
+__all__ = ["run_agent", "AgentResult", "Agent"]
 
 
 def __getattr__(name: str):
@@ -19,4 +19,10 @@ def __getattr__(name: str):
         from aether_agent.agent import run_agent, AgentResult
 
         return {"run_agent": run_agent, "AgentResult": AgentResult}[name]
+    if name == "Agent":
+        # Public library API: `from aether_agent import Agent`. agent_profile is
+        # dependency-light (does not pull the numpy-backed engine at import).
+        from aether_agent.agent_profile import Agent
+
+        return Agent
     raise AttributeError(f"module 'aether_agent' has no attribute {name!r}")

--- a/aether_agent/agent.py
+++ b/aether_agent/agent.py
@@ -77,6 +77,7 @@ def run_agent_events(
     git_checkpoint: bool = True,
     verify_finish: bool = True,
     on_status: Optional[Callable[[str], None]] = None,
+    system: Optional[str] = None,
 ) -> Iterator[dict[str, Any]]:
     """Drive the chat+tool loop, yielding render-ready event dicts.
 
@@ -99,8 +100,9 @@ def run_agent_events(
     schema = schema if schema is not None else tool_schema()
     emit = on_status or (lambda s: None)
 
+    sys_prompt = system if system is not None else SYSTEM_PROMPT
     messages: list[dict] = [
-        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "system", "content": sys_prompt},
         {"role": "user", "content": task},
     ]
     phase = "reasoning"

--- a/aether_agent/agent_commands.py
+++ b/aether_agent/agent_commands.py
@@ -1,0 +1,57 @@
+# aether_agent/agent_commands.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Custom commands — per-agent prompt-macros (sub-project C).
+
+A command is a string template stored in ``Agent.commands`` that expands into an
+agent turn. Placeholders: ``$1``..``$9`` (positional args), ``$*``/``$@`` (all
+args), ``$$`` -> literal ``$``. Pure expansion — no shell, no eval. Authoring
+(add/remove) returns a NEW validated ``Agent`` (immutability).
+"""
+from __future__ import annotations
+
+import re
+
+from aether_agent.agent_profile import Agent, is_valid_command_name
+
+_POS_RE = re.compile(r"\$([1-9])")
+_SENTINEL = "\x00"
+
+
+def valid_name(name: str) -> bool:
+    return is_valid_command_name(name)
+
+
+def expand(template: str, args: list[str]) -> str:
+    """Expand a command template against positional args (pure; no shell/eval)."""
+    all_args = " ".join(args)
+    s = (template or "").replace("$$", _SENTINEL)  # protect literal $ first
+    s = s.replace("$*", all_args).replace("$@", all_args)
+    s = _POS_RE.sub(lambda m: args[int(m.group(1)) - 1] if int(m.group(1)) - 1 < len(args) else "", s)
+    return s.replace(_SENTINEL, "$")
+
+
+def add(agent: Agent, name: str, template: str) -> Agent:
+    """Return a NEW agent with command ``name`` set. Raises ValueError on a bad
+    name or empty template (validation also runs inside Agent.set)."""
+    if not valid_name(name):
+        raise ValueError(f"invalid command name: {name!r} (must be a slug and not a built-in)")
+    if not str(template).strip():
+        raise ValueError("command template must be a non-empty string")
+    cmds = dict(agent.commands)
+    cmds[name] = template
+    return agent.set(commands=cmds)
+
+
+def remove(agent: Agent, name: str) -> Agent:
+    cmds = dict(agent.commands)
+    cmds.pop(name, None)
+    return agent.set(commands=cmds)
+
+
+def list_commands(agent: Agent) -> dict:
+    return dict(agent.commands)
+
+
+__all__ = ["valid_name", "expand", "add", "remove", "list_commands"]

--- a/aether_agent/agent_profile.py
+++ b/aether_agent/agent_profile.py
@@ -33,6 +33,21 @@ _PERMISSION = ("ask", "auto", "skip")
 _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _MAX_STEPS_RANGE = (1, 500)
 
+#: command names a custom command may NOT take (would shadow a built-in slash).
+RESERVED_COMMANDS = frozenset({
+    "help", "models", "model", "agents", "agent", "new-agent", "orchestrator",
+    "orchestrators", "tier", "audit", "web", "clear", "exit", "quit",
+    "pull", "doctor", "serve", "setup", "config",
+})
+_CMD_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+#: tools an AGENT may list (the 8 bridge tools + the local-only authoring tool).
+ALLOWED_AGENT_TOOLS = tuple(TOOLS) + ("define_command",)
+
+
+def is_valid_command_name(name: str) -> bool:
+    return bool(_CMD_NAME_RE.match(name or "")) and name not in RESERVED_COMMANDS
+
 
 @dataclass(frozen=True)
 class Agent:
@@ -145,14 +160,17 @@ def validate(agent: "Agent") -> list[str]:
         p.append(f"permission must be one of {_PERMISSION} (got {agent.permission!r})")
     if agent.accent not in ACCENTS:
         p.append(f"accent must be one of {sorted(ACCENTS)} (got {agent.accent!r})")
-    unknown = [t for t in agent.tools if t not in TOOLS]
+    unknown = [t for t in agent.tools if t not in ALLOWED_AGENT_TOOLS]
     if unknown:
-        p.append(f"tools must be a subset of the 8 canonical tools (unknown: {unknown})")
+        p.append(f"tools must be a subset of {sorted(ALLOWED_AGENT_TOOLS)} (unknown: {unknown})")
     lo, hi = _MAX_STEPS_RANGE
     if not isinstance(agent.max_steps, int) or not (lo <= agent.max_steps <= hi):
         p.append(f"max_steps must be an int in [{lo}, {hi}] (got {agent.max_steps!r})")
-    if agent.commands:
-        p.append("commands is reserved for a future release and must be empty")
+    for cname, ctmpl in (agent.commands or {}).items():
+        if not is_valid_command_name(cname):
+            p.append(f"command name {cname!r} must be a slug and not a reserved built-in")
+        if not isinstance(ctmpl, str) or not ctmpl.strip():
+            p.append(f"command {cname!r} template must be a non-empty string")
     return p
 
 
@@ -163,4 +181,7 @@ def _as_int(v: Any, default: int) -> int:
         return default
 
 
-__all__ = ["Agent", "validate", "ACCENTS"]
+__all__ = [
+    "Agent", "validate", "ACCENTS",
+    "RESERVED_COMMANDS", "ALLOWED_AGENT_TOOLS", "is_valid_command_name",
+]

--- a/aether_agent/agent_profile.py
+++ b/aether_agent/agent_profile.py
@@ -1,0 +1,166 @@
+# aether_agent/agent_profile.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""The Agent — a named, shareable local agent profile + the library API.
+
+An Agent is an immutable dataclass persisted as one JSON file per agent (see
+``agent_store``). It carries the agent's model, its own memory-pool size, a
+persona, a visual identity (accent / prompt / banner), and tool + permission
+guardrails. No ``effort`` field — effort tiers are an AetherCloud-only concept.
+
+Library use::
+
+    a = Agent.create("jane", model="qwen2.5-coder:7b", pool_gb=10)
+    for ev in a.run("summarize the repo"): ...
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, replace
+from typing import Any, Iterator
+
+from aether_agent.adapter import DEFAULT_MODEL
+from aether_agent.protocol import TOOLS
+
+#: accent name -> ANSI SGR color code (cp1252-safe; used by validate + the REPL).
+ACCENTS: dict[str, str] = {
+    "cyan": "36", "green": "32", "magenta": "35", "yellow": "33",
+    "blue": "34", "red": "31", "white": "37", "dim": "2",
+}
+_VERBOSITY = ("terse", "normal", "verbose")
+_PERMISSION = ("ask", "auto", "skip")
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_MAX_STEPS_RANGE = (1, 500)
+
+
+@dataclass(frozen=True)
+class Agent:
+    name: str
+    model: str = DEFAULT_MODEL
+    pool_gb: int = 5
+    persona: str = "You are a helpful local coding agent."
+    verbosity: str = "normal"
+    show_tools: bool = True
+    accent: str = "cyan"
+    prompt: str = ""
+    banner: str = ""
+    tools: tuple[str, ...] = tuple(TOOLS)
+    permission: str = "ask"
+    max_steps: int = 40
+    commands: dict[str, Any] = field(default_factory=dict)  # reserved for sub-project C
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Agent":
+        """Build an Agent from a (possibly partial) dict, filling defaults and
+        ignoring unknown keys (e.g. a stray ``effort`` from a future/foreign file)."""
+        d = dict(data or {})
+        tools = d.get("tools")
+        name = str(d.get("name", ""))
+        kw: dict[str, Any] = {
+            "name": name,
+            "model": str(d.get("model", DEFAULT_MODEL)) or DEFAULT_MODEL,
+            "pool_gb": _as_int(d.get("pool_gb"), 5),
+            "persona": str(d.get("persona", "You are a helpful local coding agent.")),
+            "verbosity": str(d.get("verbosity", "normal")),
+            "show_tools": bool(d.get("show_tools", True)),
+            "accent": str(d.get("accent", "cyan")),
+            "prompt": str(d.get("prompt", "") or f"{name} > "),
+            "banner": str(d.get("banner", "")),
+            "tools": tuple(tools) if isinstance(tools, (list, tuple)) else tuple(TOOLS),
+            "permission": str(d.get("permission", "ask")),
+            "max_steps": _as_int(d.get("max_steps"), 40),
+            "commands": dict(d.get("commands") or {}),
+        }
+        return cls(**kw)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name, "model": self.model, "pool_gb": self.pool_gb,
+            "persona": self.persona, "verbosity": self.verbosity, "show_tools": self.show_tools,
+            "accent": self.accent, "prompt": self.prompt, "banner": self.banner,
+            "tools": list(self.tools), "permission": self.permission,
+            "max_steps": self.max_steps, "commands": dict(self.commands),
+        }
+
+    def set(self, **fields: Any) -> "Agent":
+        """Return a NEW validated copy with the given fields changed. ``memory`` is
+        an alias for ``pool_gb`` (matches the `/agent set memory` command)."""
+        if "memory" in fields:
+            fields["pool_gb"] = _as_int(fields.pop("memory"), self.pool_gb)
+        if "tools" in fields and isinstance(fields["tools"], list):
+            fields["tools"] = tuple(fields["tools"])
+        updated = replace(self, **fields)
+        problems = validate(updated)
+        if problems:
+            raise ValueError("; ".join(problems))
+        return updated
+
+    # --- library API (proxies to agent_store / agent_runner; lazy imports) ----
+    @classmethod
+    def create(cls, name: str, **fields: Any) -> "Agent":
+        from aether_agent import agent_store
+        agent = cls.from_dict({"name": name, **fields})
+        problems = validate(agent)
+        if problems:
+            raise ValueError("; ".join(problems))
+        agent_store.create(agent)
+        return agent
+
+    @classmethod
+    def load(cls, name: str) -> "Agent":
+        from aether_agent import agent_store
+        return agent_store.load(name)
+
+    @classmethod
+    def list(cls) -> list[str]:
+        from aether_agent import agent_store
+        return agent_store.list_agents()
+
+    def save(self) -> None:
+        from aether_agent import agent_store
+        agent_store.save(self)
+
+    def delete(self, purge: bool = False) -> None:
+        from aether_agent import agent_store
+        agent_store.delete(self.name, purge=purge)
+
+    def run(self, task: str, **kw: Any) -> Iterator[dict[str, Any]]:
+        from aether_agent import agent_runner
+        yield from agent_runner.run(self, task, **kw)
+
+
+def validate(agent: "Agent") -> list[str]:
+    """Return a list of human-readable problems (empty = valid)."""
+    p: list[str] = []
+    if not _NAME_RE.match(agent.name or ""):
+        p.append(f"name must be a slug [a-z0-9_-] (got {agent.name!r})")
+    if not str(agent.model).strip():
+        p.append("model must be a non-empty string")
+    if not isinstance(agent.pool_gb, int) or agent.pool_gb < 1:
+        p.append(f"pool_gb must be an int >= 1 (got {agent.pool_gb!r})")
+    if agent.verbosity not in _VERBOSITY:
+        p.append(f"verbosity must be one of {_VERBOSITY} (got {agent.verbosity!r})")
+    if agent.permission not in _PERMISSION:
+        p.append(f"permission must be one of {_PERMISSION} (got {agent.permission!r})")
+    if agent.accent not in ACCENTS:
+        p.append(f"accent must be one of {sorted(ACCENTS)} (got {agent.accent!r})")
+    unknown = [t for t in agent.tools if t not in TOOLS]
+    if unknown:
+        p.append(f"tools must be a subset of the 8 canonical tools (unknown: {unknown})")
+    lo, hi = _MAX_STEPS_RANGE
+    if not isinstance(agent.max_steps, int) or not (lo <= agent.max_steps <= hi):
+        p.append(f"max_steps must be an int in [{lo}, {hi}] (got {agent.max_steps!r})")
+    if agent.commands:
+        p.append("commands is reserved for a future release and must be empty")
+    return p
+
+
+def _as_int(v: Any, default: int) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = ["Agent", "validate", "ACCENTS"]

--- a/aether_agent/agent_runner.py
+++ b/aether_agent/agent_runner.py
@@ -1,0 +1,108 @@
+# aether_agent/agent_runner.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Run a task AS a custom agent.
+
+Builds the agent's own ``Session`` (its persistent memory pool), an Ollama chat
+on the agent's model, a persona system prompt, and a policy-wrapped ``Tools``
+that enforces the agent's tool allowlist + permission mode — then drives
+``agent.run_agent_events`` and yields its render-ready events. Session creation
+is injectable (``session_factory``) so tests never touch numpy/disk.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Iterator, Optional
+
+from aether_agent.adapter import OllamaChat
+from aether_agent.agent import run_agent_events
+from aether_agent.agent_profile import Agent
+from aether_agent.tools import Tools, tool_schema
+
+#: tools that change the workspace / run code — gated by permission mode.
+DESTRUCTIVE = {"write_file", "run_shell", "git_commit"}
+ConfirmFn = Callable[[str, dict], bool]
+
+
+def _deny(_name: str, _args: dict) -> bool:
+    return False
+
+
+class _PolicyTools:
+    """Wrap a real ``Tools`` with an allowlist + a permission gate. Same
+    ``execute(name, args) -> str`` contract; refusals are returned as strings
+    (never raised) so the agent loop reads them like any tool output."""
+
+    def __init__(self, inner: Tools, allowed: set, permission: str, confirm: ConfirmFn) -> None:
+        self._inner = inner
+        self._allowed = set(allowed)
+        self._permission = permission
+        self._confirm = confirm
+        self.test_cmd = getattr(inner, "test_cmd", "")  # the verify gate reads this attr
+
+    def execute(self, name: str, args: dict) -> str:
+        if name not in self._allowed:
+            return f"[tool {name} not allowed for this agent]"
+        if name in DESTRUCTIVE and self._permission != "skip":
+            if not self._confirm(name, args):
+                return f"[denied: {name} (permission={self._permission})]"
+        return self._inner.execute(name, args)
+
+    def run_tests(self, command: Optional[str] = None) -> str:
+        return self._inner.run_tests(command)
+
+
+def _default_session_factory(agent: Agent):
+    from aether_agent import agent_store
+    from aether_context import Session
+
+    return Session(
+        model=f"ollama/{agent.model}",
+        pool_gb=agent.pool_gb,
+        pool_dir=str(agent_store.agent_pool_dir(agent.name)),
+        pool_mode="separate",
+        pull=False,
+        fallback_to_mock=True,
+    )
+
+
+def run(
+    agent: Agent,
+    task: str,
+    *,
+    cwd: str = ".",
+    confirm: Optional[ConfirmFn] = None,
+    llm: Any = None,
+    session_factory: Optional[Callable[[Agent], Any]] = None,
+    on_status: Optional[Callable[[str], None]] = None,
+) -> Iterator[dict[str, Any]]:
+    """Drive one task as ``agent``; yield render-ready events. ``llm`` and
+    ``session_factory`` are injectable for tests (no real Ollama / Session)."""
+    chat = llm if llm is not None else OllamaChat(model=agent.model)
+    sess = (session_factory or _default_session_factory)(agent)
+    allowed = set(agent.tools)
+    schema = [s for s in tool_schema() if s["function"]["name"] in allowed]
+    tools = _PolicyTools(Tools(cwd), allowed, agent.permission, confirm or _deny)
+    try:
+        yield from run_agent_events(
+            task,
+            llm=chat,
+            tools=tools,
+            cwd=cwd,
+            pool_gb=agent.pool_gb,
+            max_steps=agent.max_steps,
+            sess=sess,
+            schema=schema,
+            system=agent.persona,
+            git_checkpoint=False,
+            verify_finish=False,
+            on_status=on_status,
+        )
+    finally:
+        try:
+            sess.close()
+        except Exception:  # noqa: BLE001 — teardown best-effort
+            pass
+
+
+__all__ = ["run", "DESTRUCTIVE", "ConfirmFn"]

--- a/aether_agent/agent_runner.py
+++ b/aether_agent/agent_runner.py
@@ -43,12 +43,14 @@ class _PolicyTools:
     ``execute(name, args) -> str`` contract; refusals are returned as strings
     (never raised) so the agent loop reads them like any tool output."""
 
-    def __init__(self, inner: Tools, allowed: set, permission: str, confirm: ConfirmFn, agent_name: str = "") -> None:
+    def __init__(self, inner: Tools, allowed: set, permission: str, confirm: ConfirmFn,
+                 agent_name: str = "", write_lock: Any = None) -> None:
         self._inner = inner
         self._allowed = set(allowed)
         self._permission = permission
         self._confirm = confirm
         self._agent_name = agent_name
+        self._write_lock = write_lock  # shared one-writer lock across concurrent agents (D)
         self.test_cmd = getattr(inner, "test_cmd", "")  # the verify gate reads this attr
 
     def execute(self, name: str, args: dict) -> str:
@@ -59,6 +61,9 @@ class _PolicyTools:
         if name in DESTRUCTIVE and self._permission != "skip":
             if not self._confirm(name, args):
                 return f"[denied: {name} (permission={self._permission})]"
+        if name in DESTRUCTIVE and self._write_lock is not None:
+            with self._write_lock:
+                return self._inner.execute(name, args)
         return self._inner.execute(name, args)
 
     def _define_command(self, args: dict) -> str:
@@ -102,6 +107,7 @@ def run(
     llm: Any = None,
     session_factory: Optional[Callable[[Agent], Any]] = None,
     on_status: Optional[Callable[[str], None]] = None,
+    write_lock: Any = None,
 ) -> Iterator[dict[str, Any]]:
     """Drive one task as ``agent``; yield render-ready events. ``llm`` and
     ``session_factory`` are injectable for tests (no real Ollama / Session)."""
@@ -124,7 +130,7 @@ def run(
             },
         })
     tools = _PolicyTools(Tools(cwd), allowed=set(agent.tools), permission=agent.permission,
-                         confirm=confirm or _deny, agent_name=agent.name)
+                         confirm=confirm or _deny, agent_name=agent.name, write_lock=write_lock)
     try:
         yield from run_agent_events(
             task,

--- a/aether_agent/agent_runner.py
+++ b/aether_agent/agent_runner.py
@@ -28,25 +28,52 @@ def _deny(_name: str, _args: dict) -> bool:
     return False
 
 
+def _offered_tool_names(agent) -> list[str]:
+    """The tool names offered to the model for this agent: the canonical tools it
+    allows, plus the local-only define_command when the agent opts in."""
+    from aether_agent.protocol import TOOLS
+    names = [t for t in agent.tools if t in TOOLS]
+    if "define_command" in agent.tools:
+        names.append("define_command")
+    return names
+
+
 class _PolicyTools:
     """Wrap a real ``Tools`` with an allowlist + a permission gate. Same
     ``execute(name, args) -> str`` contract; refusals are returned as strings
     (never raised) so the agent loop reads them like any tool output."""
 
-    def __init__(self, inner: Tools, allowed: set, permission: str, confirm: ConfirmFn) -> None:
+    def __init__(self, inner: Tools, allowed: set, permission: str, confirm: ConfirmFn, agent_name: str = "") -> None:
         self._inner = inner
         self._allowed = set(allowed)
         self._permission = permission
         self._confirm = confirm
+        self._agent_name = agent_name
         self.test_cmd = getattr(inner, "test_cmd", "")  # the verify gate reads this attr
 
     def execute(self, name: str, args: dict) -> str:
+        if name == "define_command":
+            return self._define_command(args)
         if name not in self._allowed:
             return f"[tool {name} not allowed for this agent]"
         if name in DESTRUCTIVE and self._permission != "skip":
             if not self._confirm(name, args):
                 return f"[denied: {name} (permission={self._permission})]"
         return self._inner.execute(name, args)
+
+    def _define_command(self, args: dict) -> str:
+        if "define_command" not in self._allowed:
+            return "[tool define_command not allowed for this agent]"
+        from aether_agent import agent_commands, agent_store
+
+        cname = str(args.get("name", ""))
+        template = str(args.get("template", ""))
+        try:
+            updated = agent_commands.add(agent_store.load(self._agent_name), cname, template)
+        except (ValueError, TypeError, OSError) as e:
+            return f"[define_command refused: {e}]"
+        agent_store.save(updated)
+        return f"[defined command /{cname}]"
 
     def run_tests(self, command: Optional[str] = None) -> str:
         return self._inner.run_tests(command)
@@ -80,9 +107,24 @@ def run(
     ``session_factory`` are injectable for tests (no real Ollama / Session)."""
     chat = llm if llm is not None else OllamaChat(model=agent.model)
     sess = (session_factory or _default_session_factory)(agent)
-    allowed = set(agent.tools)
-    schema = [s for s in tool_schema() if s["function"]["name"] in allowed]
-    tools = _PolicyTools(Tools(cwd), allowed, agent.permission, confirm or _deny)
+    offered = set(_offered_tool_names(agent))
+    schema = [s for s in tool_schema() if s["function"]["name"] in offered]
+    if "define_command" in offered:
+        schema.append({
+            "type": "function",
+            "function": {
+                "name": "define_command",
+                "description": "Save a reusable slash-command (prompt macro) on this agent. "
+                               "args: {name, template}. template may use $1..$9 and $*.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "template": {"type": "string"}},
+                    "required": ["name", "template"],
+                },
+            },
+        })
+    tools = _PolicyTools(Tools(cwd), allowed=set(agent.tools), permission=agent.permission,
+                         confirm=confirm or _deny, agent_name=agent.name)
     try:
         yield from run_agent_events(
             task,

--- a/aether_agent/agent_slash.py
+++ b/aether_agent/agent_slash.py
@@ -26,7 +26,7 @@ from aether_agent import agent_store
 from aether_agent.agent_profile import Agent
 
 SlashResult = dict[str, Any]
-_VERBS = {"set", "show", "edit", "delete"}
+_VERBS = {"set", "show", "edit", "delete", "cmd", "run"}
 _SET_ALIASES = {"memory": "pool_gb"}
 
 
@@ -99,6 +99,10 @@ def _agent(args: list, active: str) -> SlashResult:
         return _edit(name)
     if verb == "delete":
         return _delete(name, rest[1:])
+    if verb == "cmd":
+        return _cmd(name, rest[1:])
+    if verb == "run":
+        return _run_cmd(name, rest[1:])
     return {"run_agent": {"name": name, "task": " ".join(rest)}, "text": ""}
 
 
@@ -149,6 +153,50 @@ def _delete(name: str, flags: list) -> SlashResult:
     purge = "--purge" in flags
     agent_store.delete(name, purge=purge)
     return _text(f"deleted {name}{' (+pool)' if purge else ''}")
+
+
+def _cmd(name: str, args: list) -> SlashResult:
+    from aether_agent import agent_commands
+    if not args:
+        return _text("usage: /agent <name> cmd add <cmd> = <template> | list | remove <cmd>")
+    sub = args[0].lower()
+    if sub == "list":
+        cmds = agent_commands.list_commands(agent_store.load(name))
+        if not cmds:
+            return _text("(no commands)")
+        return _text("\n".join(f"/{k}\t{v}" for k, v in sorted(cmds.items())))
+    if sub == "remove":
+        if len(args) < 2:
+            return _text("usage: /agent <name> cmd remove <cmd>")
+        updated = agent_commands.remove(agent_store.load(name), args[1])
+        agent_store.save(updated)
+        return _text(f"removed /{args[1]}")
+    if sub == "add":
+        rest = args[1:]
+        if "=" not in rest:
+            return _text("usage: /agent <name> cmd add <cmd> = <template>")
+        eq = rest.index("=")
+        cmd_name = " ".join(rest[:eq]).strip()
+        template = " ".join(rest[eq + 1:]).strip()
+        try:
+            updated = agent_commands.add(agent_store.load(name), cmd_name, template)
+        except (ValueError, TypeError) as e:
+            return _text(f"could not add command: {e}")
+        agent_store.save(updated)
+        return _text(f"added /{cmd_name} = {template}")
+    return _text("usage: /agent <name> cmd add <cmd> = <template> | list | remove <cmd>")
+
+
+def _run_cmd(name: str, args: list) -> SlashResult:
+    from aether_agent import agent_commands
+    if not args:
+        return _text("usage: /agent <name> run <cmd> [args]")
+    cmd_name = args[0]
+    cmds = agent_commands.list_commands(agent_store.load(name))
+    if cmd_name not in cmds:
+        return _text(f"no such command: /{cmd_name} (see /agent {name} cmd list)")
+    task = agent_commands.expand(cmds[cmd_name], args[1:])
+    return {"run_agent": {"name": name, "task": task}, "text": ""}
 
 
 __all__ = ["dispatch_agent", "SlashResult"]

--- a/aether_agent/agent_slash.py
+++ b/aether_agent/agent_slash.py
@@ -66,19 +66,19 @@ def _new_agent(args: list) -> SlashResult:
 
 
 def _agents(active: str) -> SlashResult:
+    from aether_agent import agents_view
     names = agent_store.list_agents()
     if not names:
-        return _text("(no agents yet — create one with /new-agent <name>)")
-    lines = ["agents (* active):"]
+        return _text("(no agents yet - create one with /new-agent <name>)")
+    rows = []
     for n in names:
         try:
             a = agent_store.load(n)
-            mark = "*" if n == active else " "
-            lines.append(f"{mark} {n}\t{a.model}\t{a.pool_gb}GB")
+            rows.append({"name": n, "model": a.model, "pool_gb": a.pool_gb,
+                         "n_commands": len(a.commands)})
         except (ValueError, OSError):
-            lines.append(f"  {n}\t(corrupt file)")
-    lines.append("switch: /agent <name>   run: /agent <name> <task>")
-    return _text("\n".join(lines))
+            rows.append({"name": n, "model": "(corrupt)", "pool_gb": 0, "n_commands": 0})
+    return _text(agents_view.render_agents_columns(rows, active=active))
 
 
 def _agent(args: list, active: str) -> SlashResult:

--- a/aether_agent/agent_slash.py
+++ b/aether_agent/agent_slash.py
@@ -1,0 +1,154 @@
+# aether_agent/agent_slash.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""The `/agent` command grammar (sub-project B).
+
+Pure handlers: configuration verbs mutate the store and return a ``text`` result;
+switching/running return action flags (``switch_agent`` / ``run_agent``) the REPL
+acts on (mirrors the existing ``setup``/``restart`` flags in slash.py). No TTY,
+no Ollama — fully unit-testable.
+
+    /new-agent <name>
+    /agents
+    /agent <name>                 -> {"switch_agent": name}
+    /agent <name> <task...>       -> {"run_agent": {"name", "task"}}
+    /agent <name> set <key> <val>
+    /agent <name> show | edit | delete [--purge]
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any
+
+from aether_agent import agent_store
+from aether_agent.agent_profile import Agent
+
+SlashResult = dict[str, Any]
+_VERBS = {"set", "show", "edit", "delete"}
+_SET_ALIASES = {"memory": "pool_gb"}
+
+
+def _text(s: str) -> SlashResult:
+    return {"text": s}
+
+
+def dispatch_agent(line: str, *, active: str) -> SlashResult:
+    """Route a `/new-agent`, `/agents`, or `/agent ...` line. Never raises."""
+    body = (line or "").strip()
+    if body.startswith("/"):
+        body = body[1:]
+    parts = body.split()
+    if not parts:
+        return _text("usage: /agent <name> [task | set <k> <v> | show | edit | delete]")
+    head = parts[0].lower()
+    if head == "new-agent":
+        return _new_agent(parts[1:])
+    if head == "agents":
+        return _agents(active)
+    if head == "agent":
+        return _agent(parts[1:], active)
+    return _text(f"(unknown command: /{head})")
+
+
+def _new_agent(args: list) -> SlashResult:
+    if not args:
+        return _text("usage: /new-agent <name>")
+    name = args[0]
+    if agent_store.exists(name):
+        return _text(f"agent already exists: {name}")
+    try:
+        Agent.create(name)
+    except (ValueError, OSError) as e:
+        return _text(f"could not create {name}: {e}")
+    return _text(f"created agent '{name}' (customize: /agent {name} set <key> <val>)")
+
+
+def _agents(active: str) -> SlashResult:
+    names = agent_store.list_agents()
+    if not names:
+        return _text("(no agents yet — create one with /new-agent <name>)")
+    lines = ["agents (* active):"]
+    for n in names:
+        try:
+            a = agent_store.load(n)
+            mark = "*" if n == active else " "
+            lines.append(f"{mark} {n}\t{a.model}\t{a.pool_gb}GB")
+        except (ValueError, OSError):
+            lines.append(f"  {n}\t(corrupt file)")
+    lines.append("switch: /agent <name>   run: /agent <name> <task>")
+    return _text("\n".join(lines))
+
+
+def _agent(args: list, active: str) -> SlashResult:
+    if not args:
+        return _text("usage: /agent <name> [task | set <k> <v> | show | edit | delete]")
+    name = args[0]
+    rest = args[1:]
+    if not agent_store.exists(name):
+        return _text(f"no such agent: {name} (see /agents, or /new-agent {name})")
+    if not rest:
+        return {"switch_agent": name, "text": f"switched to {name}"}
+    verb = rest[0].lower()
+    if verb == "set":
+        return _set(name, rest[1:])
+    if verb == "show":
+        return _show(name)
+    if verb == "edit":
+        return _edit(name)
+    if verb == "delete":
+        return _delete(name, rest[1:])
+    return {"run_agent": {"name": name, "task": " ".join(rest)}, "text": ""}
+
+
+def _set(name: str, kv: list) -> SlashResult:
+    if len(kv) < 2:
+        return _text("usage: /agent <name> set <key> <value>")
+    key = _SET_ALIASES.get(kv[0].lower(), kv[0].lower())
+    value = _coerce(key, " ".join(kv[1:]))
+    try:
+        updated = agent_store.load(name).set(**{key: value})
+    except (ValueError, TypeError) as e:
+        return _text(f"invalid {key}: {e}")
+    agent_store.save(updated)
+    return _text(f"{name}.{key} = {getattr(updated, key, value)}")
+
+
+def _coerce(key: str, raw: str) -> Any:
+    if key in ("pool_gb", "max_steps"):
+        try:
+            return int(raw)
+        except ValueError:
+            return raw
+    if key == "show_tools":
+        return raw.strip().lower() in ("true", "1", "yes", "on")
+    if key == "tools":
+        return [t.strip() for t in raw.replace(",", " ").split() if t.strip()]
+    return raw
+
+
+def _show(name: str) -> SlashResult:
+    a = agent_store.load(name)
+    return _text("\n".join(f"{k} = {v}" for k, v in a.to_dict().items() if k != "commands"))
+
+
+def _edit(name: str) -> SlashResult:
+    path = agent_store.agent_path(name)
+    editor = os.environ.get("EDITOR") or os.environ.get("VISUAL")
+    if not editor:
+        return _text(f"set $EDITOR to edit, or edit the file directly: {path}")
+    try:
+        subprocess.run([editor, str(path)], check=False, timeout=600)
+    except Exception as e:  # noqa: BLE001 — editor failures must not crash the REPL
+        return _text(f"could not open editor ({e}); file: {path}")
+    return _text(f"edited {path}")
+
+
+def _delete(name: str, flags: list) -> SlashResult:
+    purge = "--purge" in flags
+    agent_store.delete(name, purge=purge)
+    return _text(f"deleted {name}{' (+pool)' if purge else ''}")
+
+
+__all__ = ["dispatch_agent", "SlashResult"]

--- a/aether_agent/agent_store.py
+++ b/aether_agent/agent_store.py
@@ -1,0 +1,82 @@
+# aether_agent/agent_store.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""File-per-agent persistence.
+
+Definitions live at ``<config>/agents/<name>.json``; each agent's memory pool is
+separate local state at ``<config>/agents/<name>/pool/``. Sharing an agent =
+copying its one ``<name>.json``. Honors ``AETHER_CONFIG_DIR`` (via ``config``).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from aether_agent.agent_profile import Agent
+from aether_agent.config import config_dir
+
+
+def agents_dir() -> Path:
+    return Path(config_dir()) / "agents"
+
+
+def agent_path(name: str) -> Path:
+    d = agents_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d / f"{name}.json"
+
+
+def agent_pool_dir(name: str) -> Path:
+    return agents_dir() / name / "pool"
+
+
+def exists(name: str) -> bool:
+    return agent_path(name).is_file()
+
+
+def list_agents() -> list[str]:
+    d = agents_dir()
+    if not d.is_dir():
+        return []
+    return sorted(p.stem for p in d.glob("*.json"))
+
+
+def create(agent: Agent) -> None:
+    if exists(agent.name):
+        raise FileExistsError(f"agent already exists: {agent.name}")
+    save(agent)
+
+
+def save(agent: Agent) -> None:
+    agent_path(agent.name).write_text(
+        json.dumps(agent.to_dict(), indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def load(name: str) -> Agent:
+    path = agent_path(name)
+    if not path.is_file():
+        raise FileNotFoundError(f"no such agent: {name}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        raise ValueError(f"agent file is corrupt: {name} ({e})") from e
+    return Agent.from_dict(data)
+
+
+def delete(name: str, *, purge: bool = False) -> None:
+    path = agent_path(name)
+    if path.is_file():
+        path.unlink()
+    if purge:
+        pool_parent = agents_dir() / name
+        if pool_parent.is_dir():
+            shutil.rmtree(pool_parent, ignore_errors=True)
+
+
+__all__ = [
+    "agents_dir", "agent_path", "agent_pool_dir",
+    "exists", "list_agents", "create", "save", "load", "delete",
+]

--- a/aether_agent/agents_view.py
+++ b/aether_agent/agents_view.py
@@ -1,0 +1,47 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""The `/agents` column dashboard - a pure, cp1252-safe renderer.
+
+`render_agents_columns(rows, active, width)` lays out agent cards side by side,
+N-per-row to the terminal width. No ANSI/color here (keeps width math correct and
+the output testable); the active agent is marked with `*`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+_CARD_W = 22
+
+
+def render_agents_columns(rows: list[dict], active: str = "", width: int = 80) -> str:
+    if not rows:
+        return "(no agents yet - create one with /new-agent <name>)"
+    cards = [_card(r, active) for r in rows]
+    per_row = max(1, width // (_CARD_W + 2))
+    lines: list[str] = []
+    for i in range(0, len(cards), per_row):
+        group = cards[i:i + per_row]
+        height = max(len(c) for c in group)
+        for c in group:
+            c.extend([""] * (height - len(c)))
+        for row_line in range(height):
+            lines.append("  ".join(c[row_line].ljust(_CARD_W) for c in group).rstrip())
+        lines.append("")  # blank line between card rows
+    return "\n".join(lines).rstrip()
+
+
+def _card(r: dict[str, Any], active: str) -> list[str]:
+    name = str(r.get("name", ""))
+    mark = "*" if name and name == active else " "
+    model = str(r.get("model", ""))
+    pool = r.get("pool_gb", 0)
+    n = r.get("n_commands", 0)
+    return [
+        f"{mark} {name}"[:_CARD_W],
+        f"  {model}"[:_CARD_W],
+        f"  {pool} GB . {n} cmds"[:_CARD_W],
+    ]
+
+
+__all__ = ["render_agents_columns"]

--- a/aether_agent/cli.py
+++ b/aether_agent/cli.py
@@ -30,7 +30,7 @@ from aether_agent.transport import ApiClient
 
 #: The recognized subcommands. A first positional matching one of these is routed
 #: to its handler; anything else (not starting with ``-``) is a one-shot prompt.
-_SUBCOMMANDS = frozenset({"code", "brain", "auth", "models", "config"})
+_SUBCOMMANDS = frozenset({"code", "brain", "auth", "models", "config", "doctor", "setup"})
 
 
 # --- top-level dispatch ----------------------------------------------------
@@ -56,6 +56,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         return _cmd_models(args[1:])
     if head == "config":
         return _cmd_config(args[1:])
+    if head == "doctor":
+        return _cmd_doctor(args[1:])
+    if head == "setup":
+        return _cmd_setup(args[1:])
 
     # An explicit flag with no subcommand (e.g. ``aether --help``) -> show help.
     if head.startswith("-"):
@@ -255,6 +259,33 @@ def _coerce(value: str) -> Any:
     return value
 
 
+# --- doctor / setup --------------------------------------------------------
+def _ollama_ctl():
+    from aether_agent.ollama_ctl import OllamaCtl
+    return OllamaCtl()
+
+
+def _preflight(ctl, **kw):
+    from aether_agent.onboarding import preflight
+    return preflight(ctl, **kw)
+
+
+def _cmd_doctor(rest: list[str]) -> int:
+    from aether_agent.onboarding import doctor
+    print(doctor(_ollama_ctl()))
+    return 0
+
+
+def _cmd_setup(rest: list[str]) -> int:
+    ctl = _ollama_ctl()
+    pf = _preflight(ctl, emit=lambda s: sys.stdout.write(s))
+    if not pf.ok:
+        print(f"\n{pf.message}", file=sys.stderr)
+        return 1
+    print(f"\nready — model: {pf.chosen_model}")
+    return 0
+
+
 # --- help ------------------------------------------------------------------
 def _print_help() -> None:
     print(
@@ -269,6 +300,8 @@ def _print_help() -> None:
                 "  aether auth login|status|logout|token",
                 "  aether models                list models",
                 "  aether config [show|get k|set k v]",
+                "  aether doctor                check the local Ollama setup",
+                "  aether setup                 run first-run setup (install/serve/pull)",
             ]
         )
     )

--- a/aether_agent/cli.py
+++ b/aether_agent/cli.py
@@ -282,7 +282,7 @@ def _cmd_setup(rest: list[str]) -> int:
     if not pf.ok:
         print(f"\n{pf.message}", file=sys.stderr)
         return 1
-    print(f"\nready — model: {pf.chosen_model}")
+    print(f"\nready - model: {pf.chosen_model}")
     return 0
 
 

--- a/aether_agent/hardware.py
+++ b/aether_agent/hardware.py
@@ -1,0 +1,112 @@
+# aether_agent/hardware.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Hardware detection + a curated local-model catalog + a best-fit picker.
+
+``detect_resources`` is fail-soft (any probe error -> a conservative 8 GB / no-GPU
+default) and takes injectable probes so tests never touch the real machine.
+``best_fit`` never returns an oversized or license-flagged model as the auto-pick.
+"""
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    tag: str
+    size_gb: float
+    min_ram_gb: float
+    gpu_pref: bool
+    license_note: str | None
+    blurb: str
+
+
+# Ordered small -> large. license_note != None => never an auto-default.
+CATALOG: tuple[ModelInfo, ...] = (
+    ModelInfo("qwen2.5-coder:3b", 1.9, 4, False, None, "low-end, permissive (Apache-2.0)"),
+    ModelInfo("gemma3n:e4b", 3.3, 6, False, "Gemma3 custom license", "light machines"),
+    ModelInfo("qwen2.5-coder:7b", 4.7, 8, False, None, "universal, fits an 8 GB GPU"),
+    ModelInfo("qwen3-coder:30b", 24.0, 24, True, None, "depth build, 256K ctx (Apache-2.0)"),
+)
+DEFAULT_FLOOR = "qwen2.5-coder:3b"
+
+
+@dataclass(frozen=True)
+class Resources:
+    ram_gb: float
+    vram_gb: float | None
+    gpu: str | None
+
+
+def detect_resources(*, ram_probe=None, vram_probe=None) -> Resources:
+    """Detect RAM/VRAM. Fail-soft to (8 GB, no GPU). Probes injectable for tests."""
+    try:
+        ram = float((ram_probe or _ram_gb)())
+    except Exception:  # noqa: BLE001 — detection must never crash startup
+        ram = 8.0
+    try:
+        vram, gpu = (vram_probe or _vram)()
+    except Exception:  # noqa: BLE001
+        vram, gpu = None, None
+    return Resources(ram_gb=ram, vram_gb=vram, gpu=gpu)
+
+
+def best_fit(res: Resources) -> tuple[str, str]:
+    """Largest permissive model that fits. Returns (tag, reason)."""
+    if res.vram_gb and res.vram_gb > 0:
+        eff, where = res.vram_gb, (res.gpu or "VRAM")
+    else:
+        eff, where = res.ram_gb * 0.7, "RAM"
+    eligible = [m for m in CATALOG if m.license_note is None and m.min_ram_gb <= eff]
+    if not eligible:
+        return DEFAULT_FLOOR, f"~{eff:.0f} GB usable -> safe default {DEFAULT_FLOOR}"
+    best = max(eligible, key=lambda m: m.size_gb)
+    return best.tag, f"{where} ~{eff:.0f} GB -> {best.tag}"
+
+
+# --- real probes (best-effort, platform-specific) --------------------------
+def _ram_gb() -> float:
+    sysname = platform.system()
+    if sysname == "Windows":
+        import ctypes
+
+        class _Mem(ctypes.Structure):
+            _fields_ = [("dwLength", ctypes.c_ulong), ("dwMemoryLoad", ctypes.c_ulong),
+                        ("ullTotalPhys", ctypes.c_ulonglong), ("ullAvailPhys", ctypes.c_ulonglong),
+                        ("ullTotalPageFile", ctypes.c_ulonglong), ("ullAvailPageFile", ctypes.c_ulonglong),
+                        ("ullTotalVirtual", ctypes.c_ulonglong), ("ullAvailVirtual", ctypes.c_ulonglong),
+                        ("ullAvailExtendedVirtual", ctypes.c_ulonglong)]
+
+        m = _Mem()
+        m.dwLength = ctypes.sizeof(_Mem)
+        ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(m))
+        return m.ullTotalPhys / 1024**3
+    if sysname == "Darwin":
+        out = subprocess.check_output(["sysctl", "-n", "hw.memsize"], timeout=5)
+        return int(out.strip()) / 1024**3
+    # Linux / other: /proc/meminfo
+    with open("/proc/meminfo", encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) / 1024**2  # kB -> GB
+    raise OSError("cannot read MemTotal")
+
+
+def _vram() -> tuple[float | None, str | None]:
+    if not shutil.which("nvidia-smi"):
+        return None, None
+    out = subprocess.check_output(
+        ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
+        timeout=5,
+    ).decode("utf-8", "replace").strip()
+    first = out.splitlines()[0]
+    name, mib = (p.strip() for p in first.split(","))
+    return float(mib) / 1024, name  # MiB -> GB
+
+
+__all__ = ["ModelInfo", "CATALOG", "DEFAULT_FLOOR", "Resources", "detect_resources", "best_fit"]

--- a/aether_agent/multi_runner.py
+++ b/aether_agent/multi_runner.py
@@ -1,0 +1,73 @@
+# aether_agent/multi_runner.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Run several agents at once (sub-project D).
+
+A daemon thread per ``(agent, task)`` runs ``agent_runner.run`` (Ollama is HTTP
+I/O-bound, so the GIL releases during the request -> real parallelism). Every
+event is pushed to a single ``queue.Queue`` that the MAIN thread drains and hands
+to ``emit(label, event)`` -- so all terminal writes happen on one thread (no
+garbled output). A shared ``write_lock`` (passed into each runner) serializes
+destructive tools across agents. Bounded to 8 concurrent.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Callable
+
+from aether_agent import agent_runner
+
+MAX_CONCURRENT = 8
+Emit = Callable[[str, dict], None]
+ConfirmFn = Callable[[str, dict], bool]
+
+
+def _deny(_name: str, _args: dict) -> bool:
+    return False
+
+
+def run_many(jobs, *, emit: Emit, confirm: "ConfirmFn | None" = None, cwd: str = ".") -> list[dict]:
+    """Run ``jobs`` (list of ``(Agent, task)``) concurrently; ``emit(label, ev)``
+    is called on the main thread per event. Returns a summary dict per agent."""
+    jobs = list(jobs)[:MAX_CONCURRENT]
+    write_lock = threading.Lock()
+    q: "queue.Queue[tuple[str, dict]]" = queue.Queue()
+    summaries: dict[str, dict] = {
+        a.name: {"name": a.name, "ok": False, "summary": "", "tool_calls": 0} for a, _ in jobs
+    }
+
+    def worker(agent, task) -> None:
+        try:
+            for ev in agent_runner.run(
+                agent, task, cwd=cwd, confirm=confirm or _deny, write_lock=write_lock
+            ):
+                q.put((agent.name, ev))
+        except Exception as e:  # noqa: BLE001 — surface as an error event, never crash the thread
+            q.put((agent.name, {"type": "error", "msg": str(e)}))
+        finally:
+            q.put((agent.name, {"type": "_thread_done"}))
+
+    threads = [threading.Thread(target=worker, args=(a, t), daemon=True) for a, t in jobs]
+    for th in threads:
+        th.start()
+
+    remaining = len(jobs)
+    while remaining > 0:
+        label, ev = q.get()
+        etype = ev.get("type")
+        if etype == "_thread_done":
+            remaining -= 1
+            continue
+        if etype == "tool_call":
+            summaries[label]["tool_calls"] += 1
+        elif etype == "done":
+            summaries[label]["ok"] = bool(ev.get("ok", True))
+            summaries[label]["summary"] = str(ev.get("text", ""))
+        emit(label, ev)
+
+    return [summaries[a.name] for a, _ in jobs]
+
+
+__all__ = ["run_many", "MAX_CONCURRENT"]

--- a/aether_agent/multi_runner.py
+++ b/aether_agent/multi_runner.py
@@ -31,7 +31,17 @@ def _deny(_name: str, _args: dict) -> bool:
 def run_many(jobs, *, emit: Emit, confirm: "ConfirmFn | None" = None, cwd: str = ".") -> list[dict]:
     """Run ``jobs`` (list of ``(Agent, task)``) concurrently; ``emit(label, ev)``
     is called on the main thread per event. Returns a summary dict per agent."""
-    jobs = list(jobs)[:MAX_CONCURRENT]
+    # One run per agent per batch: running the SAME agent twice at once would open
+    # two Sessions on its single (shared) pool dir concurrently -> a memory-pool
+    # write race the tool write_lock does not cover. Dedupe by name (keep first).
+    seen: set[str] = set()
+    deduped = []
+    for agent, task in list(jobs):
+        if agent.name in seen:
+            continue
+        seen.add(agent.name)
+        deduped.append((agent, task))
+    jobs = deduped[:MAX_CONCURRENT]
     write_lock = threading.Lock()
     q: "queue.Queue[tuple[str, dict]]" = queue.Queue()
     summaries: dict[str, dict] = {

--- a/aether_agent/ollama_ctl.py
+++ b/aether_agent/ollama_ctl.py
@@ -1,0 +1,232 @@
+# aether_agent/ollama_ctl.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Ollama lifecycle control — the terminal's managed view of the local daemon.
+
+Talks to the Ollama HTTP API (``/api/tags``, ``/api/pull`` stream, ``/api/ps``,
+``/api/delete``) and supervises a ``serve`` subprocess we may own. Every IO seam
+(HTTP GET, HTTP streaming POST, ``Popen``, ``which``, ``sleep``, download, run)
+is injectable so the whole surface is unit-testable offline. ``install`` (Task 4)
+is the only path that downloads; it is consent-gated + https/official-host-pinned.
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable, Iterator, Optional
+
+from aether_agent.adapter import DEFAULT_HOST
+
+_PROBE_TIMEOUT = 4.0
+_SERVE_READY_TIMEOUT = 30.0
+_SERVE_POLL_INTERVAL = 0.4
+
+OFFICIAL_HOSTS = ("ollama.com", "www.ollama.com", "github.com")
+_WIN_INSTALLER = "https://ollama.com/download/OllamaSetup.exe"
+_UNIX_INSTALL_SH = "https://ollama.com/install.sh"
+_MANUAL_LINK = "https://ollama.com/download"
+
+ProgressFn = Callable[[str, float, float], None]
+
+
+def is_official_url(url: str) -> bool:
+    """True only for an https URL whose host is an official Ollama host."""
+    try:
+        p = urllib.parse.urlsplit(url)
+    except ValueError:
+        return False
+    if p.scheme != "https":
+        return False
+    return (p.hostname or "").lower() in OFFICIAL_HOSTS
+
+
+def _default_installer_url() -> str:
+    return _WIN_INSTALLER if platform.system() == "Windows" else _UNIX_INSTALL_SH
+
+
+class OllamaCtl:
+    def __init__(
+        self,
+        host: str = DEFAULT_HOST,
+        *,
+        http_get: Optional[Callable[[str], Any]] = None,
+        http_post_stream: Optional[Callable[[str, dict], Iterator[dict]]] = None,
+        popen: Optional[Callable[[list[str]], Any]] = None,
+        which: Optional[Callable[[str], Optional[str]]] = None,
+        sleep: Optional[Callable[[float], None]] = None,
+        installer_url: Optional[Callable[[], str]] = None,
+        downloader: Optional[Callable[[str], bytes]] = None,
+        runner: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self.host = host.rstrip("/")
+        self._get = http_get or self._default_get
+        self._post_stream = http_post_stream or self._default_post_stream
+        self._popen = popen or (lambda args: subprocess.Popen(args))
+        self._which = which or shutil.which
+        self._sleep = sleep or time.sleep
+        self._installer_url = installer_url or _default_installer_url
+        self._download = downloader or self._default_download
+        self._run_installer = runner or self._default_run_installer
+        self._owned = False
+        self._proc: Any = None
+
+    # --- detection ---------------------------------------------------------
+    def _daemon_up(self) -> bool:
+        try:
+            self._get("/api/tags")
+            return True
+        except Exception:  # noqa: BLE001 — any failure means "not up"
+            return False
+
+    def detect(self) -> dict:
+        return {"installed": bool(self._which("ollama")), "daemon_up": self._daemon_up()}
+
+    # --- serve lifecycle ---------------------------------------------------
+    def ensure_serve(self) -> bool:
+        """Ensure the daemon is up. Start it (and mark OWNED) only if it is down.
+        Returns True when reachable, False on a start timeout."""
+        if self._daemon_up():
+            self._owned = False
+            return True
+        self._proc = self._popen(["ollama", "serve"])
+        self._owned = True
+        waited = 0.0
+        while waited < _SERVE_READY_TIMEOUT:
+            if self._daemon_up():
+                return True
+            self._sleep(_SERVE_POLL_INTERVAL)
+            waited += _SERVE_POLL_INTERVAL
+        return False
+
+    def stop_owned(self) -> None:
+        """Terminate the serve subprocess only if we started it."""
+        if self._owned and self._proc is not None:
+            try:
+                self._proc.terminate()
+            except Exception:  # noqa: BLE001 — teardown is best-effort
+                pass
+            self._owned = False
+            self._proc = None
+
+    # --- model ops ---------------------------------------------------------
+    def list_models(self) -> list[dict]:
+        try:
+            payload = self._get("/api/tags") or {}
+        except Exception:  # noqa: BLE001
+            return []
+        out = []
+        for m in payload.get("models", []) if isinstance(payload, dict) else []:
+            if isinstance(m, dict) and m.get("name"):
+                out.append({"tag": str(m["name"]), "size_bytes": int(m.get("size", 0) or 0)})
+        return out
+
+    def ps(self) -> list[dict]:
+        try:
+            payload = self._get("/api/ps") or {}
+        except Exception:  # noqa: BLE001
+            return []
+        return payload.get("models", []) if isinstance(payload, dict) else []
+
+    def pull(self, tag: str, on_progress: Optional[ProgressFn] = None) -> tuple[bool, str]:
+        """Pull/update a model, streaming NDJSON progress to ``on_progress``."""
+        last = ""
+        try:
+            for obj in self._post_stream("/api/pull", {"name": tag, "stream": True}):
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("error"):
+                    return False, str(obj["error"])
+                last = str(obj.get("status", ""))
+                if on_progress is not None:
+                    on_progress(last, float(obj.get("completed", 0) or 0), float(obj.get("total", 0) or 0))
+        except Exception as e:  # noqa: BLE001 — surface as a clean failure
+            return False, str(e)
+        return True, last or "done"
+
+    def remove(self, tag: str) -> tuple[bool, str]:
+        try:
+            self._default_delete("/api/delete", {"name": tag})
+            return True, "removed"
+        except Exception as e:  # noqa: BLE001
+            return False, str(e)
+
+    # --- install (consent-gated, host-pinned) ------------------------------
+    def install(self, *, consent: bool) -> tuple[bool, str]:
+        if not consent:
+            return False, f"install needs consent; get it yourself: {_MANUAL_LINK}"
+        url = self._installer_url()
+        if not is_official_url(url):
+            return False, f"refusing non-official installer url ({url}); use {_MANUAL_LINK}"
+        try:
+            blob = self._download(url)
+        except Exception as e:  # noqa: BLE001
+            return False, f"download failed ({e}); install manually: {_MANUAL_LINK}"
+        if not blob:
+            return False, f"empty download; install manually: {_MANUAL_LINK}"
+        suffix = ".exe" if url.endswith(".exe") else ".sh"
+        fd, path = tempfile.mkstemp(prefix="ollama-install-", suffix=suffix)
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(blob)
+            self._run_installer(path)
+        except Exception as e:  # noqa: BLE001
+            return False, f"installer failed ({e}); install manually: {_MANUAL_LINK}"
+        if not self._which("ollama"):
+            return False, f"install ran but ollama still not found; see {_MANUAL_LINK}"
+        return True, "ollama installed"
+
+    # --- default IO seams (real urllib / subprocess) -----------------------
+    def _default_get(self, path: str) -> Any:
+        req = urllib.request.Request(self.host + path, method="GET")
+        with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+
+    def _default_post_stream(self, path: str, body: dict) -> Iterator[dict]:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            self.host + path, data=data, method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=_SERVE_READY_TIMEOUT * 20) as resp:  # noqa: S310
+            for raw in resp:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except ValueError:
+                    continue
+
+    def _default_delete(self, path: str, body: dict) -> None:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            self.host + path, data=data, method="DELETE",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT) as resp:  # noqa: S310
+            resp.read()
+
+    def _default_download(self, url: str) -> bytes:
+        if not is_official_url(url):  # defense in depth — never fetch a non-official url
+            raise ValueError("non-official url")
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 — pinned official host
+            return resp.read()
+
+    def _default_run_installer(self, path: str) -> None:
+        if path.endswith(".exe"):
+            subprocess.run([path, "/VERYSILENT"], check=False, timeout=600)
+        else:
+            subprocess.run(["sh", path], check=False, timeout=600)
+
+
+__all__ = ["OllamaCtl", "ProgressFn", "OFFICIAL_HOSTS", "is_official_url"]

--- a/aether_agent/onboarding.py
+++ b/aether_agent/onboarding.py
@@ -1,0 +1,102 @@
+# aether_agent/onboarding.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""First-run / preflight state machine for the Ollama-managed terminal.
+
+``preflight(ctl, ...)`` runs detect -> (install?) -> serve -> pick -> pull and
+returns a typed :class:`Preflight`. Silent and instant when everything is already
+healthy. ``prompt``/``resources``/``emit`` are injected so the flow is testable
+with no TTY, no network, no real Ollama. ``emit`` defaults to a no-op (quiet
+tests); ``repl.py`` passes a real writer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from aether_agent import hardware, progress
+
+Prompt = Callable[[str], str]
+Emit = Callable[[str], None]
+ResourcePick = Callable[[], "tuple[str, str]"]
+
+
+@dataclass
+class Preflight:
+    ok: bool
+    chosen_model: str | None = None
+    message: str = ""
+    steps: list[str] = field(default_factory=list)
+
+
+def _default_pick() -> "tuple[str, str]":
+    return hardware.best_fit(hardware.detect_resources())
+
+
+def preflight(
+    ctl: Any,
+    *,
+    resources: ResourcePick | None = None,
+    prompt: Prompt = lambda q: "",
+    emit: Emit = lambda s: None,
+) -> Preflight:
+    pick = resources or _default_pick
+    steps: list[str] = []
+
+    if not ctl.detect().get("installed"):
+        ans = prompt("Ollama not found. Install it now? [y/N] ").strip().lower()
+        if ans not in ("y", "yes"):
+            return Preflight(False, None, "Install Ollama manually: https://ollama.com/download", steps)
+        ok, detail = ctl.install(consent=True)
+        steps.append(progress.step("install ollama", ok))
+        emit(steps[-1] + "\n")
+        if not ok:
+            return Preflight(False, None, detail, steps)
+
+    if not ctl.detect().get("daemon_up"):
+        ok = ctl.ensure_serve()
+        steps.append(progress.step("start ollama serve", ok))
+        emit(steps[-1] + "\n")
+        if not ok:
+            return Preflight(False, None, "could not start ollama serve", steps)
+
+    installed = {m["tag"] for m in ctl.list_models()}
+    if installed:
+        return Preflight(True, sorted(installed)[0], "", steps)
+
+    tag, reason = pick()
+    emit(f"  recommended: {tag}  ({reason})\n")
+    ans = prompt(f"Pull {tag}? [Enter=yes / tag <x>] ").strip()
+    if ans.lower().startswith("tag "):
+        tag = ans[4:].strip() or tag
+    ok, detail = ctl.pull(tag, on_progress=lambda s, c, t: emit("\r" + progress.pull_line(tag, c, t)))
+    emit("\n" + progress.step(f"pull {tag}", ok) + "\n")
+    if not ok:
+        return Preflight(False, None, f"pull failed: {detail}", steps)
+    return Preflight(True, tag, "", steps)
+
+
+def doctor(ctl: Any, *, resources: ResourcePick | None = None) -> str:
+    """Report-only health check with exact fixes. Never starts/installs anything."""
+    pick = resources or _default_pick
+    det = ctl.detect()
+    models = [m["tag"] for m in ctl.list_models()] if det.get("daemon_up") else []
+    tag, reason = pick()
+    lines = [
+        "aether doctor",
+        progress.step("ollama installed", det.get("installed", False)),
+        progress.step("ollama daemon up", det.get("daemon_up", False)),
+        progress.step(f"a model is pulled ({len(models)})", bool(models)),
+        f"  recommended for this machine: {tag}  ({reason})",
+    ]
+    if not det.get("installed"):
+        lines.append("  fix: install -> https://ollama.com/download (or run /setup)")
+    elif not det.get("daemon_up"):
+        lines.append("  fix: start it -> run /setup (or `ollama serve`)")
+    elif not models:
+        lines.append(f"  fix: pull a model -> /pull {tag}")
+    return "\n".join(lines)
+
+
+__all__ = ["Preflight", "preflight", "doctor"]

--- a/aether_agent/progress.py
+++ b/aether_agent/progress.py
@@ -1,0 +1,60 @@
+# aether_agent/progress.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Pure, cp1252-safe render helpers for the Ollama-managed terminal UI.
+
+No IO, no ANSI cursor control here (callers own the terminal) — just strings, so
+every function is trivially unit-testable and safe on a Windows cp1252 console.
+"""
+from __future__ import annotations
+
+_BLOCK = "#"
+_EMPTY = "-"
+_SPINNER = ("|", "/", "-", "\\")
+
+
+def progress_bar(frac: float, width: int = 24) -> str:
+    """Render ``[####----] 51%``. ``frac`` is clamped to [0, 1]."""
+    try:
+        f = float(frac)
+    except (TypeError, ValueError):
+        f = 0.0
+    f = 0.0 if f < 0 else 1.0 if f > 1 else f
+    filled = round(f * width)
+    bar = _BLOCK * filled + _EMPTY * (width - filled)
+    return f"[{bar}] {int(round(f * 100))}%"
+
+
+def fmt_bytes(n: float) -> str:
+    """Human bytes: ``4.7 GB``. Whole-byte values render without a decimal."""
+    try:
+        val = float(n or 0)
+    except (TypeError, ValueError):
+        val = 0.0
+    if val < 1024:
+        return f"{int(val)} B"
+    for unit in ("KB", "MB", "GB", "TB"):
+        val /= 1024
+        if val < 1024 or unit == "TB":
+            return f"{val:.1f} {unit}"
+    return f"{val:.1f} TB"
+
+
+def spinner_frame(i: int) -> str:
+    return _SPINNER[i % len(_SPINNER)]
+
+
+def step(label: str, ok: bool | None = None) -> str:
+    """A step line: ``... label`` (pending) · ``[ok] label`` · ``[x] label``."""
+    mark = "..." if ok is None else ("[ok]" if ok else "[x]")
+    return f"  {mark} {label}"
+
+
+def pull_line(tag: str, completed: float, total: float) -> str:
+    """Single-line live pull status: ``tag  2.0 GB / 4.0 GB  [####----] 50%``."""
+    frac = (float(completed) / float(total)) if total else 0.0
+    return f"{tag}   {fmt_bytes(completed)} / {fmt_bytes(total)}   {progress_bar(frac)}"
+
+
+__all__ = ["progress_bar", "fmt_bytes", "spinner_frame", "step", "pull_line"]

--- a/aether_agent/repl.py
+++ b/aether_agent/repl.py
@@ -169,7 +169,10 @@ def main(argv: Optional[list[str]] = None) -> int:
                     _safe_write(out, text + "\n")
                 if res.get("setup") and ollama is not None:
                     pf = _preflight(ollama, emit=lambda s: _safe_write(out, s))
-                    ctx.model = pf.chosen_model or ctx.model
+                    if pf.ok:
+                        ctx.model = pf.chosen_model or ctx.model
+                    else:
+                        _safe_write(out, f"\n{pf.message}\n")
                 if res.get("restart"):
                     ctx.authed = store.get() is not None
                     _safe_write(out, "(session restarted — context cleared)\n")

--- a/aether_agent/repl.py
+++ b/aether_agent/repl.py
@@ -26,6 +26,8 @@ from typing import Any, Optional
 from aether_agent.auth import FileTokenStore, auth_status
 from aether_agent.brains import select_brain
 from aether_agent.config import load_config
+from aether_agent.ollama_ctl import OllamaCtl
+from aether_agent.onboarding import preflight as _preflight_impl
 from aether_agent.slash import SlashContext, dispatch
 from aether_agent.splash import render_splash
 from aether_agent.transport import ApiClient
@@ -93,8 +95,20 @@ def _run_turn(brain: Any, line: str, out: Any) -> None:
         _safe_write(out, "\n(interrupted)\n")
 
 
-def _make_ctx(authed: bool, api: Any, model: str) -> SlashContext:
-    return SlashContext(api=api, authed=authed, model=model)
+def _build_ollama(backend: str, authed: bool) -> Any:
+    """The local Ollama controller, only when this session will serve locally."""
+    b = (backend or "auto").strip().lower()
+    if b == "cloud" or (b == "auto" and authed):
+        return None  # cloud session — no local daemon to manage
+    return OllamaCtl()
+
+
+def _preflight(ctl: Any, **kw: Any) -> Any:
+    return _preflight_impl(ctl, **kw)
+
+
+def _make_ctx(authed: bool, api: Any, model: str, ollama: Any = None) -> SlashContext:
+    return SlashContext(api=api, authed=authed, model=model, ollama=ollama)
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -111,50 +125,66 @@ def main(argv: Optional[list[str]] = None) -> int:
     authed = store.get() is not None
     api = ApiClient(base_url, store)
 
+    ollama = _build_ollama(backend, authed)
+    chosen_model = model
+    if ollama is not None:
+        pf = _preflight(ollama, emit=lambda s: _safe_write(out, s))
+        if not pf.ok:
+            _safe_write(out, f"\n{pf.message}\n")
+            ollama.stop_owned()
+            return 1
+        chosen_model = pf.chosen_model or model
+
     label = _backend_label(backend, authed)
     short_backend = "cloud" if "cloud" in label else "local"
-    _safe_write(out, render_splash(VERSION, model or "auto", short_backend) + "\n\n")
+    _safe_write(out, render_splash(VERSION, chosen_model or "auto", short_backend) + "\n\n")
     _safe_write(out, "Type a prompt, or /help for commands. /exit to quit.\n\n")
 
-    ctx = _make_ctx(authed, api, model)
+    ctx = _make_ctx(authed, api, chosen_model, ollama)
     is_tty = bool(getattr(sys.stdin, "isatty", lambda: False)())
     if is_tty:
         _enable_readline_history()
 
-    while True:
-        try:
-            line = input(_PROMPT) if is_tty else _read_line()
-        except KeyboardInterrupt:
-            out.write("\n")  # Ctrl-C at the prompt exits cleanly
-            return 0
-        except EOFError:
-            out.write("\n")
-            return 0
-        if line is None:
-            return 0  # non-tty EOF
-        line = line.strip()
-        if not line:
-            continue
-        if line.startswith("/"):
-            res = dispatch(ctx, line)
-            if res.get("exit"):
+    try:
+        while True:
+            try:
+                line = input(_PROMPT) if is_tty else _read_line()
+            except KeyboardInterrupt:
+                out.write("\n")
                 return 0
-            text = res.get("text")
-            if text:
-                _safe_write(out, text + "\n")
-            if res.get("restart"):
-                ctx.authed = store.get() is not None
-                _safe_write(out, "(session restarted — context cleared)\n")
-            continue
-        # A chat turn. Rebuild the brain per turn so a /model switch takes effect.
-        brain = select_brain(
-            authed=store.get() is not None,
-            backend=backend,
-            api=api,
-            model=ctx.model or model or "",
-        )
-        _run_turn(brain, line, out)
-        out.write("\n")
+            except EOFError:
+                out.write("\n")
+                return 0
+            if line is None:
+                return 0
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("/"):
+                res = dispatch(ctx, line)
+                if res.get("exit"):
+                    return 0
+                text = res.get("text")
+                if text:
+                    _safe_write(out, text + "\n")
+                if res.get("setup") and ollama is not None:
+                    pf = _preflight(ollama, emit=lambda s: _safe_write(out, s))
+                    ctx.model = pf.chosen_model or ctx.model
+                if res.get("restart"):
+                    ctx.authed = store.get() is not None
+                    _safe_write(out, "(session restarted — context cleared)\n")
+                continue
+            brain = select_brain(
+                authed=store.get() is not None,
+                backend=backend,
+                api=api,
+                model=ctx.model or chosen_model or "",
+            )
+            _run_turn(brain, line, out)
+            out.write("\n")
+    finally:
+        if ollama is not None:
+            ollama.stop_owned()
 
 
 def _safe_write(out: Any, text: str) -> None:

--- a/aether_agent/repl.py
+++ b/aether_agent/repl.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import sys
 from typing import Any, Optional
 
+from aether_agent.agent_profile import ACCENTS, Agent
 from aether_agent.auth import FileTokenStore, auth_status
 from aether_agent.brains import select_brain
 from aether_agent.config import load_config
@@ -111,6 +112,33 @@ def _make_ctx(authed: bool, api: Any, model: str, ollama: Any = None) -> SlashCo
     return SlashContext(api=api, authed=authed, model=model, ollama=ollama)
 
 
+def _apply_agent(agent: Agent) -> dict[str, Any]:
+    """Compute the REPL UX state for an active agent (pure; cp1252-safe ANSI)."""
+    return {
+        "name": agent.name,
+        "prompt": agent.prompt or f"{agent.name} > ",
+        "accent_ansi": f"\x1b[{ACCENTS.get(agent.accent, '36')}m",
+        "banner": agent.banner,
+        "persona": agent.persona,
+    }
+
+
+def _handle_agent_action(res: dict[str, Any], out: Any) -> None:
+    """Execute a /agent run action: stream the agent's turn via the runner."""
+    from aether_agent import agent_runner, agent_store
+
+    run = res.get("run_agent")
+    if not run:
+        return
+    try:
+        agent = agent_store.load(run["name"])
+    except (ValueError, OSError) as e:
+        _safe_write(out, f"\n[x] {e}\n")
+        return
+    for ev in agent_runner.run(agent, run["task"], confirm=lambda n, a: False):
+        _render_event(ev, out)
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     """Run the interactive REPL. Returns a process exit code (0 on clean exit).
     ``argv`` is accepted for signature parity with other entry points but the
@@ -141,6 +169,8 @@ def main(argv: Optional[list[str]] = None) -> int:
     _safe_write(out, "Type a prompt, or /help for commands. /exit to quit.\n\n")
 
     ctx = _make_ctx(authed, api, chosen_model, ollama)
+    active_agent: Optional[Agent] = None
+    prompt_str = _PROMPT
     is_tty = bool(getattr(sys.stdin, "isatty", lambda: False)())
     if is_tty:
         _enable_readline_history()
@@ -148,7 +178,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         while True:
             try:
-                line = input(_PROMPT) if is_tty else _read_line()
+                line = input(prompt_str) if is_tty else _read_line()
             except KeyboardInterrupt:
                 out.write("\n")
                 return 0
@@ -167,6 +197,18 @@ def main(argv: Optional[list[str]] = None) -> int:
                 text = res.get("text")
                 if text:
                     _safe_write(out, text + "\n")
+                if res.get("switch_agent"):
+                    try:
+                        active_agent = Agent.load(res["switch_agent"])
+                        ctx.active_agent = active_agent.name
+                        st = _apply_agent(active_agent)
+                        prompt_str = st["prompt"]
+                        if st["banner"]:
+                            _safe_write(out, st["accent_ansi"] + st["banner"] + "\x1b[0m\n")
+                    except (ValueError, OSError) as e:
+                        _safe_write(out, f"\n[x] {e}\n")
+                if res.get("run_agent"):
+                    _handle_agent_action(res, out)
                 if res.get("setup") and ollama is not None:
                     pf = _preflight(ollama, emit=lambda s: _safe_write(out, s))
                     if pf.ok:
@@ -176,6 +218,12 @@ def main(argv: Optional[list[str]] = None) -> int:
                 if res.get("restart"):
                     ctx.authed = store.get() is not None
                     _safe_write(out, "(session restarted — context cleared)\n")
+                continue
+            if active_agent is not None:
+                from aether_agent import agent_runner
+                for ev in agent_runner.run(active_agent, line, confirm=lambda n, a: False):
+                    _render_event(ev, out)
+                out.write("\n")
                 continue
             brain = select_brain(
                 authed=store.get() is not None,

--- a/aether_agent/repl.py
+++ b/aether_agent/repl.py
@@ -139,6 +139,63 @@ def _handle_agent_action(res: dict[str, Any], out: Any) -> None:
         _render_event(ev, out)
 
 
+def _parse_multi(line: str):
+    """Parse a ` \\ `-joined multi-agent run line into [(Agent, task), ...].
+    Returns None when it is not a 2+ agent-run line."""
+    if " \\ " not in line:
+        return None
+    from aether_agent import agent_store
+
+    jobs = []
+    for seg in line.split(" \\ "):
+        s = seg.strip()
+        if s.startswith("/"):
+            s = s[1:]
+        parts = s.split()
+        if len(parts) < 3 or parts[0].lower() != "agent":
+            return None  # not all segments are agent runs -> not a multi-run
+        if parts[2].lower() in {"set", "show", "edit", "delete", "cmd", "run"}:
+            return None  # a verb, not a task
+        name = parts[1]
+        task = " ".join(parts[2:])
+        try:
+            jobs.append((agent_store.load(name), task))
+        except (ValueError, OSError):
+            return None
+    return jobs if len(jobs) >= 2 else None
+
+
+def _handle_multi(jobs: Any, out: Any) -> None:
+    """Run jobs concurrently, rendering labeled interleaved output + a summary."""
+    from aether_agent import multi_runner
+
+    accents = {a.name: f"\x1b[{ACCENTS.get(a.accent, '36')}m" for a, _ in jobs}
+
+    def emit(label: str, ev: dict) -> None:
+        _render_labeled(label, ev, accents.get(label, ""), out)
+
+    summaries = multi_runner.run_many(jobs, emit=emit, confirm=lambda n, a: False)
+    _safe_write(out, "\n--- done ---\n")
+    for s in summaries:
+        _safe_write(out, f"{s['name']}: {s['summary'] or ('ok' if s['ok'] else 'stopped')}\n")
+
+
+def _render_labeled(label: str, ev: dict, accent_ansi: str, out: Any) -> None:
+    """Render one event prefixed by [label] (accent-colored), cp1252-safe."""
+    tag = f"{accent_ansi}[{label}]\x1b[0m " if accent_ansi else f"[{label}] "
+    etype = ev.get("type")
+    if etype in ("monologue", "done"):
+        text = str(ev.get("text", ""))
+        if text:
+            _safe_write(out, tag + _first_line(text, 120) + "\n")
+    elif etype == "tool_call":
+        _safe_write(out, tag + f"- {ev.get('name', '')}({_fmt_args(ev.get('args', {}))})\n")
+    elif etype == "tool_result":
+        _safe_write(out, tag + f"- {ev.get('name', '')} -> {_first_line(str(ev.get('output', '')))}\n")
+    elif etype == "error":
+        _safe_write(out, tag + f"[x] {ev.get('msg', 'error')}\n")
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     """Run the interactive REPL. Returns a process exit code (0 on clean exit).
     ``argv`` is accepted for signature parity with other entry points but the
@@ -189,6 +246,11 @@ def main(argv: Optional[list[str]] = None) -> int:
                 return 0
             line = line.strip()
             if not line:
+                continue
+            jobs = _parse_multi(line)
+            if jobs is not None:
+                _handle_multi(jobs, out)
+                out.write("\n")
                 continue
             if line.startswith("/"):
                 res = dispatch(ctx, line)

--- a/aether_agent/slash.py
+++ b/aether_agent/slash.py
@@ -55,6 +55,7 @@ class SlashContext:
     model: str = ""
     agent: str = ""
     web: Any = None
+    ollama: Any = None  # an ollama_ctl.OllamaCtl (local lifecycle); None when cloud-only
 
 
 # --- help text -------------------------------------------------------------
@@ -66,6 +67,10 @@ _HELP_LINES = (
     "/tier              plan tier + default",
     "/audit [n]         recent Aether audit trail",
     "/web <query>       search the web inline",
+    "/pull <tag>        download/update a local model",
+    "/doctor            check the local Ollama setup",
+    "/serve             show the Ollama daemon state",
+    "/setup             re-run first-run setup",
     "/clear             clear screen",
     "/exit              leave (also /quit)",
 )
@@ -96,6 +101,8 @@ def _exit(ctx: SlashContext, arg: str) -> SlashResult:
 
 
 def _models(ctx: SlashContext, arg: str) -> SlashResult:
+    if not ctx.authed and ctx.ollama is not None:
+        return _ollama_models(ctx)
     if not ctx.authed:
         return _text("(local Ollama — set a model with /model <tag>)")
     payload = ctx.api.get_json(MODELS_PATH)
@@ -201,6 +208,57 @@ def _web(ctx: SlashContext, arg: str) -> SlashResult:
     return _text(out)
 
 
+def _ollama_models(ctx: SlashContext) -> SlashResult:
+    from aether_agent.hardware import CATALOG, best_fit, detect_resources
+
+    ctl = ctx.ollama
+    installed = {m["tag"] for m in ctl.list_models()} if ctl else set()
+    rec, _ = best_fit(detect_resources())
+    lines = ["local models (* installed, › current, ! recommended):"]
+    for m in CATALOG:
+        dot = "*" if m.tag in installed else " "
+        cur = "›" if m.tag == ctx.model else " "
+        star = "!" if m.tag == rec else " "
+        note = f"  [{m.license_note}]" if m.license_note else ""
+        lines.append(f"{dot}{cur}{star} {m.tag}\t{m.size_gb:g}GB\t{m.blurb}{note}")
+    for tag in sorted(installed):
+        if all(tag != m.tag for m in CATALOG):
+            cur = "›" if tag == ctx.model else " "
+            lines.append(f"*{cur}  {tag}\t(installed)")
+    lines.append("switch: /model <tag>   ·   pull: /pull <tag>")
+    return _text("\n".join(lines))
+
+
+def _pull(ctx: SlashContext, arg: str) -> SlashResult:
+    tag = arg.strip()
+    if not tag:
+        return _text("usage: /pull <tag>")
+    if ctx.ollama is None:
+        return _text("(pull is a local-Ollama command)")
+    ok, detail = ctx.ollama.pull(tag)
+    return _text(f"pull {tag}: {'ok' if ok else 'failed'} ({detail})")
+
+
+def _doctor(ctx: SlashContext, arg: str) -> SlashResult:
+    if ctx.ollama is None:
+        return _text("(doctor checks the local Ollama; not available in cloud-only mode)")
+    from aether_agent import onboarding
+    return _text(onboarding.doctor(ctx.ollama))
+
+
+def _serve(ctx: SlashContext, arg: str) -> SlashResult:
+    if ctx.ollama is None:
+        return _text("(serve status is a local-Ollama command)")
+    det = ctx.ollama.detect()
+    owned = bool(getattr(ctx.ollama, "_owned", False))
+    state = "up" if det.get("daemon_up") else "down"
+    return _text(f"ollama daemon: {state}{' (owned by this session)' if owned else ''}")
+
+
+def _setup(ctx: SlashContext, arg: str) -> SlashResult:
+    return {"setup": True, "text": "re-running setup…"}
+
+
 def _to_int(s: str, *, default: int) -> int:
     try:
         v = int(s)
@@ -221,6 +279,10 @@ REGISTRY: dict[str, Handler] = {
     "audit": _audit,
     "clear": _clear,
     "web": _web,
+    "pull": _pull,
+    "doctor": _doctor,
+    "serve": _serve,
+    "setup": _setup,
     "exit": _exit,
     "quit": _exit,
 }

--- a/aether_agent/slash.py
+++ b/aether_agent/slash.py
@@ -319,9 +319,30 @@ def dispatch(ctx: SlashContext, line: str) -> SlashResult:
     cmd = parts[0].lower() if parts else ""
     arg = " ".join(parts[1:])
     handler = REGISTRY.get(cmd)
-    if handler is None:
-        return _text(f"(unknown command: /{cmd}) — try /help")
-    return handler(ctx, arg)
+    if handler is not None:
+        return handler(ctx, arg)
+    custom = _resolve_custom_command(ctx, cmd, arg)
+    if custom is not None:
+        return custom
+    return _text(f"(unknown command: /{cmd}) — try /help")
+
+
+def _resolve_custom_command(ctx: SlashContext, cmd: str, arg: str) -> SlashResult | None:
+    """If an agent is active and has a command named ``cmd``, expand it into a
+    run_agent action. Returns None when there is no match (caller -> unknown)."""
+    if not getattr(ctx, "active_agent", ""):
+        return None
+    from aether_agent import agent_commands, agent_store
+
+    try:
+        agent = agent_store.load(ctx.active_agent)
+    except (ValueError, OSError):
+        return None
+    cmds = agent_commands.list_commands(agent)
+    if cmd not in cmds:
+        return None
+    task = agent_commands.expand(cmds[cmd], arg.split())
+    return {"run_agent": {"name": ctx.active_agent, "task": task}}
 
 
 __all__ = ["SlashContext", "SlashResult", "REGISTRY", "dispatch"]

--- a/aether_agent/slash.py
+++ b/aether_agent/slash.py
@@ -56,14 +56,16 @@ class SlashContext:
     agent: str = ""
     web: Any = None
     ollama: Any = None  # an ollama_ctl.OllamaCtl (local lifecycle); None when cloud-only
+    active_agent: str = ""  # name of the active custom agent (B); "" = none
 
 
 # --- help text -------------------------------------------------------------
 _HELP_LINES = (
     "/models            list chat models",
     "/model <tag>       switch model (clears context)",
-    "/agents            list orchestrators (Neo/Kronus)",
-    "/agent <id>        switch orchestrator",
+    "/agents            list your custom agents",
+    "/agent <name>      switch agent (or: /agent <name> <task>)",
+    "/new-agent <name>  create a custom agent",
     "/tier              plan tier + default",
     "/audit [n]         recent Aether audit trail",
     "/web <query>       search the web inline",
@@ -128,7 +130,7 @@ def _model(ctx: SlashContext, arg: str) -> SlashResult:
     return {"restart": {"model": tag}, "text": f"model -> {tag} (context cleared)"}
 
 
-def _agents(ctx: SlashContext, arg: str) -> SlashResult:
+def _agents_orch(ctx: SlashContext, arg: str) -> SlashResult:
     if not ctx.authed:
         return _text("(orchestrators are a cloud feature — log in with: aether auth login)")
     payload = ctx.api.get_json(AGENTS_PATH)
@@ -145,7 +147,7 @@ def _agents(ctx: SlashContext, arg: str) -> SlashResult:
     return _text("\n".join(lines))
 
 
-def _agent(ctx: SlashContext, arg: str) -> SlashResult:
+def _agent_orch(ctx: SlashContext, arg: str) -> SlashResult:
     aid = arg.strip()
     if not aid:
         return _text("usage: /agent <id>")
@@ -206,6 +208,21 @@ def _web(ctx: SlashContext, arg: str) -> SlashResult:
     except Exception as e:  # noqa: BLE001 — a tool error must not crash the REPL
         out = f"[web_search error: {e}]"
     return _text(out)
+
+
+def _new_agent(ctx: SlashContext, arg: str) -> SlashResult:
+    from aether_agent.agent_slash import dispatch_agent
+    return dispatch_agent(f"/new-agent {arg}".strip(), active=ctx.active_agent)
+
+
+def _agents(ctx: SlashContext, arg: str) -> SlashResult:
+    from aether_agent.agent_slash import dispatch_agent
+    return dispatch_agent("/agents", active=ctx.active_agent)
+
+
+def _agent_cmd(ctx: SlashContext, arg: str) -> SlashResult:
+    from aether_agent.agent_slash import dispatch_agent
+    return dispatch_agent(f"/agent {arg}".strip(), active=ctx.active_agent)
 
 
 def _ollama_models(ctx: SlashContext) -> SlashResult:
@@ -273,8 +290,11 @@ REGISTRY: dict[str, Handler] = {
     "": _help,        # bare "/" -> help
     "models": _models,
     "model": _model,
-    "agents": _agents,
-    "agent": _agent,
+    "agents": _agents,             # B: list custom local agents
+    "agent": _agent_cmd,           # B: /agent <name> <verb>
+    "new-agent": _new_agent,       # B: create
+    "orchestrators": _agents_orch, # cloud orchestrators (was /agents)
+    "orchestrator": _agent_orch,   # cloud orchestrator switch (was /agent)
     "tier": _tier,
     "audit": _audit,
     "clear": _clear,

--- a/docs/superpowers/plans/2026-06-15-custom-commands.md
+++ b/docs/superpowers/plans/2026-06-15-custom-commands.md
@@ -1,0 +1,708 @@
+# Custom Local Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users (and the agent, via a gated `define_command` tool) save reusable prompt-macros on an agent and invoke them as bare slash commands (`/review src/api.py`), expanding into an agent turn.
+
+**Architecture:** One new stdlib module `aether_agent/agent_commands.py` (name-validation + template expansion + add/remove/list), un-reserve B's `commands` field into a validated `{name: template}` map, resolve custom slashes in `slash.dispatch` after built-ins, and a local-only `define_command` tool in `agent_runner` (kept OUT of the 8-tool bridge protocol).
+
+**Tech Stack:** Python 3.10+, stdlib only (`re`, `json`, `dataclasses`), `pytest`. No new deps. Reuses B (`agent_profile`, `agent_store`, `agent_slash`, `agent_runner`, `slash`, `tools`, `protocol`).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-custom-commands-design.md`
+**Branch:** `feat/custom-commands` (off `main`).
+**Gate:** `.venv/Scripts/python.exe -m pytest -q` AND `.venv/Scripts/python.exe -m ruff check aether_agent tests`.
+
+---
+
+## File Structure
+
+| File | New/Mod | Responsibility |
+|---|---|---|
+| `aether_agent/agent_profile.py` | Mod | `RESERVED_COMMANDS` + `is_valid_command_name()` + `ALLOWED_AGENT_TOOLS`; `commands` validated as `{name: template}`; tools validated against `ALLOWED_AGENT_TOOLS`. |
+| `aether_agent/agent_commands.py` | New | `valid_name` (re-uses profile) + `expand(template, args)` + `add/remove/list_commands`. |
+| `aether_agent/agent_slash.py` | Mod | `cmd add|list|remove` verb + `run <cmd>` verb. |
+| `aether_agent/slash.py` | Mod | `dispatch` resolves a bare `/<word>` against the active agent's commands after built-ins. |
+| `aether_agent/agent_runner.py` | Mod | inject + handle the local-only `define_command` tool when allowed. |
+
+Ordering matters: Task 1 (profile validation) MUST precede Task 2 (`agent_commands.add` calls `Agent.set(commands=...)`, which validates).
+
+---
+
+## Task 1: `agent_profile.py` — un-reserve `commands` + allow `define_command`
+
+**Files:**
+- Modify: `aether_agent/agent_profile.py`
+- Test: `tests/test_agent_profile_commands.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_profile_commands.py
+from aether_agent import agent_profile
+from aether_agent.agent_profile import Agent
+
+
+def test_commands_map_validates():
+    good = Agent.from_dict({"name": "jane", "commands": {"review": "Review $1 for bugs"}})
+    assert agent_profile.validate(good) == []
+
+
+def test_reserved_or_empty_command_rejected():
+    bad = Agent.from_dict({"name": "jane", "commands": {"help": "x"}})  # reserved name
+    assert any("command" in p.lower() for p in agent_profile.validate(bad))
+    empty = Agent.from_dict({"name": "jane", "commands": {"ok": "   "}})  # empty template
+    assert any("template" in p.lower() for p in agent_profile.validate(empty))
+
+
+def test_define_command_allowed_in_tools():
+    a = Agent.from_dict({"name": "jane", "tools": ["read_file", "define_command"]})
+    assert agent_profile.validate(a) == []  # define_command is an allowed agent tool
+
+
+def test_is_valid_command_name():
+    assert agent_profile.is_valid_command_name("review")
+    assert not agent_profile.is_valid_command_name("help")        # reserved
+    assert not agent_profile.is_valid_command_name("Bad Name")    # not a slug
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_profile_commands.py -q`
+Expected: FAIL — `AttributeError: module 'aether_agent.agent_profile' has no attribute 'is_valid_command_name'` (and the reserved-name test fails because B still requires `commands` empty).
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/agent_profile.py`)
+
+`re` is already imported at the top of `agent_profile.py`. Add near the other module constants (after `_MAX_STEPS_RANGE`):
+
+```python
+#: command names a custom command may NOT take (would shadow a built-in slash).
+RESERVED_COMMANDS = frozenset({
+    "help", "models", "model", "agents", "agent", "new-agent", "orchestrator",
+    "orchestrators", "tier", "audit", "web", "clear", "exit", "quit",
+    "pull", "doctor", "serve", "setup", "config",
+})
+_CMD_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+#: tools an AGENT may list (the 8 bridge tools + the local-only authoring tool).
+ALLOWED_AGENT_TOOLS = tuple(TOOLS) + ("define_command",)
+
+
+def is_valid_command_name(name: str) -> bool:
+    return bool(_CMD_NAME_RE.match(name or "")) and name not in RESERVED_COMMANDS
+```
+
+Change the tools check in `validate()` from `if t not in TOOLS` to:
+
+```python
+    unknown = [t for t in agent.tools if t not in ALLOWED_AGENT_TOOLS]
+    if unknown:
+        p.append(f"tools must be a subset of {sorted(ALLOWED_AGENT_TOOLS)} (unknown: {unknown})")
+```
+
+Replace the `if agent.commands:` block in `validate()` with:
+
+```python
+    for cname, ctmpl in (agent.commands or {}).items():
+        if not is_valid_command_name(cname):
+            p.append(f"command name {cname!r} must be a slug and not a reserved built-in")
+        if not isinstance(ctmpl, str) or not ctmpl.strip():
+            p.append(f"command {cname!r} template must be a non-empty string")
+```
+
+Add `RESERVED_COMMANDS`, `ALLOWED_AGENT_TOOLS`, `is_valid_command_name` to `__all__`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_profile_commands.py tests/test_agent_profile.py -q`
+Expected: PASS (new green; the existing `test_agent_profile.py` still green — `commands` defaults to `{}`, which passes the loop trivially)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_profile.py tests/test_agent_profile_commands.py
+git commit -m "feat(cmds): un-reserve Agent.commands as a validated {name:template} map + allow define_command tool"
+```
+
+---
+
+## Task 2: `agent_commands.py` — name validation + expansion + add/remove/list
+
+**Files:**
+- Create: `aether_agent/agent_commands.py`
+- Test: `tests/test_agent_commands.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_commands.py
+import pytest
+
+from aether_agent import agent_commands
+from aether_agent.agent_profile import Agent
+
+
+def test_valid_name():
+    assert agent_commands.valid_name("review")
+    assert not agent_commands.valid_name("help")       # reserved
+    assert not agent_commands.valid_name("Bad Name")   # not a slug
+
+
+def test_expand_positional_all_and_dollar():
+    assert agent_commands.expand("Review $1 and $2", ["a.py", "b.py"]) == "Review a.py and b.py"
+    assert agent_commands.expand("all: $*", ["x", "y", "z"]) == "all: x y z"
+    assert agent_commands.expand("all: $@", ["x", "y"]) == "all: x y"
+    assert agent_commands.expand("cost $$5 for $1", ["a"]) == "cost $5 for a"
+    assert agent_commands.expand("missing $3 here", ["a"]) == "missing  here"  # absent -> ""
+    assert agent_commands.expand("no placeholders", []) == "no placeholders"
+
+
+def test_add_remove_list_roundtrip():
+    a = Agent.from_dict({"name": "jane"})
+    a = agent_commands.add(a, "review", "Review $1 for bugs")
+    assert agent_commands.list_commands(a) == {"review": "Review $1 for bugs"}
+    a = agent_commands.remove(a, "review")
+    assert agent_commands.list_commands(a) == {}
+
+
+def test_add_rejects_bad_name_and_empty_template():
+    a = Agent.from_dict({"name": "jane"})
+    with pytest.raises(ValueError):
+        agent_commands.add(a, "help", "x")        # reserved
+    with pytest.raises(ValueError):
+        agent_commands.add(a, "ok", "   ")        # empty template
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_commands.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.agent_commands'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/agent_commands.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Custom commands — per-agent prompt-macros (sub-project C).
+
+A command is a string template stored in ``Agent.commands`` that expands into an
+agent turn. Placeholders: ``$1``..``$9`` (positional args), ``$*``/``$@`` (all
+args), ``$$`` -> literal ``$``. Pure expansion — no shell, no eval. Authoring
+(add/remove) returns a NEW validated ``Agent`` (immutability).
+"""
+from __future__ import annotations
+
+import re
+
+from aether_agent.agent_profile import Agent, is_valid_command_name
+
+_POS_RE = re.compile(r"\$([1-9])")
+_SENTINEL = "\x00"
+
+
+def valid_name(name: str) -> bool:
+    return is_valid_command_name(name)
+
+
+def expand(template: str, args: list[str]) -> str:
+    """Expand a command template against positional args (pure; no shell/eval)."""
+    all_args = " ".join(args)
+    s = (template or "").replace("$$", _SENTINEL)  # protect literal $ first
+    s = s.replace("$*", all_args).replace("$@", all_args)
+    s = _POS_RE.sub(lambda m: args[int(m.group(1)) - 1] if int(m.group(1)) - 1 < len(args) else "", s)
+    return s.replace(_SENTINEL, "$")
+
+
+def add(agent: Agent, name: str, template: str) -> Agent:
+    """Return a NEW agent with command ``name`` set. Raises ValueError on a bad
+    name or empty template (validation also runs inside Agent.set)."""
+    if not valid_name(name):
+        raise ValueError(f"invalid command name: {name!r} (must be a slug and not a built-in)")
+    if not str(template).strip():
+        raise ValueError("command template must be a non-empty string")
+    cmds = dict(agent.commands)
+    cmds[name] = template
+    return agent.set(commands=cmds)
+
+
+def remove(agent: Agent, name: str) -> Agent:
+    cmds = dict(agent.commands)
+    cmds.pop(name, None)
+    return agent.set(commands=cmds)
+
+
+def list_commands(agent: Agent) -> dict:
+    return dict(agent.commands)
+
+
+__all__ = ["valid_name", "expand", "add", "remove", "list_commands"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_commands.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_commands.py tests/test_agent_commands.py
+git commit -m "feat(cmds): agent_commands — name validation, template expansion, add/remove/list"
+```
+
+---
+
+## Task 3: `agent_slash.py` — `cmd` + `run` verbs
+
+**Files:**
+- Modify: `aether_agent/agent_slash.py`
+- Test: `tests/test_agent_slash_cmd.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_slash_cmd.py
+import pytest
+
+from aether_agent import agent_slash
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def _mk(name="jane"):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": name}))
+
+
+def test_cmd_add_list_remove():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane cmd add review = Review $1 for bugs", active="")
+    assert "review" in res["text"]
+    assert Agent.load("jane").commands == {"review": "Review $1 for bugs"}
+    res2 = agent_slash.dispatch_agent("/agent jane cmd list", active="")
+    assert "review" in res2["text"]
+    agent_slash.dispatch_agent("/agent jane cmd remove review", active="")
+    assert Agent.load("jane").commands == {}
+
+
+def test_cmd_add_requires_equals_and_rejects_reserved():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane cmd add review Review $1", active="")  # no '='
+    assert "=" in res["text"]
+    res2 = agent_slash.dispatch_agent("/agent jane cmd add help = x", active="")  # reserved
+    assert "command" in res2["text"].lower()
+    assert Agent.load("jane").commands == {}  # nothing saved
+
+
+def test_run_verb_expands_to_run_agent():
+    _mk()
+    agent_slash.dispatch_agent("/agent jane cmd add review = Review $1 for bugs", active="")
+    res = agent_slash.dispatch_agent("/agent jane run review src/api.py", active="")
+    assert res.get("run_agent") == {"name": "jane", "task": "Review src/api.py for bugs"}
+
+
+def test_run_unknown_command_friendly():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane run ghost x", active="")
+    assert "no" in res["text"].lower() or "unknown" in res["text"].lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_slash_cmd.py -q`
+Expected: FAIL — the `cmd`/`run` verbs aren't handled (a `cmd add ...` is currently treated as a one-shot task and returns a `run_agent` flag, not a text result), so the assertions fail.
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/agent_slash.py`)
+
+Add `"cmd"` and `"run"` to `_VERBS`:
+
+```python
+_VERBS = {"set", "show", "edit", "delete", "cmd", "run"}
+```
+
+Add routing in `_agent()` (after the `delete` branch, before the one-shot-task fallthrough):
+
+```python
+    if verb == "cmd":
+        return _cmd(name, rest[1:])
+    if verb == "run":
+        return _run_cmd(name, rest[1:])
+```
+
+Add the two handlers:
+
+```python
+def _cmd(name: str, args: list) -> SlashResult:
+    from aether_agent import agent_commands
+    if not args:
+        return _text("usage: /agent <name> cmd add <cmd> = <template> | list | remove <cmd>")
+    sub = args[0].lower()
+    if sub == "list":
+        cmds = agent_commands.list_commands(agent_store.load(name))
+        if not cmds:
+            return _text("(no commands)")
+        return _text("\n".join(f"/{k}\t{v}" for k, v in sorted(cmds.items())))
+    if sub == "remove":
+        if len(args) < 2:
+            return _text("usage: /agent <name> cmd remove <cmd>")
+        updated = agent_commands.remove(agent_store.load(name), args[1])
+        agent_store.save(updated)
+        return _text(f"removed /{args[1]}")
+    if sub == "add":
+        rest = args[1:]
+        if "=" not in rest:
+            return _text("usage: /agent <name> cmd add <cmd> = <template>")
+        eq = rest.index("=")
+        cmd_name = " ".join(rest[:eq]).strip()
+        template = " ".join(rest[eq + 1:]).strip()
+        try:
+            updated = agent_commands.add(agent_store.load(name), cmd_name, template)
+        except (ValueError, TypeError) as e:
+            return _text(f"could not add command: {e}")
+        agent_store.save(updated)
+        return _text(f"added /{cmd_name} = {template}")
+    return _text("usage: /agent <name> cmd add <cmd> = <template> | list | remove <cmd>")
+
+
+def _run_cmd(name: str, args: list) -> SlashResult:
+    from aether_agent import agent_commands
+    if not args:
+        return _text("usage: /agent <name> run <cmd> [args]")
+    cmd_name = args[0]
+    cmds = agent_commands.list_commands(agent_store.load(name))
+    if cmd_name not in cmds:
+        return _text(f"no such command: /{cmd_name} (see /agent {name} cmd list)")
+    task = agent_commands.expand(cmds[cmd_name], args[1:])
+    return {"run_agent": {"name": name, "task": task}, "text": ""}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_slash_cmd.py tests/test_agent_slash.py -q`
+Expected: PASS (new green; existing agent_slash tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_slash.py tests/test_agent_slash_cmd.py
+git commit -m "feat(cmds): /agent <name> cmd add|list|remove + run <cmd> verbs"
+```
+
+---
+
+## Task 4: `slash.py` — resolve bare `/<custom>` after built-ins
+
+**Files:**
+- Modify: `aether_agent/slash.py` (`dispatch`)
+- Test: `tests/test_slash_custom_invoke.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_slash_custom_invoke.py
+import pytest
+
+from aether_agent.slash import SlashContext, dispatch
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def _mk_with_cmd():
+    from aether_agent import agent_store, agent_commands
+    a = agent_commands.add(Agent.from_dict({"name": "jane"}), "review", "Review $1 for bugs")
+    agent_store.create(a)
+
+
+def test_builtin_wins_over_custom_same_name():
+    res = dispatch(SlashContext(api=None, active_agent="jane"), "/help")
+    assert "/exit" in res["text"]  # the built-in help text resolves, not a custom
+
+
+def test_active_agent_custom_resolves():
+    _mk_with_cmd()
+    res = dispatch(SlashContext(api=None, active_agent="jane"), "/review src/api.py")
+    assert res.get("run_agent") == {"name": "jane", "task": "Review src/api.py for bugs"}
+
+
+def test_no_active_agent_unknown():
+    _mk_with_cmd()
+    res = dispatch(SlashContext(api=None, active_agent=""), "/review x")
+    assert "unknown" in res["text"].lower()
+
+
+def test_unknown_name_with_active_agent_is_unknown():
+    _mk_with_cmd()
+    res = dispatch(SlashContext(api=None, active_agent="jane"), "/ghost x")
+    assert "unknown" in res["text"].lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_slash_custom_invoke.py -q`
+Expected: FAIL — `test_active_agent_custom_resolves` fails (a custom `/review` currently returns the "unknown command" note).
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/slash.py`)
+
+The unknown-command branch in `dispatch` currently is:
+
+```python
+    handler = REGISTRY.get(cmd)
+    if handler is None:
+        return _text(f"(unknown command: /{cmd}) — try /help")
+    return handler(ctx, arg)
+```
+
+Change it to resolve a custom command BEFORE returning unknown:
+
+```python
+    handler = REGISTRY.get(cmd)
+    if handler is not None:
+        return handler(ctx, arg)
+    custom = _resolve_custom_command(ctx, cmd, arg)
+    if custom is not None:
+        return custom
+    return _text(f"(unknown command: /{cmd}) — try /help")
+```
+
+Add the resolver (near `dispatch`):
+
+```python
+def _resolve_custom_command(ctx: SlashContext, cmd: str, arg: str):
+    """If an agent is active and has a command named ``cmd``, expand it into a
+    run_agent action. Returns None when there is no match (caller -> unknown)."""
+    if not getattr(ctx, "active_agent", ""):
+        return None
+    from aether_agent import agent_commands, agent_store
+
+    try:
+        agent = agent_store.load(ctx.active_agent)
+    except (ValueError, OSError):
+        return None
+    cmds = agent_commands.list_commands(agent)
+    if cmd not in cmds:
+        return None
+    task = agent_commands.expand(cmds[cmd], arg.split())
+    return {"run_agent": {"name": ctx.active_agent, "task": task}}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_slash_custom_invoke.py tests/test_slash.py tests/test_slash_agents.py -q`
+Expected: PASS (new green; existing slash tests still green — built-ins still resolve first)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/slash.py tests/test_slash_custom_invoke.py
+git commit -m "feat(cmds): resolve bare /<custom> against the active agent after built-ins"
+```
+
+---
+
+## Task 5: `agent_runner.py` — the local-only `define_command` tool
+
+**Files:**
+- Modify: `aether_agent/agent_runner.py`
+- Test: `tests/test_agent_runner_define_command.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_runner_define_command.py
+import pytest
+
+from aether_agent import agent_runner
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_define_command_schema_only_when_allowed():
+    with_tool = Agent.from_dict({"name": "jane", "tools": ["read_file", "define_command"]})
+    without = Agent.from_dict({"name": "jane", "tools": ["read_file"]})
+    assert "define_command" in agent_runner._offered_tool_names(with_tool)
+    assert "define_command" not in agent_runner._offered_tool_names(without)
+
+
+def test_define_command_writes_and_reloads():
+    from aether_agent import agent_store
+    a = Agent.from_dict({"name": "jane", "tools": ["read_file", "define_command"]})
+    agent_store.create(a)
+    pt = agent_runner._PolicyTools(
+        inner=None, allowed=set(a.tools), permission="skip", confirm=lambda n, x: True, agent_name="jane",
+    )
+    out = pt.execute("define_command", {"name": "review", "template": "Review $1 for bugs"})
+    assert "defined" in out.lower()
+    assert agent_store.load("jane").commands == {"review": "Review $1 for bugs"}
+
+
+def test_define_command_refused_when_not_allowed():
+    pt = agent_runner._PolicyTools(
+        inner=None, allowed={"read_file"}, permission="skip", confirm=lambda n, x: True, agent_name="jane",
+    )
+    out = pt.execute("define_command", {"name": "review", "template": "x"})
+    assert "not allowed" in out.lower()
+
+
+def test_define_command_rejects_reserved_name():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane", "tools": ["define_command"]}))
+    pt = agent_runner._PolicyTools(
+        inner=None, allowed={"define_command"}, permission="skip", confirm=lambda n, x: True, agent_name="jane",
+    )
+    out = pt.execute("define_command", {"name": "help", "template": "x"})
+    assert "refused" in out.lower()
+    assert agent_store.load("jane").commands == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_runner_define_command.py -q`
+Expected: FAIL — `AttributeError: module 'aether_agent.agent_runner' has no attribute '_offered_tool_names'` / `_PolicyTools.__init__() got an unexpected keyword argument 'agent_name'`.
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/agent_runner.py`)
+
+Add a module-level helper:
+
+```python
+def _offered_tool_names(agent) -> list[str]:
+    """The tool names offered to the model for this agent: the canonical tools it
+    allows, plus the local-only define_command when the agent opts in."""
+    from aether_agent.protocol import TOOLS
+    names = [t for t in agent.tools if t in TOOLS]
+    if "define_command" in agent.tools:
+        names.append("define_command")
+    return names
+```
+
+Change `_PolicyTools.__init__` to accept `agent_name`:
+
+```python
+    def __init__(self, inner, allowed: set, permission: str, confirm: ConfirmFn, agent_name: str = "") -> None:
+        self._inner = inner
+        self._allowed = set(allowed)
+        self._permission = permission
+        self._confirm = confirm
+        self._agent_name = agent_name
+        self.test_cmd = getattr(inner, "test_cmd", "")
+```
+
+In `_PolicyTools.execute`, handle `define_command` BEFORE the allowlist/inner delegation:
+
+```python
+    def execute(self, name: str, args: dict) -> str:
+        if name == "define_command":
+            return self._define_command(args)
+        if name not in self._allowed:
+            return f"[tool {name} not allowed for this agent]"
+        if name in DESTRUCTIVE and self._permission != "skip":
+            if not self._confirm(name, args):
+                return f"[denied: {name} (permission={self._permission})]"
+        return self._inner.execute(name, args)
+
+    def _define_command(self, args: dict) -> str:
+        if "define_command" not in self._allowed:
+            return "[tool define_command not allowed for this agent]"
+        from aether_agent import agent_commands, agent_store
+
+        cname = str(args.get("name", ""))
+        template = str(args.get("template", ""))
+        try:
+            updated = agent_commands.add(agent_store.load(self._agent_name), cname, template)
+        except (ValueError, TypeError, OSError) as e:
+            return f"[define_command refused: {e}]"
+        agent_store.save(updated)
+        return f"[defined command /{cname}]"
+```
+
+In `run()`, build the schema from the offered tools (so define_command is advertised when allowed) and
+pass `agent_name`. Replace the `schema = [...]` and `tools = _PolicyTools(...)` lines with:
+
+```python
+    offered = set(_offered_tool_names(agent))
+    schema = [s for s in tool_schema() if s["function"]["name"] in offered]
+    if "define_command" in offered:
+        schema.append({
+            "type": "function",
+            "function": {
+                "name": "define_command",
+                "description": "Save a reusable slash-command (prompt macro) on this agent. "
+                               "args: {name, template}. template may use $1..$9 and $*.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "template": {"type": "string"}},
+                    "required": ["name", "template"],
+                },
+            },
+        })
+    tools = _PolicyTools(Tools(cwd), allowed=set(agent.tools), permission=agent.permission,
+                         confirm=confirm or _deny, agent_name=agent.name)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_runner_define_command.py tests/test_agent_runner.py -q`
+Expected: PASS (new green; existing agent_runner tests still green — they construct `_PolicyTools(inner, allowed, permission, confirm)` positionally and `agent_name` defaults to "")
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_runner.py tests/test_agent_runner_define_command.py
+git commit -m "feat(cmds): local-only define_command tool (opt-in, macro-only, bounded self-modification)"
+```
+
+---
+
+## Task 6: Full-suite + ruff + push
+
+**Files:** full suite
+
+- [ ] **Step 1: Ruff**
+
+Run: `.venv/Scripts/python.exe -m ruff check aether_agent tests`
+Expected: `All checks passed!` — remove any F401 and re-run.
+
+- [ ] **Step 2: Full suite**
+
+Run: `.venv/Scripts/python.exe -m pytest -q`
+Expected: PASS — all prior tests (506+) plus the ~20 new C tests. Zero regressions.
+
+- [ ] **Step 3: Boot smoke (no Ollama)**
+
+Run (bash): `AETHER_CONFIG_DIR="$(mktemp -d)" .venv/Scripts/python.exe -c "
+from aether_agent import Agent
+from aether_agent.slash import SlashContext, dispatch
+Agent.create('jane')
+print(dispatch(SlashContext(api=None), '/agent jane cmd add review = Review \$1 for bugs')['text'])
+print('invoke ->', dispatch(SlashContext(api=None, active_agent='jane'), '/review x.py').get('run_agent'))
+"`
+Expected: `added /review = ...` / `invoke -> {'name': 'jane', 'task': 'Review x.py for bugs'}`.
+
+- [ ] **Step 4: Commit any fixes + push**
+
+```bash
+git add -A && git commit -m "test(cmds): full-suite + ruff green after custom commands (sub-project C)"
+git push -u origin feat/custom-commands
+```
+
+---
+
+## Self-review (author checklist — completed)
+
+- **Spec coverage:** prompt-macro storage + validation (T1) · name-validation + expansion + add/remove/list (T2) · manual `cmd` + `run` verbs (T3) · bare-slash resolution after built-ins (T4) · gated local-only `define_command` (T5) · offline tests per unit. All spec sections map to a task.
+- **Placeholder scan:** no TBD/TODO; complete code each step.
+- **Type consistency:** `agent_commands.{valid_name,expand,add,remove,list_commands}` consistent across T2–T5; `agent_profile.{is_valid_command_name,RESERVED_COMMANDS,ALLOWED_AGENT_TOOLS}` across T1,T2; `_PolicyTools(..., agent_name="")` + `_offered_tool_names` + `_define_command` across T5; the `run_agent` flag shape (`{"name","task"}`) matches B's repl handler. `define_command` is NOT added to `protocol.TOOLS` (bridge stays 8).
+- **Scope:** C only — shell bindings, global commands, typed args, D all out.
+```

--- a/docs/superpowers/plans/2026-06-15-custom-local-agents.md
+++ b/docs/superpowers/plans/2026-06-15-custom-local-agents.md
@@ -1,0 +1,1353 @@
+# Custom Local Agents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user create named, shareable local agents — each with its own model, its own persistent Unlimited-Context memory pool, a persona, a visual identity, and tool/permission guardrails — and run/switch them with a unified `/agent` grammar plus an `Agent` library API.
+
+**Architecture:** Four new stdlib-only modules in `aether_agent/` — `agent_profile.py` (the `Agent` dataclass + validation + the library API), `agent_store.py` (file-per-agent persistence + per-agent pool dirs), `agent_runner.py` (build a per-agent `Session`+policy-wrapped `Tools` and drive `run_agent_events`), `agent_slash.py` (the `/agent` grammar) — wired into `slash.py` and `repl.py`. One tiny additive change to `agent.py` (a `system=` param so a persona can override the default system prompt).
+
+**Tech Stack:** Python 3.10+, stdlib only (`json`, `dataclasses`, `re`, `os`, `pathlib`, `shutil`, `subprocess`), `pytest`. No new runtime deps. Reuses `aether_context.Session`, `aether_agent.{adapter,tools,brains,agent,config,protocol,persona}`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-custom-local-agents-design.md`
+**Branch:** `feat/custom-local-agents` (off `main`, which has sub-project A).
+**Gate:** `.venv/Scripts/python.exe -m pytest -q` AND `.venv/Scripts/python.exe -m ruff check aether_agent tests` (CI gates on ruff — no unused imports / F401).
+
+---
+
+## File Structure
+
+| File | New/Mod | Responsibility |
+|---|---|---|
+| `aether_agent/agent_profile.py` | New | `Agent` frozen dataclass + defaults + `validate` + `from_dict`/`to_dict` + `set` + library classmethods (`create/load/list/delete`) + `run`. `ACCENTS` palette. |
+| `aether_agent/agent_store.py` | New | `agents_dir`/`agent_path`/`agent_pool_dir` + `create/load/save/list_agents/delete/exists` (file-per-agent, fail-soft). |
+| `aether_agent/agent_runner.py` | New | `_PolicyTools` (allowlist + permission) + `run(agent, task, ...)` -> event iterator over `run_agent_events`. |
+| `aether_agent/agent_slash.py` | New | `dispatch_agent(line, *, active)` grammar + handlers (`/new-agent`, `/agents`, `/agent ...`). Config verbs pure; switch/run return action flags. |
+| `aether_agent/agent.py` | Mod | add `system: Optional[str] = None` to `run_agent_events` (persona override; default = `SYSTEM_PROMPT`). |
+| `aether_agent/slash.py` | Mod | register `new-agent`/`agents`/`agent`; add `active_agent` to `SlashContext`; help lines; move old cloud orchestrator list/switch to `/orchestrators`/`/orchestrator`. |
+| `aether_agent/repl.py` | Mod | active-agent state; apply persona/accent/prompt/banner on switch; run turns as the active agent; handle `switch_agent`/`run_agent` flags. |
+| `aether_agent/__init__.py` | Mod | re-export `Agent`. |
+
+Reuse (no duplication): `config.config_dir()` (base of `agents_dir`), `protocol.TOOLS` (the canonical 8), `tools.tool_schema()`/`Tools`, `adapter.OllamaChat`, `agent.run_agent_events`, `Session`.
+
+---
+
+## Task 1: `agent_profile.py` — the Agent dataclass + validation
+
+**Files:**
+- Create: `aether_agent/agent_profile.py`
+- Test: `tests/test_agent_profile.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_profile.py
+from aether_agent import agent_profile
+from aether_agent.agent_profile import Agent
+
+
+def test_from_dict_fills_defaults_and_ignores_effort():
+    a = Agent.from_dict({"name": "jane", "effort": "codepro"})  # effort ignored
+    assert a.name == "jane"
+    assert a.model  # a default model
+    assert a.pool_gb == 5
+    assert a.permission == "ask"
+    assert set(a.tools)  # defaults to the canonical 8
+    assert not hasattr(a, "effort")
+
+
+def test_validate_catches_bad_fields():
+    bad = Agent.from_dict({
+        "name": "Bad Name!", "pool_gb": 0, "permission": "nope",
+        "tools": ["read_file", "made_up_tool"], "max_steps": 9999, "accent": "chartreuse",
+    })
+    problems = agent_profile.validate(bad)
+    joined = " ".join(problems).lower()
+    assert "name" in joined
+    assert "pool_gb" in joined or "pool" in joined
+    assert "permission" in joined
+    assert "tool" in joined
+    assert "max_steps" in joined or "step" in joined
+    assert "accent" in joined
+
+
+def test_valid_agent_has_no_problems():
+    a = Agent.from_dict({"name": "jane"})
+    assert agent_profile.validate(a) == []
+
+
+def test_roundtrip_and_set_returns_new_validated_copy():
+    a = Agent.from_dict({"name": "jane"})
+    d = a.to_dict()
+    assert d["name"] == "jane" and "commands" in d and "effort" not in d
+    b = a.set(pool_gb=10, accent="green")
+    assert b.pool_gb == 10 and b.accent == "green"
+    assert a.pool_gb == 5  # original unchanged (immutable)
+
+
+def test_set_with_invalid_value_raises():
+    a = Agent.from_dict({"name": "jane"})
+    try:
+        a.set(permission="bogus")
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "permission" in str(e).lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_profile.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.agent_profile'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/agent_profile.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""The Agent — a named, shareable local agent profile + the library API.
+
+An Agent is an immutable dataclass persisted as one JSON file per agent (see
+``agent_store``). It carries the agent's model, its own memory-pool size, a
+persona, a visual identity (accent / prompt / banner), and tool + permission
+guardrails. No ``effort`` field — effort tiers are an AetherCloud-only concept.
+
+Library use::
+
+    a = Agent.create("jane", model="qwen2.5-coder:7b", pool_gb=10)
+    for ev in a.run("summarize the repo"): ...
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, replace
+from typing import Any, Iterator
+
+from aether_agent.adapter import DEFAULT_MODEL
+from aether_agent.protocol import TOOLS
+
+#: accent name -> ANSI SGR color code (cp1252-safe; used by validate + the REPL).
+ACCENTS: dict[str, str] = {
+    "cyan": "36", "green": "32", "magenta": "35", "yellow": "33",
+    "blue": "34", "red": "31", "white": "37", "dim": "2",
+}
+_VERBOSITY = ("terse", "normal", "verbose")
+_PERMISSION = ("ask", "auto", "skip")
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_MAX_STEPS_RANGE = (1, 500)
+
+
+@dataclass(frozen=True)
+class Agent:
+    name: str
+    model: str = DEFAULT_MODEL
+    pool_gb: int = 5
+    persona: str = "You are a helpful local coding agent."
+    verbosity: str = "normal"
+    show_tools: bool = True
+    accent: str = "cyan"
+    prompt: str = ""
+    banner: str = ""
+    tools: tuple[str, ...] = tuple(TOOLS)
+    permission: str = "ask"
+    max_steps: int = 40
+    commands: dict[str, Any] = field(default_factory=dict)  # reserved for sub-project C
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Agent":
+        """Build an Agent from a (possibly partial) dict, filling defaults and
+        ignoring unknown keys (e.g. a stray ``effort`` from a future/foreign file)."""
+        d = dict(data or {})
+        tools = d.get("tools")
+        name = str(d.get("name", ""))
+        kw: dict[str, Any] = {
+            "name": name,
+            "model": str(d.get("model", DEFAULT_MODEL)) or DEFAULT_MODEL,
+            "pool_gb": _as_int(d.get("pool_gb"), 5),
+            "persona": str(d.get("persona", "You are a helpful local coding agent.")),
+            "verbosity": str(d.get("verbosity", "normal")),
+            "show_tools": bool(d.get("show_tools", True)),
+            "accent": str(d.get("accent", "cyan")),
+            "prompt": str(d.get("prompt", "") or f"{name} > "),
+            "banner": str(d.get("banner", "")),
+            "tools": tuple(tools) if isinstance(tools, (list, tuple)) else tuple(TOOLS),
+            "permission": str(d.get("permission", "ask")),
+            "max_steps": _as_int(d.get("max_steps"), 40),
+            "commands": dict(d.get("commands") or {}),
+        }
+        return cls(**kw)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name, "model": self.model, "pool_gb": self.pool_gb,
+            "persona": self.persona, "verbosity": self.verbosity, "show_tools": self.show_tools,
+            "accent": self.accent, "prompt": self.prompt, "banner": self.banner,
+            "tools": list(self.tools), "permission": self.permission,
+            "max_steps": self.max_steps, "commands": dict(self.commands),
+        }
+
+    def set(self, **fields: Any) -> "Agent":
+        """Return a NEW validated copy with the given fields changed. ``memory`` is
+        an alias for ``pool_gb`` (matches the `/agent set memory` command)."""
+        if "memory" in fields:
+            fields["pool_gb"] = _as_int(fields.pop("memory"), self.pool_gb)
+        if "tools" in fields and isinstance(fields["tools"], list):
+            fields["tools"] = tuple(fields["tools"])
+        updated = replace(self, **fields)
+        problems = validate(updated)
+        if problems:
+            raise ValueError("; ".join(problems))
+        return updated
+
+    # --- library API (proxies to agent_store / agent_runner; lazy imports) ----
+    @classmethod
+    def create(cls, name: str, **fields: Any) -> "Agent":
+        from aether_agent import agent_store
+        agent = cls.from_dict({"name": name, **fields})
+        problems = validate(agent)
+        if problems:
+            raise ValueError("; ".join(problems))
+        agent_store.create(agent)
+        return agent
+
+    @classmethod
+    def load(cls, name: str) -> "Agent":
+        from aether_agent import agent_store
+        return agent_store.load(name)
+
+    @classmethod
+    def list(cls) -> list[str]:
+        from aether_agent import agent_store
+        return agent_store.list_agents()
+
+    def save(self) -> None:
+        from aether_agent import agent_store
+        agent_store.save(self)
+
+    def delete(self, purge: bool = False) -> None:
+        from aether_agent import agent_store
+        agent_store.delete(self.name, purge=purge)
+
+    def run(self, task: str, **kw: Any) -> Iterator[dict[str, Any]]:
+        from aether_agent import agent_runner
+        yield from agent_runner.run(self, task, **kw)
+
+
+def validate(agent: "Agent") -> list[str]:
+    """Return a list of human-readable problems (empty = valid)."""
+    p: list[str] = []
+    if not _NAME_RE.match(agent.name or ""):
+        p.append(f"name must be a slug [a-z0-9_-] (got {agent.name!r})")
+    if not str(agent.model).strip():
+        p.append("model must be a non-empty string")
+    if not isinstance(agent.pool_gb, int) or agent.pool_gb < 1:
+        p.append(f"pool_gb must be an int >= 1 (got {agent.pool_gb!r})")
+    if agent.verbosity not in _VERBOSITY:
+        p.append(f"verbosity must be one of {_VERBOSITY} (got {agent.verbosity!r})")
+    if agent.permission not in _PERMISSION:
+        p.append(f"permission must be one of {_PERMISSION} (got {agent.permission!r})")
+    if agent.accent not in ACCENTS:
+        p.append(f"accent must be one of {sorted(ACCENTS)} (got {agent.accent!r})")
+    unknown = [t for t in agent.tools if t not in TOOLS]
+    if unknown:
+        p.append(f"tools must be a subset of the 8 canonical tools (unknown: {unknown})")
+    lo, hi = _MAX_STEPS_RANGE
+    if not isinstance(agent.max_steps, int) or not (lo <= agent.max_steps <= hi):
+        p.append(f"max_steps must be an int in [{lo}, {hi}] (got {agent.max_steps!r})")
+    if agent.commands:
+        p.append("commands is reserved for a future release and must be empty")
+    return p
+
+
+def _as_int(v: Any, default: int) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = ["Agent", "validate", "ACCENTS"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_profile.py -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_profile.py tests/test_agent_profile.py
+git commit -m "feat(agents): agent_profile — Agent dataclass + validation + library API surface"
+```
+
+---
+
+## Task 2: `agent_store.py` — file-per-agent persistence
+
+**Files:**
+- Create: `aether_agent/agent_store.py`
+- Test: `tests/test_agent_store.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_store.py
+import pytest
+
+from aether_agent import agent_store
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_create_load_list_exists():
+    a = Agent.from_dict({"name": "jane", "pool_gb": 7})
+    agent_store.create(a)
+    assert agent_store.exists("jane")
+    assert agent_store.list_agents() == ["jane"]
+    loaded = agent_store.load("jane")
+    assert loaded.name == "jane" and loaded.pool_gb == 7
+
+
+def test_create_duplicate_raises():
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    with pytest.raises(Exception):
+        agent_store.create(Agent.from_dict({"name": "jane"}))
+
+
+def test_load_missing_raises():
+    with pytest.raises(Exception):
+        agent_store.load("nope")
+
+
+def test_pool_dir_path_layout():
+    p = agent_store.agent_pool_dir("jane")
+    assert p.name == "pool" and p.parent.name == "jane"
+    assert "agents" in str(p)
+
+
+def test_delete_keeps_pool_unless_purge():
+    a = Agent.from_dict({"name": "jane"})
+    agent_store.create(a)
+    pool = agent_store.agent_pool_dir("jane")
+    pool.mkdir(parents=True, exist_ok=True)
+    agent_store.delete("jane", purge=False)
+    assert not agent_store.exists("jane")
+    assert pool.exists()  # pool kept
+    agent_store.create(a)
+    agent_store.delete("jane", purge=True)
+    assert not pool.exists()
+
+
+def test_corrupt_file_fails_soft():
+    agent_store.agent_path("broken").write_text("{ not json", encoding="utf-8")
+    with pytest.raises(Exception):
+        agent_store.load("broken")
+    assert "broken" in agent_store.list_agents()  # listing must not crash
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_store.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.agent_store'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/agent_store.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""File-per-agent persistence.
+
+Definitions live at ``<config>/agents/<name>.json``; each agent's memory pool is
+separate local state at ``<config>/agents/<name>/pool/``. Sharing an agent =
+copying its one ``<name>.json``. Honors ``AETHER_CONFIG_DIR`` (via ``config``).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from aether_agent.agent_profile import Agent
+from aether_agent.config import config_dir
+
+
+def agents_dir() -> Path:
+    return Path(config_dir()) / "agents"
+
+
+def agent_path(name: str) -> Path:
+    d = agents_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return d / f"{name}.json"
+
+
+def agent_pool_dir(name: str) -> Path:
+    return agents_dir() / name / "pool"
+
+
+def exists(name: str) -> bool:
+    return agent_path(name).is_file()
+
+
+def list_agents() -> list[str]:
+    d = agents_dir()
+    if not d.is_dir():
+        return []
+    return sorted(p.stem for p in d.glob("*.json"))
+
+
+def create(agent: Agent) -> None:
+    if exists(agent.name):
+        raise FileExistsError(f"agent already exists: {agent.name}")
+    save(agent)
+
+
+def save(agent: Agent) -> None:
+    agent_path(agent.name).write_text(
+        json.dumps(agent.to_dict(), indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def load(name: str) -> Agent:
+    path = agent_path(name)
+    if not path.is_file():
+        raise FileNotFoundError(f"no such agent: {name}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        raise ValueError(f"agent file is corrupt: {name} ({e})") from e
+    return Agent.from_dict(data)
+
+
+def delete(name: str, *, purge: bool = False) -> None:
+    path = agent_path(name)
+    if path.is_file():
+        path.unlink()
+    if purge:
+        pool_parent = agents_dir() / name
+        if pool_parent.is_dir():
+            shutil.rmtree(pool_parent, ignore_errors=True)
+
+
+__all__ = [
+    "agents_dir", "agent_path", "agent_pool_dir",
+    "exists", "list_agents", "create", "save", "load", "delete",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_store.py -q`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_store.py tests/test_agent_store.py
+git commit -m "feat(agents): agent_store — file-per-agent CRUD + per-agent pool dirs"
+```
+
+---
+
+## Task 3: `run_agent_events` persona override (`agent.py`)
+
+**Files:**
+- Modify: `aether_agent/agent.py` (add a `system` param)
+- Test: `tests/test_run_agent_events_system.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_run_agent_events_system.py
+from aether_agent import agent as agent_mod
+from aether_agent.tools import Tools
+
+
+class _FakeLLM:
+    def __init__(self):
+        self.seen_system = None
+
+    def chat(self, messages, tools=None):
+        self.seen_system = messages[0]["content"]
+        return {"role": "assistant", "content": "ok", "tool_calls": []}
+
+
+def test_system_param_overrides_default_persona(tmp_path):
+    llm = _FakeLLM()
+    tools = Tools(str(tmp_path), test_cmd="")  # empty test_cmd -> verify gate is a no-op
+    events = list(agent_mod.run_agent_events(
+        "hi", llm=llm, tools=tools, system="You are Jane.", verify_finish=False,
+    ))
+    assert llm.seen_system == "You are Jane."
+    assert any(e["type"] == "done" for e in events)
+
+
+def test_system_defaults_to_builtin_when_omitted(tmp_path):
+    from aether_agent.persona import SYSTEM_PROMPT
+    llm = _FakeLLM()
+    tools = Tools(str(tmp_path), test_cmd="")
+    list(agent_mod.run_agent_events("hi", llm=llm, tools=tools, verify_finish=False))
+    assert llm.seen_system == SYSTEM_PROMPT
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_run_agent_events_system.py -q`
+Expected: FAIL — `TypeError: run_agent_events() got an unexpected keyword argument 'system'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/agent.py`)
+
+Add the param to the `run_agent_events` signature (after the `on_status` line):
+
+```python
+    on_status: Optional[Callable[[str], None]] = None,
+    system: Optional[str] = None,
+) -> Iterator[dict[str, Any]]:
+```
+
+Change the messages init (currently `messages: list[dict] = [{"role": "system", "content": SYSTEM_PROMPT}, ...]`) to:
+
+```python
+    sys_prompt = system if system is not None else SYSTEM_PROMPT
+    messages: list[dict] = [
+        {"role": "system", "content": sys_prompt},
+        {"role": "user", "content": task},
+    ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_run_agent_events_system.py tests/test_brains.py -q`
+Expected: PASS (new green; existing brains tests unaffected)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent.py tests/test_run_agent_events_system.py
+git commit -m "feat(agents): run_agent_events accepts a system= persona override (default unchanged)"
+```
+
+---
+
+## Task 4: `agent_runner.py` — per-agent Session + policy tools
+
+**Files:**
+- Create: `aether_agent/agent_runner.py`
+- Test: `tests/test_agent_runner.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_runner.py
+from aether_agent import agent_runner
+from aether_agent.agent_profile import Agent
+from aether_agent.tools import Tools
+
+
+def test_policy_tools_blocks_disallowed_and_allows_allowed(tmp_path):
+    inner = Tools(str(tmp_path))
+    pt = agent_runner._PolicyTools(inner, allowed={"read_file"}, permission="skip", confirm=lambda n, a: True)
+    assert "not allowed" in pt.execute("write_file", {"path": "x", "content": "y"}).lower()
+    out = pt.execute("read_file", {"path": "missing"})
+    assert "no such file" in out.lower()  # delegated to inner
+
+
+def test_policy_tools_ask_denies_destructive_without_confirm(tmp_path):
+    inner = Tools(str(tmp_path))
+    pt = agent_runner._PolicyTools(inner, allowed={"write_file"}, permission="ask", confirm=lambda n, a: False)
+    assert "denied" in pt.execute("write_file", {"path": "x", "content": "y"}).lower()
+    pt2 = agent_runner._PolicyTools(inner, allowed={"write_file"}, permission="ask", confirm=lambda n, a: True)
+    assert "wrote" in pt2.execute("write_file", {"path": "x.txt", "content": "y"}).lower()
+
+
+def test_run_builds_session_with_agent_pool_and_streams(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    captured = {}
+
+    class _FakeSession:
+        def remember(self, *a, **k): pass
+        def status_dict(self): return {}
+        def close(self): captured["closed"] = True
+
+    def fake_session_factory(agent):
+        captured["pool_gb"] = agent.pool_gb
+        captured["model"] = agent.model
+        return _FakeSession()
+
+    class _FakeLLM:
+        def chat(self, messages, tools=None):
+            captured["system"] = messages[0]["content"]
+            captured["schema_names"] = [t["function"]["name"] for t in (tools or [])]
+            return {"role": "assistant", "content": "done", "tool_calls": []}
+
+    a = Agent.from_dict({"name": "jane", "pool_gb": 9, "persona": "You are Jane.",
+                         "tools": ["read_file", "web_search"], "permission": "skip"})
+    events = list(agent_runner.run(
+        a, "hello", cwd=str(tmp_path), llm=_FakeLLM(), session_factory=fake_session_factory,
+    ))
+    assert captured["pool_gb"] == 9 and captured["model"] == a.model
+    assert captured["system"] == "You are Jane."
+    assert set(captured["schema_names"]) == {"read_file", "web_search"}
+    assert any(e["type"] == "done" for e in events)
+    assert captured.get("closed") is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_runner.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.agent_runner'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/agent_runner.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Run a task AS a custom agent.
+
+Builds the agent's own ``Session`` (its persistent memory pool), an Ollama chat
+on the agent's model, a persona system prompt, and a policy-wrapped ``Tools``
+that enforces the agent's tool allowlist + permission mode — then drives
+``agent.run_agent_events`` and yields its render-ready events. Session creation
+is injectable (``session_factory``) so tests never touch numpy/disk.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Iterator, Optional
+
+from aether_agent.adapter import OllamaChat
+from aether_agent.agent import run_agent_events
+from aether_agent.agent_profile import Agent
+from aether_agent.tools import Tools, tool_schema
+
+#: tools that change the workspace / run code — gated by permission mode.
+DESTRUCTIVE = {"write_file", "run_shell", "git_commit"}
+ConfirmFn = Callable[[str, dict], bool]
+
+
+def _deny(_name: str, _args: dict) -> bool:
+    return False
+
+
+class _PolicyTools:
+    """Wrap a real ``Tools`` with an allowlist + a permission gate. Same
+    ``execute(name, args) -> str`` contract; refusals are returned as strings
+    (never raised) so the agent loop reads them like any tool output."""
+
+    def __init__(self, inner: Tools, allowed: set, permission: str, confirm: ConfirmFn) -> None:
+        self._inner = inner
+        self._allowed = set(allowed)
+        self._permission = permission
+        self._confirm = confirm
+        self.test_cmd = getattr(inner, "test_cmd", "")  # the verify gate reads this attr
+
+    def execute(self, name: str, args: dict) -> str:
+        if name not in self._allowed:
+            return f"[tool {name} not allowed for this agent]"
+        if name in DESTRUCTIVE and self._permission != "skip":
+            if not self._confirm(name, args):
+                return f"[denied: {name} (permission={self._permission})]"
+        return self._inner.execute(name, args)
+
+    def run_tests(self, command: Optional[str] = None) -> str:
+        return self._inner.run_tests(command)
+
+
+def _default_session_factory(agent: Agent):
+    from aether_agent import agent_store
+    from aether_context import Session
+
+    return Session(
+        model=f"ollama/{agent.model}",
+        pool_gb=agent.pool_gb,
+        pool_dir=str(agent_store.agent_pool_dir(agent.name)),
+        pool_mode="separate",
+        pull=False,
+        fallback_to_mock=True,
+    )
+
+
+def run(
+    agent: Agent,
+    task: str,
+    *,
+    cwd: str = ".",
+    confirm: Optional[ConfirmFn] = None,
+    llm: Any = None,
+    session_factory: Optional[Callable[[Agent], Any]] = None,
+    on_status: Optional[Callable[[str], None]] = None,
+) -> Iterator[dict[str, Any]]:
+    """Drive one task as ``agent``; yield render-ready events. ``llm`` and
+    ``session_factory`` are injectable for tests (no real Ollama / Session)."""
+    chat = llm if llm is not None else OllamaChat(model=agent.model)
+    sess = (session_factory or _default_session_factory)(agent)
+    allowed = set(agent.tools)
+    schema = [s for s in tool_schema() if s["function"]["name"] in allowed]
+    tools = _PolicyTools(Tools(cwd), allowed, agent.permission, confirm or _deny)
+    try:
+        yield from run_agent_events(
+            task,
+            llm=chat,
+            tools=tools,
+            cwd=cwd,
+            pool_gb=agent.pool_gb,
+            max_steps=agent.max_steps,
+            sess=sess,
+            schema=schema,
+            system=agent.persona,
+            git_checkpoint=False,
+            verify_finish=False,
+            on_status=on_status,
+        )
+    finally:
+        try:
+            sess.close()
+        except Exception:  # noqa: BLE001 — teardown best-effort
+            pass
+
+
+__all__ = ["run", "DESTRUCTIVE", "ConfirmFn"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_runner.py -q`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_runner.py tests/test_agent_runner.py
+git commit -m "feat(agents): agent_runner — per-agent Session + allowlist/permission policy tools"
+```
+
+---
+
+## Task 5: `agent_slash.py` — the `/agent` grammar
+
+**Files:**
+- Create: `aether_agent/agent_slash.py`
+- Test: `tests/test_agent_slash.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_slash.py
+import pytest
+
+from aether_agent import agent_slash
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def _mk(name="jane"):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": name}))
+
+
+def test_new_agent_creates():
+    res = agent_slash.dispatch_agent("/new-agent jane", active="")
+    assert "jane" in res["text"]
+    from aether_agent import agent_store
+    assert agent_store.exists("jane")
+
+
+def test_new_agent_duplicate_reports():
+    _mk()
+    res = agent_slash.dispatch_agent("/new-agent jane", active="")
+    assert "exist" in res["text"].lower()
+
+
+def test_agents_lists_with_active_marker():
+    _mk("jane"); _mk("neo")
+    res = agent_slash.dispatch_agent("/agents", active="neo")
+    assert "jane" in res["text"] and "neo" in res["text"]
+
+
+def test_agent_switch_returns_flag():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane", active="")
+    assert res.get("switch_agent") == "jane"
+
+
+def test_agent_run_returns_flag():
+    _mk()
+    res = agent_slash.dispatch_agent('/agent jane fix the bug', active="")
+    assert res.get("run_agent") == {"name": "jane", "task": "fix the bug"}
+
+
+def test_agent_set_persists():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane set memory 10", active="")
+    assert "10" in res["text"]
+    assert Agent.load("jane").pool_gb == 10
+
+
+def test_agent_set_invalid_reports_not_crash():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane set permission bogus", active="")
+    assert "permission" in res["text"].lower()
+    assert Agent.load("jane").permission == "ask"  # unchanged
+
+
+def test_unknown_agent_is_friendly():
+    res = agent_slash.dispatch_agent("/agent ghost", active="")
+    assert "no" in res["text"].lower() or "unknown" in res["text"].lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_slash.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.agent_slash'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/agent_slash.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""The `/agent` command grammar (sub-project B).
+
+Pure handlers: configuration verbs mutate the store and return a ``text`` result;
+switching/running return action flags (``switch_agent`` / ``run_agent``) the REPL
+acts on (mirrors the existing ``setup``/``restart`` flags in slash.py). No TTY,
+no Ollama — fully unit-testable.
+
+    /new-agent <name>
+    /agents
+    /agent <name>                 -> {"switch_agent": name}
+    /agent <name> <task...>       -> {"run_agent": {"name", "task"}}
+    /agent <name> set <key> <val>
+    /agent <name> show | edit | delete [--purge]
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any
+
+from aether_agent import agent_store
+from aether_agent.agent_profile import Agent
+
+SlashResult = dict[str, Any]
+_VERBS = {"set", "show", "edit", "delete"}
+_SET_ALIASES = {"memory": "pool_gb"}
+
+
+def _text(s: str) -> SlashResult:
+    return {"text": s}
+
+
+def dispatch_agent(line: str, *, active: str) -> SlashResult:
+    """Route a `/new-agent`, `/agents`, or `/agent ...` line. Never raises."""
+    body = (line or "").strip()
+    if body.startswith("/"):
+        body = body[1:]
+    parts = body.split()
+    if not parts:
+        return _text("usage: /agent <name> [task | set <k> <v> | show | edit | delete]")
+    head = parts[0].lower()
+    if head == "new-agent":
+        return _new_agent(parts[1:])
+    if head == "agents":
+        return _agents(active)
+    if head == "agent":
+        return _agent(parts[1:], active)
+    return _text(f"(unknown command: /{head})")
+
+
+def _new_agent(args: list) -> SlashResult:
+    if not args:
+        return _text("usage: /new-agent <name>")
+    name = args[0]
+    if agent_store.exists(name):
+        return _text(f"agent already exists: {name}")
+    try:
+        Agent.create(name)
+    except (ValueError, OSError) as e:
+        return _text(f"could not create {name}: {e}")
+    return _text(f"created agent '{name}' (customize: /agent {name} set <key> <val>)")
+
+
+def _agents(active: str) -> SlashResult:
+    names = agent_store.list_agents()
+    if not names:
+        return _text("(no agents yet — create one with /new-agent <name>)")
+    lines = ["agents (* active):"]
+    for n in names:
+        try:
+            a = agent_store.load(n)
+            mark = "*" if n == active else " "
+            lines.append(f"{mark} {n}\t{a.model}\t{a.pool_gb}GB")
+        except (ValueError, OSError):
+            lines.append(f"  {n}\t(corrupt file)")
+    lines.append("switch: /agent <name>   run: /agent <name> <task>")
+    return _text("\n".join(lines))
+
+
+def _agent(args: list, active: str) -> SlashResult:
+    if not args:
+        return _text("usage: /agent <name> [task | set <k> <v> | show | edit | delete]")
+    name = args[0]
+    rest = args[1:]
+    if not agent_store.exists(name):
+        return _text(f"no such agent: {name} (see /agents, or /new-agent {name})")
+    if not rest:
+        return {"switch_agent": name, "text": f"switched to {name}"}
+    verb = rest[0].lower()
+    if verb == "set":
+        return _set(name, rest[1:])
+    if verb == "show":
+        return _show(name)
+    if verb == "edit":
+        return _edit(name)
+    if verb == "delete":
+        return _delete(name, rest[1:])
+    return {"run_agent": {"name": name, "task": " ".join(rest)}, "text": ""}
+
+
+def _set(name: str, kv: list) -> SlashResult:
+    if len(kv) < 2:
+        return _text("usage: /agent <name> set <key> <value>")
+    key = _SET_ALIASES.get(kv[0].lower(), kv[0].lower())
+    value = _coerce(key, " ".join(kv[1:]))
+    try:
+        updated = agent_store.load(name).set(**{key: value})
+    except (ValueError, TypeError) as e:
+        return _text(f"invalid {key}: {e}")
+    agent_store.save(updated)
+    return _text(f"{name}.{key} = {getattr(updated, key, value)}")
+
+
+def _coerce(key: str, raw: str) -> Any:
+    if key in ("pool_gb", "max_steps"):
+        try:
+            return int(raw)
+        except ValueError:
+            return raw
+    if key == "show_tools":
+        return raw.strip().lower() in ("true", "1", "yes", "on")
+    if key == "tools":
+        return [t.strip() for t in raw.replace(",", " ").split() if t.strip()]
+    return raw
+
+
+def _show(name: str) -> SlashResult:
+    a = agent_store.load(name)
+    return _text("\n".join(f"{k} = {v}" for k, v in a.to_dict().items() if k != "commands"))
+
+
+def _edit(name: str) -> SlashResult:
+    path = agent_store.agent_path(name)
+    editor = os.environ.get("EDITOR") or os.environ.get("VISUAL")
+    if not editor:
+        return _text(f"set $EDITOR to edit, or edit the file directly: {path}")
+    try:
+        subprocess.run([editor, str(path)], check=False, timeout=600)
+    except Exception as e:  # noqa: BLE001 — editor failures must not crash the REPL
+        return _text(f"could not open editor ({e}); file: {path}")
+    return _text(f"edited {path}")
+
+
+def _delete(name: str, flags: list) -> SlashResult:
+    purge = "--purge" in flags
+    agent_store.delete(name, purge=purge)
+    return _text(f"deleted {name}{' (+pool)' if purge else ''}")
+
+
+__all__ = ["dispatch_agent", "SlashResult"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_slash.py -q`
+Expected: PASS (8 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_slash.py tests/test_agent_slash.py
+git commit -m "feat(agents): agent_slash — /new-agent, /agents, /agent <name> <verb> grammar"
+```
+
+---
+
+## Task 6: wire `/agent*` into `slash.py`
+
+**Files:**
+- Modify: `aether_agent/slash.py`
+- Test: `tests/test_slash_agents.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_slash_agents.py
+import pytest
+
+from aether_agent.slash import SlashContext, dispatch
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_slash_routes_agent_commands():
+    res = dispatch(SlashContext(api=None), "/new-agent jane")
+    assert "jane" in res["text"]
+    res2 = dispatch(SlashContext(api=None, active_agent=""), "/agent jane")
+    assert res2.get("switch_agent") == "jane"
+    res3 = dispatch(SlashContext(api=None), "/agents")
+    assert "jane" in res3["text"]
+
+
+def test_help_lists_agent_commands():
+    res = dispatch(SlashContext(api=None), "/help")
+    assert "/agent" in res["text"] and "/new-agent" in res["text"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_slash_agents.py -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'active_agent'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/slash.py`)
+
+(a) Add `active_agent` to `SlashContext` (after the `ollama: Any = None` line):
+
+```python
+    active_agent: str = ""  # name of the active custom agent (B); "" = none
+```
+
+(b) Rename the existing cloud-orchestrator handlers so `/agents` + `/agent` can mean custom agents:
+- rename the existing `def _agents(...)` → `def _agents_orch(...)` (keep its body verbatim).
+- rename the existing `def _agent(...)` → `def _agent_orch(...)` (keep its body verbatim).
+
+(c) Add the three new handlers (after `_web`):
+
+```python
+def _new_agent(ctx: SlashContext, arg: str) -> SlashResult:
+    from aether_agent.agent_slash import dispatch_agent
+    return dispatch_agent(f"/new-agent {arg}".strip(), active=ctx.active_agent)
+
+
+def _agents(ctx: SlashContext, arg: str) -> SlashResult:
+    from aether_agent.agent_slash import dispatch_agent
+    return dispatch_agent("/agents", active=ctx.active_agent)
+
+
+def _agent_cmd(ctx: SlashContext, arg: str) -> SlashResult:
+    from aether_agent.agent_slash import dispatch_agent
+    return dispatch_agent(f"/agent {arg}".strip(), active=ctx.active_agent)
+```
+
+(d) Update `REGISTRY` — replace the old `"agents": _agents,` and `"agent": _agent,` entries with:
+
+```python
+    "agents": _agents,             # B: list custom local agents
+    "agent": _agent_cmd,           # B: /agent <name> <verb>
+    "new-agent": _new_agent,       # B: create
+    "orchestrators": _agents_orch, # cloud orchestrators (was /agents)
+    "orchestrator": _agent_orch,   # cloud orchestrator switch (was /agent)
+```
+
+(e) Update `_HELP_LINES` — replace the two orchestrator lines (`/agents`, `/agent <id>`) with:
+
+```python
+    "/agents            list your custom agents",
+    "/agent <name>      switch agent (or: /agent <name> <task>)",
+    "/new-agent <name>  create a custom agent",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_slash_agents.py tests/test_slash.py tests/test_slash_ollama.py -q`
+Expected: PASS — if `tests/test_slash.py` asserted the old `/agents`/`/agent` orchestrator text, update those two assertions to use `/orchestrators` / `/orchestrator`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/slash.py tests/test_slash_agents.py tests/test_slash.py
+git commit -m "feat(agents): register /new-agent /agents /agent; move cloud orchestrators to /orchestrators"
+```
+
+---
+
+## Task 7: `repl.py` — active agent + run-as-agent + UX
+
+**Files:**
+- Modify: `aether_agent/repl.py`
+- Test: `tests/test_repl_agents.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_repl_agents.py
+import io
+
+import pytest
+
+from aether_agent import repl
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_apply_agent_sets_prompt_accent_persona():
+    a = Agent.from_dict({"name": "jane", "accent": "green", "prompt": "jane > ", "banner": "~J~"})
+    state = repl._apply_agent(a)
+    assert state["prompt"] == "jane > "
+    assert "32" in state["accent_ansi"]  # green = 32
+    assert state["banner"] == "~J~"
+
+
+def test_run_agent_flag_streams_via_runner(monkeypatch):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    seen = {}
+
+    def fake_run(agent, task, **kw):
+        seen["name"] = agent.name
+        seen["task"] = task
+        yield {"type": "done", "text": "ran"}
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    out = io.StringIO()
+    repl._handle_agent_action({"run_agent": {"name": "jane", "task": "do x"}}, out)
+    assert seen == {"name": "jane", "task": "do x"}
+    assert "ran" in out.getvalue()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_repl_agents.py -q`
+Expected: FAIL — `AttributeError: module 'aether_agent.repl' has no attribute '_apply_agent'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/repl.py`)
+
+(a) Add import:
+
+```python
+from aether_agent.agent_profile import ACCENTS, Agent
+```
+
+(b) Add helpers (module level, near `_make_ctx`):
+
+```python
+def _apply_agent(agent: Agent) -> dict[str, Any]:
+    """Compute the REPL UX state for an active agent (pure; cp1252-safe ANSI)."""
+    return {
+        "name": agent.name,
+        "prompt": agent.prompt or f"{agent.name} > ",
+        "accent_ansi": f"\x1b[{ACCENTS.get(agent.accent, '36')}m",
+        "banner": agent.banner,
+        "persona": agent.persona,
+    }
+
+
+def _handle_agent_action(res: dict[str, Any], out: Any) -> None:
+    """Execute a /agent run action: stream the agent's turn via the runner."""
+    from aether_agent import agent_runner, agent_store
+
+    run = res.get("run_agent")
+    if not run:
+        return
+    try:
+        agent = agent_store.load(run["name"])
+    except (ValueError, OSError) as e:
+        _safe_write(out, f"\n[x] {e}\n")
+        return
+    for ev in agent_runner.run(agent, run["task"], confirm=lambda n, a: False):
+        _render_event(ev, out)
+```
+
+(c) In `main()`, add active-agent state right after `ctx = _make_ctx(...)`:
+
+```python
+    active_agent: Optional[Agent] = None
+    prompt_str = _PROMPT
+```
+
+(d) Change the prompt read in the loop from `input(_PROMPT)` to `input(prompt_str)`.
+
+(e) In the slash-result handling (inside `if line.startswith("/"):`), AFTER the `text` write and BEFORE
+`if res.get("setup")`, insert:
+
+```python
+                if res.get("switch_agent"):
+                    try:
+                        active_agent = Agent.load(res["switch_agent"])
+                        ctx.active_agent = active_agent.name
+                        st = _apply_agent(active_agent)
+                        prompt_str = st["prompt"]
+                        if st["banner"]:
+                            _safe_write(out, st["accent_ansi"] + st["banner"] + "\x1b[0m\n")
+                    except (ValueError, OSError) as e:
+                        _safe_write(out, f"\n[x] {e}\n")
+                if res.get("run_agent"):
+                    _handle_agent_action(res, out)
+```
+
+(f) In the normal-turn branch (the non-slash path), run AS the active agent when one is set. Replace the
+existing brain build+run lines with:
+
+```python
+            if active_agent is not None:
+                from aether_agent import agent_runner
+                for ev in agent_runner.run(active_agent, line, confirm=lambda n, a: False):
+                    _render_event(ev, out)
+                out.write("\n")
+                continue
+            brain = select_brain(
+                authed=store.get() is not None,
+                backend=backend,
+                api=api,
+                model=ctx.model or chosen_model or "",
+            )
+            _run_turn(brain, line, out)
+            out.write("\n")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_repl_agents.py tests/test_repl_preflight.py -q`
+Expected: PASS (new green; existing repl tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/repl.py tests/test_repl_agents.py
+git commit -m "feat(agents): REPL active-agent state — switch applies UX, turns run as the agent"
+```
+
+---
+
+## Task 8: `Agent` library re-export + end-to-end library test
+
+**Files:**
+- Modify: `aether_agent/__init__.py`
+- Test: `tests/test_agent_library.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_library.py
+import pytest
+
+from aether_agent import Agent  # the public library API
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_create_load_list_set_save_delete_roundtrip():
+    a = Agent.create("jane", model="qwen2.5-coder:7b", pool_gb=8)
+    assert a.pool_gb == 8
+    assert Agent.list() == ["jane"]
+    b = Agent.load("jane").set(pool_gb=12)
+    b.save()
+    assert Agent.load("jane").pool_gb == 12
+    b.delete()
+    assert Agent.list() == []
+
+
+def test_run_streams_via_runner(monkeypatch):
+    Agent.create("jane")
+
+    def fake_run(agent, task, **kw):
+        yield {"type": "done", "text": f"{agent.name}:{task}"}
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    out = list(Agent.load("jane").run("hi"))
+    assert out[-1]["text"] == "jane:hi"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_library.py -q`
+Expected: FAIL — `ImportError: cannot import name 'Agent' from 'aether_agent'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/__init__.py`)
+
+Append (do not remove existing content):
+
+```python
+from aether_agent.agent_profile import Agent  # noqa: E402  (public library API)
+```
+
+If `__init__.py` defines `__all__`, append `"Agent"` to it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_library.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/__init__.py tests/test_agent_library.py
+git commit -m "feat(agents): export Agent as the public library API (from aether_agent import Agent)"
+```
+
+---
+
+## Task 9: Full-suite green + ruff + push
+
+**Files:** full suite
+
+- [ ] **Step 1: Run ruff (CI gates on it)**
+
+Run: `.venv/Scripts/python.exe -m ruff check aether_agent tests`
+Expected: `All checks passed!` — remove any F401/unused import and re-run.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `.venv/Scripts/python.exe -m pytest -q`
+Expected: PASS — all prior tests (476+) plus the ~32 new B tests. Zero regressions. If `test_slash.py`
+asserted the old `/agents`/`/agent` orchestrator output, update it to `/orchestrators`/`/orchestrator`.
+
+- [ ] **Step 3: Boot smoke (no Ollama needed)**
+
+Run (bash): `AETHER_CONFIG_DIR="$(mktemp -d)" .venv/Scripts/python.exe -c "from aether_agent import Agent; a=Agent.create('jane', pool_gb=7); print('created', a.name, a.pool_gb); print('list', Agent.list())"`
+Expected: `created jane 7` / `list ['jane']` — no crash.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "test(agents): full-suite + ruff green after custom local agents (sub-project B)"
+```
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin feat/custom-local-agents
+```
+
+---
+
+## Self-review (author checklist — completed)
+
+- **Spec coverage:** Agent dataclass + validation + no-effort (T1) · file-per-agent + per-agent pool (T2) · persona override seam (T3) · per-agent Session + allowlist + permission (T4) · `/agent` grammar incl. switch/run/set/show/edit/delete + `/new-agent` + `/agents` (T5,T6) · customizable UX applied on switch + run-as-agent (T7) · library API `from aether_agent import Agent` (T1 methods + T8 export) · offline tests per unit (every task). All spec sections map to a task.
+- **Placeholder scan:** no TBD/TODO; every code step is complete. The `commands` field is reserved-and-validated-empty (C), not a placeholder.
+- **Type consistency:** `Agent` fields + `from_dict`/`to_dict`/`set`/`validate` consistent across T1–T8; `agent_store` names (`create/load/save/list_agents/delete/exists/agents_dir/agent_path/agent_pool_dir`) identical across T2,T4,T5,T7,T8; `agent_runner.run(agent, task, *, cwd, confirm, llm, session_factory, on_status)` + `_PolicyTools` consistent across T4,T7,T8; `dispatch_agent(line, *, active)` + `switch_agent`/`run_agent` flag shapes consistent across T5,T6,T7; `run_agent_events(..., system=)` consistent across T3,T4. `ACCENTS` shared by T1 (validate) + T7 (repl).
+- **Scope:** B only — C (`commands` authoring), D (multi-agent columns), full theme, effort tiers all explicitly out.
+```

--- a/docs/superpowers/plans/2026-06-15-multi-agent.md
+++ b/docs/superpowers/plans/2026-06-15-multi-agent.md
@@ -1,0 +1,679 @@
+# Multi-Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `/agents` column dashboard + the ability to run several agents at once (`/agent jane t \ /agent neo t`) concurrently, with live per-agent labeled output and a write-serialized shared workspace.
+
+**Architecture:** Two new stdlib modules — `aether_agent/agents_view.py` (pure column renderer) and `aether_agent/multi_runner.py` (thread-per-agent orchestrator over a `queue.Queue`) — plus a `write_lock` param on `agent_runner.run`/`_PolicyTools`, a columns upgrade to `/agents`, and ` \ `-multi-run parsing + labeled rendering in `repl.py`.
+
+**Tech Stack:** Python 3.10+, stdlib only (`threading`, `queue`, `dataclasses`), `pytest`. No new deps. Reuses B (`agent_profile`, `agent_store`, `agent_runner`, `agent_slash`, `repl`, `ACCENTS`).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-multi-agent-design.md`
+**Branch:** `feat/multi-agent` (off `main`; build AFTER C if you want command counts in the dashboard, but D does not depend on C — the `write_lock` edit is orthogonal to C's `define_command` edit on `_PolicyTools`).
+**Gate:** `.venv/Scripts/python.exe -m pytest -q` AND `.venv/Scripts/python.exe -m ruff check aether_agent tests`.
+
+---
+
+## File Structure
+
+| File | New/Mod | Responsibility |
+|---|---|---|
+| `aether_agent/agents_view.py` | New | pure `render_agents_columns(rows, active, width)`. |
+| `aether_agent/agent_runner.py` | Mod | `run(..., write_lock=None)`; `_PolicyTools` serializes DESTRUCTIVE tools through the lock when set. |
+| `aether_agent/multi_runner.py` | New | `run_many(jobs, *, emit, confirm, cwd)` — threads + queue + summaries; caps at 8. |
+| `aether_agent/agent_slash.py` | Mod | `/agents` -> the column view. |
+| `aether_agent/repl.py` | Mod | parse ` \ ` multi-runs -> `run_many` + labeled rendering. |
+
+---
+
+## Task 1: `agents_view.py` — column dashboard renderer (pure)
+
+**Files:**
+- Create: `aether_agent/agents_view.py`
+- Test: `tests/test_agents_view.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agents_view.py
+from aether_agent import agents_view
+
+
+def _rows(*names):
+    return [{"name": n, "model": "qwen2.5-coder:7b", "pool_gb": 5, "n_commands": 2} for n in names]
+
+
+def test_empty():
+    assert "no agents" in agents_view.render_agents_columns([]).lower()
+
+
+def test_single_card_has_fields_and_active_marker():
+    out = agents_view.render_agents_columns(_rows("jane"), active="jane")
+    assert "jane" in out and "qwen2.5-coder:7b" in out
+    assert "5 GB" in out and "2 cmds" in out
+    assert "*" in out  # active marker
+
+
+def test_multiple_cards_wrap_to_width():
+    out = agents_view.render_agents_columns(_rows("a", "b", "c", "d"), width=50)
+    lines = out.splitlines()
+    assert any("a" in line and "b" in line for line in lines)  # a,b side by side
+    assert any("c" in line and "d" in line for line in lines)  # c,d on the next block
+
+
+def test_cp1252_safe():
+    agents_view.render_agents_columns(_rows("jane", "neo"), active="neo").encode("cp1252")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agents_view.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.agents_view'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/agents_view.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""The `/agents` column dashboard — a pure, cp1252-safe renderer.
+
+`render_agents_columns(rows, active, width)` lays out agent cards side by side,
+N-per-row to the terminal width. No ANSI/color here (keeps width math correct and
+the output testable); the active agent is marked with `*`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+_CARD_W = 22
+
+
+def render_agents_columns(rows: list[dict], active: str = "", width: int = 80) -> str:
+    if not rows:
+        return "(no agents yet - create one with /new-agent <name>)"
+    cards = [_card(r, active) for r in rows]
+    per_row = max(1, width // (_CARD_W + 2))
+    lines: list[str] = []
+    for i in range(0, len(cards), per_row):
+        group = cards[i:i + per_row]
+        height = max(len(c) for c in group)
+        for c in group:
+            c.extend([""] * (height - len(c)))
+        for row_line in range(height):
+            lines.append("  ".join(c[row_line].ljust(_CARD_W) for c in group).rstrip())
+        lines.append("")  # blank line between card rows
+    return "\n".join(lines).rstrip()
+
+
+def _card(r: dict[str, Any], active: str) -> list[str]:
+    name = str(r.get("name", ""))
+    mark = "*" if name and name == active else " "
+    model = str(r.get("model", ""))
+    pool = r.get("pool_gb", 0)
+    n = r.get("n_commands", 0)
+    return [
+        f"{mark} {name}"[:_CARD_W],
+        f"  {model}"[:_CARD_W],
+        f"  {pool} GB . {n} cmds"[:_CARD_W],
+    ]
+
+
+__all__ = ["render_agents_columns"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agents_view.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agents_view.py tests/test_agents_view.py
+git commit -m "feat(multi): agents_view — pure column dashboard renderer"
+```
+
+---
+
+## Task 2: `agent_runner.py` — `write_lock` serializes destructive tools
+
+**Files:**
+- Modify: `aether_agent/agent_runner.py`
+- Test: `tests/test_agent_runner_lock.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_runner_lock.py
+from aether_agent import agent_runner
+
+
+class _RecordingLock:
+    def __init__(self):
+        self.acquired = 0
+    def __enter__(self):
+        self.acquired += 1
+        return self
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeInner:
+    test_cmd = ""
+    def execute(self, name, args):
+        return f"[ran {name}]"
+
+
+def test_destructive_acquires_lock_read_does_not():
+    lock = _RecordingLock()
+    pt = agent_runner._PolicyTools(
+        _FakeInner(), allowed={"write_file", "read_file"}, permission="skip",
+        confirm=lambda n, a: True, write_lock=lock,
+    )
+    pt.execute("read_file", {"path": "x"})
+    assert lock.acquired == 0          # reads are not locked
+    pt.execute("write_file", {"path": "x", "content": "y"})
+    assert lock.acquired == 1          # destructive acquired the lock
+
+
+def test_no_lock_means_no_locking():
+    pt = agent_runner._PolicyTools(
+        _FakeInner(), allowed={"write_file"}, permission="skip", confirm=lambda n, a: True,
+    )
+    assert "[ran write_file]" in pt.execute("write_file", {"path": "x", "content": "y"})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_runner_lock.py -q`
+Expected: FAIL — `_PolicyTools.__init__() got an unexpected keyword argument 'write_lock'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/agent_runner.py`)
+
+Add `write_lock=None` to `_PolicyTools.__init__` and store it (keep any existing params like `agent_name`
+from sub-project C if present — this is an additive param):
+
+```python
+    def __init__(self, inner, allowed: set, permission: str, confirm: ConfirmFn,
+                 agent_name: str = "", write_lock=None) -> None:
+        self._inner = inner
+        self._allowed = set(allowed)
+        self._permission = permission
+        self._confirm = confirm
+        self._agent_name = agent_name
+        self._write_lock = write_lock
+        self.test_cmd = getattr(inner, "test_cmd", "")
+```
+
+(If sub-project C is not yet built, `agent_name` is also new — include it; if C is built, just add
+`write_lock` to the existing signature.)
+
+In `execute`, after the permission gate passes and BEFORE delegating to the inner tool, wrap a
+DESTRUCTIVE call in the lock when one is set:
+
+```python
+    def execute(self, name: str, args: dict) -> str:
+        if name not in self._allowed:
+            return f"[tool {name} not allowed for this agent]"
+        if name in DESTRUCTIVE and self._permission != "skip":
+            if not self._confirm(name, args):
+                return f"[denied: {name} (permission={self._permission})]"
+        if name in DESTRUCTIVE and self._write_lock is not None:
+            with self._write_lock:
+                return self._inner.execute(name, args)
+        return self._inner.execute(name, args)
+```
+
+(If C's `define_command` short-circuit exists, keep it as the FIRST line of `execute`.)
+
+In `run()`, add a `write_lock=None` param and pass it into `_PolicyTools`:
+
+```python
+def run(agent, task, *, cwd=".", confirm=None, llm=None, session_factory=None,
+        on_status=None, write_lock=None):
+    ...
+    tools = _PolicyTools(Tools(cwd), allowed=set(agent.tools), permission=agent.permission,
+                         confirm=confirm or _deny, agent_name=agent.name, write_lock=write_lock)
+```
+
+(Drop `agent_name=agent.name` if C is not built. The `write_lock=write_lock` addition is the D change.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_runner_lock.py tests/test_agent_runner.py -q`
+Expected: PASS (new green; existing agent_runner tests still green — `write_lock` defaults to None)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_runner.py tests/test_agent_runner_lock.py
+git commit -m "feat(multi): agent_runner write_lock serializes destructive tools (one writer)"
+```
+
+---
+
+## Task 3: `multi_runner.py` — concurrent orchestrator
+
+**Files:**
+- Create: `aether_agent/multi_runner.py`
+- Test: `tests/test_multi_runner.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_multi_runner.py
+from aether_agent import multi_runner
+from aether_agent.agent_profile import Agent
+
+
+def test_run_many_streams_labeled_events_and_summaries(monkeypatch):
+    scripts = {
+        "jane": [{"type": "monologue", "text": "j1"}, {"type": "tool_call", "name": "read_file", "args": {}},
+                 {"type": "done", "text": "jane done", "ok": True}],
+        "neo": [{"type": "monologue", "text": "n1"}, {"type": "done", "text": "neo done", "ok": True}],
+    }
+
+    def fake_run(agent, task, **kw):
+        for ev in scripts[agent.name]:
+            yield ev
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    seen = []
+    jobs = [(Agent.from_dict({"name": "jane"}), "t1"), (Agent.from_dict({"name": "neo"}), "t2")]
+    summaries = multi_runner.run_many(jobs, emit=lambda label, ev: seen.append((label, ev.get("type"))))
+    labels = {label for label, _ in seen}
+    assert labels == {"jane", "neo"}
+    assert ("jane", "monologue") in seen and ("neo", "done") in seen
+    by_name = {s["name"]: s for s in summaries}
+    assert by_name["jane"]["tool_calls"] == 1 and by_name["jane"]["ok"] is True
+    assert by_name["neo"]["summary"] == "neo done"
+
+
+def test_cap_at_8(monkeypatch):
+    def fake_run(agent, task, **kw):
+        yield {"type": "done", "text": "x", "ok": True}
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    jobs = [(Agent.from_dict({"name": f"a{i}"}), "t") for i in range(12)]
+    summaries = multi_runner.run_many(jobs, emit=lambda l, e: None)
+    assert len(summaries) == 8  # capped
+
+
+def test_shared_write_lock_passed_to_each_runner(monkeypatch):
+    locks_seen = []
+
+    def fake_run(agent, task, *, write_lock=None, **kw):
+        locks_seen.append(write_lock)
+        yield {"type": "done", "text": "x", "ok": True}
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    jobs = [(Agent.from_dict({"name": "a"}), "t"), (Agent.from_dict({"name": "b"}), "t")]
+    multi_runner.run_many(jobs, emit=lambda l, e: None)
+    assert locks_seen[0] is locks_seen[1] is not None  # same shared lock for all jobs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_multi_runner.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.multi_runner'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/multi_runner.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Run several agents at once (sub-project D).
+
+A daemon thread per ``(agent, task)`` runs ``agent_runner.run`` (Ollama is HTTP
+I/O-bound, so the GIL releases during the request -> real parallelism). Every
+event is pushed to a single ``queue.Queue`` that the MAIN thread drains and hands
+to ``emit(label, event)`` -- so all terminal writes happen on one thread (no
+garbled output). A shared ``write_lock`` (passed into each runner) serializes
+destructive tools across agents. Bounded to 8 concurrent.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Callable
+
+from aether_agent import agent_runner
+
+MAX_CONCURRENT = 8
+Emit = Callable[[str, dict], None]
+ConfirmFn = Callable[[str, dict], bool]
+
+
+def _deny(_name: str, _args: dict) -> bool:
+    return False
+
+
+def run_many(jobs, *, emit: Emit, confirm: "ConfirmFn | None" = None, cwd: str = ".") -> list[dict]:
+    """Run ``jobs`` (list of ``(Agent, task)``) concurrently; ``emit(label, ev)``
+    is called on the main thread per event. Returns a summary dict per agent."""
+    jobs = list(jobs)[:MAX_CONCURRENT]
+    write_lock = threading.Lock()
+    q: "queue.Queue[tuple[str, dict]]" = queue.Queue()
+    summaries: dict[str, dict] = {
+        a.name: {"name": a.name, "ok": False, "summary": "", "tool_calls": 0} for a, _ in jobs
+    }
+
+    def worker(agent, task) -> None:
+        try:
+            for ev in agent_runner.run(
+                agent, task, cwd=cwd, confirm=confirm or _deny, write_lock=write_lock
+            ):
+                q.put((agent.name, ev))
+        except Exception as e:  # noqa: BLE001 — surface as an error event, never crash the thread
+            q.put((agent.name, {"type": "error", "msg": str(e)}))
+        finally:
+            q.put((agent.name, {"type": "_thread_done"}))
+
+    threads = [threading.Thread(target=worker, args=(a, t), daemon=True) for a, t in jobs]
+    for th in threads:
+        th.start()
+
+    remaining = len(jobs)
+    while remaining > 0:
+        label, ev = q.get()
+        etype = ev.get("type")
+        if etype == "_thread_done":
+            remaining -= 1
+            continue
+        if etype == "tool_call":
+            summaries[label]["tool_calls"] += 1
+        elif etype == "done":
+            summaries[label]["ok"] = bool(ev.get("ok", True))
+            summaries[label]["summary"] = str(ev.get("text", ""))
+        emit(label, ev)
+
+    return [summaries[a.name] for a, _ in jobs]
+
+
+__all__ = ["run_many", "MAX_CONCURRENT"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_multi_runner.py -q`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/multi_runner.py tests/test_multi_runner.py
+git commit -m "feat(multi): multi_runner — thread-per-agent concurrent runs over a queue (labeled, write-locked, capped 8)"
+```
+
+---
+
+## Task 4: `agent_slash.py` — `/agents` column dashboard
+
+**Files:**
+- Modify: `aether_agent/agent_slash.py` (`_agents`)
+- Test: `tests/test_agent_slash_agents_columns.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_agent_slash_agents_columns.py
+import pytest
+
+from aether_agent import agent_slash
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_agents_renders_columns():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane", "model": "qwen2.5-coder:7b", "pool_gb": 5}))
+    agent_store.create(Agent.from_dict({"name": "neo", "model": "qwen3-coder:30b", "pool_gb": 10}))
+    out = agent_slash.dispatch_agent("/agents", active="neo")["text"]
+    assert "jane" in out and "neo" in out
+    assert "qwen2.5-coder:7b" in out and "qwen3-coder:30b" in out
+    assert "GB" in out  # the card stats line
+
+
+def test_agents_empty():
+    out = agent_slash.dispatch_agent("/agents", active="")["text"]
+    assert "no agents" in out.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_slash_agents_columns.py -q`
+Expected: FAIL — the current `_agents` returns the B simple-list text (a single line per agent with the
+`switch:` footer), so the multi-line card-layout assertions do not all hold.
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/agent_slash.py`)
+
+Replace the body of `_agents(active)` with the column build:
+
+```python
+def _agents(active: str) -> SlashResult:
+    from aether_agent import agents_view
+    names = agent_store.list_agents()
+    if not names:
+        return _text("(no agents yet - create one with /new-agent <name>)")
+    rows = []
+    for n in names:
+        try:
+            a = agent_store.load(n)
+            rows.append({"name": n, "model": a.model, "pool_gb": a.pool_gb,
+                         "n_commands": len(a.commands)})
+        except (ValueError, OSError):
+            rows.append({"name": n, "model": "(corrupt)", "pool_gb": 0, "n_commands": 0})
+    return _text(agents_view.render_agents_columns(rows, active=active))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_agent_slash_agents_columns.py tests/test_agent_slash.py tests/test_slash_agents.py -q`
+Expected: PASS — update any existing test that asserted the old B simple-list `/agents` text (e.g. the
+"switch:" footer) to assert only on agent names/models that appear in the column output too.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/agent_slash.py tests/test_agent_slash_agents_columns.py
+git commit -m "feat(multi): /agents renders the column dashboard via agents_view"
+```
+
+---
+
+## Task 5: `repl.py` — parse ` \ ` multi-runs + labeled rendering
+
+**Files:**
+- Modify: `aether_agent/repl.py`
+- Test: `tests/test_repl_multi.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_repl_multi.py
+import io
+
+import pytest
+
+from aether_agent import repl
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_parse_multi_two_runs():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    agent_store.create(Agent.from_dict({"name": "neo"}))
+    jobs = repl._parse_multi("/agent jane fix tests \\ /agent neo write docs")
+    assert jobs is not None
+    assert [(a.name, t) for a, t in jobs] == [("jane", "fix tests"), ("neo", "write docs")]
+
+
+def test_parse_multi_single_returns_none():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    assert repl._parse_multi("/agent jane fix tests") is None  # no ' \\ ' -> not multi
+
+
+def test_handle_multi_streams_labeled(monkeypatch):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    agent_store.create(Agent.from_dict({"name": "neo"}))
+
+    def fake_run_many(jobs, *, emit, **kw):
+        for a, _ in jobs:
+            emit(a.name, {"type": "done", "text": f"{a.name} ok"})
+        return [{"name": a.name, "ok": True, "summary": f"{a.name} ok", "tool_calls": 0} for a, _ in jobs]
+
+    monkeypatch.setattr("aether_agent.multi_runner.run_many", fake_run_many)
+    out = io.StringIO()
+    jobs = repl._parse_multi("/agent jane t \\ /agent neo t")
+    repl._handle_multi(jobs, out)
+    text = out.getvalue()
+    assert "[jane]" in text and "[neo]" in text
+    assert "done" in text.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_repl_multi.py -q`
+Expected: FAIL — `AttributeError: module 'aether_agent.repl' has no attribute '_parse_multi'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/repl.py`)
+
+Add the parser + handlers (module level):
+
+```python
+def _parse_multi(line: str):
+    """Parse a ` \\ `-joined multi-agent run line into [(Agent, task), ...].
+    Returns None when it is not a 2+ agent-run line."""
+    if " \\ " not in line:
+        return None
+    from aether_agent import agent_store
+
+    jobs = []
+    for seg in line.split(" \\ "):
+        s = seg.strip()
+        if s.startswith("/"):
+            s = s[1:]
+        parts = s.split()
+        if len(parts) < 3 or parts[0].lower() != "agent":
+            return None  # not all segments are agent runs -> not a multi-run
+        if parts[2].lower() in {"set", "show", "edit", "delete", "cmd", "run"}:
+            return None  # a verb, not a task
+        name = parts[1]
+        task = " ".join(parts[2:])
+        try:
+            jobs.append((agent_store.load(name), task))
+        except (ValueError, OSError):
+            return None
+    return jobs if len(jobs) >= 2 else None
+
+
+def _handle_multi(jobs, out) -> None:
+    """Run jobs concurrently, rendering labeled interleaved output + a summary."""
+    from aether_agent import multi_runner
+    from aether_agent.agent_profile import ACCENTS
+
+    accents = {a.name: f"\x1b[{ACCENTS.get(a.accent, '36')}m" for a, _ in jobs}
+
+    def emit(label: str, ev: dict) -> None:
+        _render_labeled(label, ev, accents.get(label, ""), out)
+
+    summaries = multi_runner.run_many(jobs, emit=emit, confirm=lambda n, a: False)
+    _safe_write(out, "\n--- done ---\n")
+    for s in summaries:
+        _safe_write(out, f"{s['name']}: {s['summary'] or ('ok' if s['ok'] else 'stopped')}\n")
+
+
+def _render_labeled(label: str, ev: dict, accent_ansi: str, out) -> None:
+    """Render one event prefixed by [label] (accent-colored), cp1252-safe."""
+    tag = f"{accent_ansi}[{label}]\x1b[0m " if accent_ansi else f"[{label}] "
+    etype = ev.get("type")
+    if etype in ("monologue", "done"):
+        text = str(ev.get("text", ""))
+        if text:
+            _safe_write(out, tag + _first_line(text, 120) + "\n")
+    elif etype == "tool_call":
+        _safe_write(out, tag + f"- {ev.get('name', '')}({_fmt_args(ev.get('args', {}))})\n")
+    elif etype == "tool_result":
+        _safe_write(out, tag + f"- {ev.get('name', '')} -> {_first_line(str(ev.get('output', '')))}\n")
+    elif etype == "error":
+        _safe_write(out, tag + f"[x] {ev.get('msg', 'error')}\n")
+```
+
+In `main()`, BEFORE the `if line.startswith("/"):` slash handling, add the multi-run branch:
+
+```python
+        jobs = _parse_multi(line)
+        if jobs is not None:
+            _handle_multi(jobs, out)
+            out.write("\n")
+            continue
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_repl_multi.py tests/test_repl_agents.py tests/test_repl_preflight.py -q`
+Expected: PASS (new green; existing repl tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/repl.py tests/test_repl_multi.py
+git commit -m "feat(multi): REPL parses ' \\ ' multi-agent runs -> concurrent labeled streaming"
+```
+
+---
+
+## Task 6: Full-suite + ruff + push
+
+**Files:** full suite
+
+- [ ] **Step 1: Ruff**
+
+Run: `.venv/Scripts/python.exe -m ruff check aether_agent tests`
+Expected: `All checks passed!` — remove any F401 and re-run.
+
+- [ ] **Step 2: Full suite**
+
+Run: `.venv/Scripts/python.exe -m pytest -q`
+Expected: PASS — all prior tests plus the ~14 new D tests. Zero regressions.
+
+- [ ] **Step 3: Boot smoke (no Ollama)**
+
+Run (bash): `AETHER_CONFIG_DIR="$(mktemp -d)" .venv/Scripts/python.exe -c "
+from aether_agent import Agent
+from aether_agent.slash import SlashContext, dispatch
+Agent.create('jane'); Agent.create('neo')
+print(dispatch(SlashContext(api=None, active_agent='neo'), '/agents')['text'])
+"`
+Expected: a column dashboard listing `jane` and `neo` with `*` on `neo`.
+
+- [ ] **Step 4: Commit any fixes + push**
+
+```bash
+git add -A && git commit -m "test(multi): full-suite + ruff green after multi-agent (sub-project D)"
+git push -u origin feat/multi-agent
+```
+
+---
+
+## Self-review (author checklist — completed)
+
+- **Spec coverage:** column dashboard renderer (T1) · write-lock serialization (T2) · concurrent thread orchestrator + cap + summaries (T3) · `/agents` columns (T4) · ` \ ` parse + labeled interleaved streaming (T5) · offline tests per unit. All spec sections map to a task.
+- **Placeholder scan:** no TBD/TODO; complete code each step.
+- **Type consistency:** `multi_runner.run_many(jobs, *, emit, confirm, cwd)` + the `(label, event)` queue shape consistent across T3,T5; `_PolicyTools(..., write_lock=None)` + `run(..., write_lock=None)` across T2,T3; `agents_view.render_agents_columns(rows, active, width)` + the `rows` dict shape (`name/model/pool_gb/n_commands`) across T1,T4; `repl._parse_multi`/`_handle_multi`/`_render_labeled` across T5. `write_lock` is additive + orthogonal to C's `define_command` edit on `_PolicyTools`.
+- **Scope:** D only — full-screen panes, worktree isolation, >8 concurrent, cross-agent messaging all out.
+```

--- a/docs/superpowers/plans/2026-06-15-ollama-wrapped-terminal.md
+++ b/docs/superpowers/plans/2026-06-15-ollama-wrapped-terminal.md
@@ -1,0 +1,1455 @@
+# Ollama-wrapped Terminal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `aether` terminal own the full Ollama lifecycle (detect/install/serve/pull/switch) with a clean, hardware-aware first-run, so a local user never touches raw Ollama.
+
+**Architecture:** Four new stdlib-only modules in `aether_agent/` — `progress.py` (pure render), `hardware.py` (resource detect + curated catalog + best-fit), `ollama_ctl.py` (lifecycle over the Ollama HTTP API + a managed `serve` subprocess), `onboarding.py` (preflight state machine) — wired into the existing `repl.py` (preflight on launch + tidy `serve` teardown), `slash.py` (`/pull /setup /doctor /serve` + local-aware `/models`), and `cli.py` (`aether doctor` / `aether setup`). All IO is behind injectable seams so tests run offline.
+
+**Tech Stack:** Python 3.10+, stdlib only (`urllib`, `subprocess`, `ctypes`, `shutil`, `json`, `dataclasses`), `pytest`. No new runtime deps.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-ollama-wrapped-terminal-design.md`
+**Branch:** `feat/ollama-wrapped-terminal`
+**Gate:** `.venv/Scripts/python.exe -m pytest -q` (Windows venv; fall back to `python -m pytest -q`).
+
+---
+
+## File Structure
+
+| File | New/Mod | Responsibility |
+|---|---|---|
+| `aether_agent/progress.py` | New | Pure render: progress bar, spinner, step lines, byte/pull formatting. cp1252-safe. |
+| `aether_agent/hardware.py` | New | `detect_resources()` (injectable probes, fail-soft) + curated `CATALOG` + `best_fit()`. |
+| `aether_agent/ollama_ctl.py` | New | `OllamaCtl`: `detect`, `ensure_serve`/`stop_owned`, `list_models`, `pull`, `ps`, `remove`, `install`. HTTP + `Popen` seams. |
+| `aether_agent/onboarding.py` | New | `preflight()` state machine -> typed `Preflight` result; `doctor()` report. |
+| `aether_agent/slash.py` | Mod | Add `ollama` to `SlashContext`; add `/pull /setup /doctor /serve`; local-aware `/models`. |
+| `aether_agent/repl.py` | Mod | Run `preflight()` on launch; pass `ollama` into `SlashContext`; `stop_owned()` in a `finally`. |
+| `aether_agent/cli.py` | Mod | `aether doctor` + `aether setup` subcommands. |
+| `tests/test_progress.py` … `tests/test_cli_doctor.py` | New | One test module per unit (offline). |
+
+Catalog note (refines spec): include a permissive low-end floor `qwen2.5-coder:3b` so a 6 GB machine gets a model that actually fits (the Gemma option is license-flagged and never auto-default).
+
+---
+
+## Task 1: `progress.py` — pure render helpers
+
+**Files:**
+- Create: `aether_agent/progress.py`
+- Test: `tests/test_progress.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_progress.py
+from aether_agent import progress
+
+
+def test_bar_empty_full_and_clamp():
+    assert progress.progress_bar(0.0, width=10) == "[----------] 0%"
+    assert progress.progress_bar(1.0, width=10) == "[##########] 100%"
+    assert progress.progress_bar(-5, width=10) == "[----------] 0%"
+    assert progress.progress_bar(2, width=10) == "[##########] 100%"
+    assert progress.progress_bar(0.5, width=10) == "[#####-----] 50%"
+
+
+def test_fmt_bytes():
+    assert progress.fmt_bytes(0) == "0 B"
+    assert progress.fmt_bytes(1536) == "1.5 KB"
+    assert progress.fmt_bytes(5 * 1024**3) == "5.0 GB"
+
+
+def test_pull_line_and_step_and_spinner():
+    line = progress.pull_line("qwen2.5-coder:7b", 2 * 1024**3, 4 * 1024**3)
+    assert "qwen2.5-coder:7b" in line and "50%" in line
+    assert progress.step("serve", ok=True) == "  [ok] serve"
+    assert progress.step("serve", ok=False) == "  [x] serve"
+    assert progress.step("serve") == "  ... serve"
+    assert progress.spinner_frame(0) in "|/-\\"
+
+
+def test_output_is_cp1252_safe():
+    s = progress.progress_bar(0.5) + progress.step("x", True) + progress.pull_line("m", 1, 2)
+    s.encode("cp1252")  # must not raise
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_progress.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.progress'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/progress.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Pure, cp1252-safe render helpers for the Ollama-managed terminal UI.
+
+No IO, no ANSI cursor control here (callers own the terminal) — just strings, so
+every function is trivially unit-testable and safe on a Windows cp1252 console.
+"""
+from __future__ import annotations
+
+_BLOCK = "#"
+_EMPTY = "-"
+_SPINNER = ("|", "/", "-", "\\")
+
+
+def progress_bar(frac: float, width: int = 24) -> str:
+    """Render ``[####----] 51%``. ``frac`` is clamped to [0, 1]."""
+    try:
+        f = float(frac)
+    except (TypeError, ValueError):
+        f = 0.0
+    f = 0.0 if f < 0 else 1.0 if f > 1 else f
+    filled = round(f * width)
+    bar = _BLOCK * filled + _EMPTY * (width - filled)
+    return f"[{bar}] {int(round(f * 100))}%"
+
+
+def fmt_bytes(n: float) -> str:
+    """Human bytes: ``4.7 GB``. Whole-byte values render without a decimal."""
+    try:
+        val = float(n or 0)
+    except (TypeError, ValueError):
+        val = 0.0
+    if val < 1024:
+        return f"{int(val)} B"
+    for unit in ("KB", "MB", "GB", "TB"):
+        val /= 1024
+        if val < 1024 or unit == "TB":
+            return f"{val:.1f} {unit}"
+    return f"{val:.1f} TB"
+
+
+def spinner_frame(i: int) -> str:
+    return _SPINNER[i % len(_SPINNER)]
+
+
+def step(label: str, ok: bool | None = None) -> str:
+    """A step line: ``... label`` (pending) · ``[ok] label`` · ``[x] label``."""
+    mark = "..." if ok is None else ("[ok]" if ok else "[x]")
+    return f"  {mark} {label}"
+
+
+def pull_line(tag: str, completed: float, total: float) -> str:
+    """Single-line live pull status: ``tag  2.0 GB / 4.0 GB  [####----] 50%``."""
+    frac = (float(completed) / float(total)) if total else 0.0
+    return f"{tag}   {fmt_bytes(completed)} / {fmt_bytes(total)}   {progress_bar(frac)}"
+
+
+__all__ = ["progress_bar", "fmt_bytes", "spinner_frame", "step", "pull_line"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_progress.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/progress.py tests/test_progress.py
+git commit -m "feat(ollama): progress.py — cp1252-safe progress/step/pull render helpers"
+```
+
+---
+
+## Task 2: `hardware.py` — resources + catalog + best-fit
+
+**Files:**
+- Create: `aether_agent/hardware.py`
+- Test: `tests/test_hardware.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_hardware.py
+from aether_agent import hardware
+from aether_agent.hardware import Resources
+
+
+def _fit(ram, vram=None, gpu=None):
+    res = hardware.detect_resources(
+        ram_probe=lambda: ram,
+        vram_probe=lambda: (vram, gpu),
+    )
+    return hardware.best_fit(res)[0]
+
+
+def test_best_fit_matrix():
+    assert _fit(16) == "qwen2.5-coder:7b"          # 16*0.7=11.2 -> 7b (min 8)
+    assert _fit(6) == "qwen2.5-coder:3b"           # 6*0.7=4.2 -> 3b (min 4)
+    assert _fit(48) == "qwen3-coder:30b"           # 48*0.7=33.6 -> 30b (min 24)
+    assert _fit(8, vram=24, gpu="NVIDIA") == "qwen3-coder:30b"  # VRAM wins
+
+
+def test_low_resources_falls_back_to_permissive_floor():
+    # 2 GB fits nothing -> the permissive floor, never the license-flagged Gemma.
+    assert _fit(2) == hardware.DEFAULT_FLOOR == "qwen2.5-coder:3b"
+
+
+def test_flagged_model_never_auto_selected():
+    # Even where Gemma (min 6) would "fit", best_fit must skip license-flagged.
+    tag = _fit(7)  # 7*0.7=4.9 -> 3b (min4); gemma(min6) excluded anyway
+    assert tag != "gemma3n:e4b"
+
+
+def test_detect_resources_failsoft_default():
+    def boom():
+        raise OSError("no probe")
+    res = hardware.detect_resources(ram_probe=boom, vram_probe=boom)
+    assert res == Resources(ram_gb=8.0, vram_gb=None, gpu=None)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_hardware.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.hardware'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/hardware.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Hardware detection + a curated local-model catalog + a best-fit picker.
+
+``detect_resources`` is fail-soft (any probe error -> a conservative 8 GB / no-GPU
+default) and takes injectable probes so tests never touch the real machine.
+``best_fit`` never returns an oversized or license-flagged model as the auto-pick.
+"""
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    tag: str
+    size_gb: float
+    min_ram_gb: float
+    gpu_pref: bool
+    license_note: str | None
+    blurb: str
+
+
+# Ordered small -> large. license_note != None => never an auto-default.
+CATALOG: tuple[ModelInfo, ...] = (
+    ModelInfo("qwen2.5-coder:3b", 1.9, 4, False, None, "low-end, permissive (Apache-2.0)"),
+    ModelInfo("gemma3n:e4b", 3.3, 6, False, "Gemma3 custom license", "light machines"),
+    ModelInfo("qwen2.5-coder:7b", 4.7, 8, False, None, "universal, fits an 8 GB GPU"),
+    ModelInfo("qwen3-coder:30b", 24.0, 24, True, None, "depth build, 256K ctx (Apache-2.0)"),
+)
+DEFAULT_FLOOR = "qwen2.5-coder:3b"
+
+
+@dataclass(frozen=True)
+class Resources:
+    ram_gb: float
+    vram_gb: float | None
+    gpu: str | None
+
+
+def detect_resources(*, ram_probe=None, vram_probe=None) -> Resources:
+    """Detect RAM/VRAM. Fail-soft to (8 GB, no GPU). Probes injectable for tests."""
+    try:
+        ram = float((ram_probe or _ram_gb)())
+    except Exception:  # noqa: BLE001 — detection must never crash startup
+        ram = 8.0
+    try:
+        vram, gpu = (vram_probe or _vram)()
+    except Exception:  # noqa: BLE001
+        vram, gpu = None, None
+    return Resources(ram_gb=ram, vram_gb=vram, gpu=gpu)
+
+
+def best_fit(res: Resources) -> tuple[str, str]:
+    """Largest permissive model that fits. Returns (tag, reason)."""
+    if res.vram_gb and res.vram_gb > 0:
+        eff, where = res.vram_gb, (res.gpu or "VRAM")
+    else:
+        eff, where = res.ram_gb * 0.7, "RAM"
+    eligible = [m for m in CATALOG if m.license_note is None and m.min_ram_gb <= eff]
+    if not eligible:
+        return DEFAULT_FLOOR, f"~{eff:.0f} GB usable -> safe default {DEFAULT_FLOOR}"
+    best = max(eligible, key=lambda m: m.size_gb)
+    return best.tag, f"{where} ~{eff:.0f} GB -> {best.tag}"
+
+
+# --- real probes (best-effort, platform-specific) --------------------------
+def _ram_gb() -> float:
+    sysname = platform.system()
+    if sysname == "Windows":
+        import ctypes
+
+        class _Mem(ctypes.Structure):
+            _fields_ = [("dwLength", ctypes.c_ulong), ("dwMemoryLoad", ctypes.c_ulong),
+                        ("ullTotalPhys", ctypes.c_ulonglong), ("ullAvailPhys", ctypes.c_ulonglong),
+                        ("ullTotalPageFile", ctypes.c_ulonglong), ("ullAvailPageFile", ctypes.c_ulonglong),
+                        ("ullTotalVirtual", ctypes.c_ulonglong), ("ullAvailVirtual", ctypes.c_ulonglong),
+                        ("ullAvailExtendedVirtual", ctypes.c_ulonglong)]
+
+        m = _Mem()
+        m.dwLength = ctypes.sizeof(_Mem)
+        ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(m))
+        return m.ullTotalPhys / 1024**3
+    if sysname == "Darwin":
+        out = subprocess.check_output(["sysctl", "-n", "hw.memsize"], timeout=5)
+        return int(out.strip()) / 1024**3
+    # Linux / other: /proc/meminfo
+    with open("/proc/meminfo", encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) / 1024**2  # kB -> GB
+    raise OSError("cannot read MemTotal")
+
+
+def _vram() -> tuple[float | None, str | None]:
+    if not shutil.which("nvidia-smi"):
+        return None, None
+    out = subprocess.check_output(
+        ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
+        timeout=5,
+    ).decode("utf-8", "replace").strip()
+    first = out.splitlines()[0]
+    name, mib = (p.strip() for p in first.split(","))
+    return float(mib) / 1024, name  # MiB -> GB
+
+
+__all__ = ["ModelInfo", "CATALOG", "DEFAULT_FLOOR", "Resources", "detect_resources", "best_fit"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_hardware.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/hardware.py tests/test_hardware.py
+git commit -m "feat(ollama): hardware.py — resource detect + curated catalog + best_fit"
+```
+
+---
+
+## Task 3: `ollama_ctl.py` — detect / serve / list / pull / ps / remove
+
+**Files:**
+- Create: `aether_agent/ollama_ctl.py`
+- Test: `tests/test_ollama_ctl.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_ollama_ctl.py
+from aether_agent.ollama_ctl import OllamaCtl
+
+
+class _FakeProc:
+    def __init__(self):
+        self.terminated = False
+    def terminate(self):
+        self.terminated = True
+    def poll(self):
+        return None
+
+
+def _ctl(*, tags_up=True, which="ollama", pull_lines=None, proc=None):
+    state = {"serves": 0}
+
+    def http_get(path):
+        if path == "/api/tags":
+            if tags_up:
+                return {"models": [{"name": "qwen2.5-coder:7b", "size": 5_000_000_000}]}
+            raise OSError("connection refused")
+        if path == "/api/ps":
+            return {"models": []}
+        raise AssertionError(path)
+
+    def http_post_stream(path, body):
+        assert path == "/api/pull"
+        for ln in (pull_lines or []):
+            yield ln
+
+    def popen(args):
+        state["serves"] += 1
+        return proc or _FakeProc()
+
+    ctl = OllamaCtl(
+        http_get=http_get,
+        http_post_stream=http_post_stream,
+        popen=popen,
+        which=lambda name: which,
+        sleep=lambda s: None,
+    )
+    ctl._serve_calls = state
+    return ctl
+
+
+def test_detect_reports_install_and_daemon():
+    d = _ctl(tags_up=True).detect()
+    assert d["installed"] is True and d["daemon_up"] is True
+    d2 = _ctl(tags_up=False, which=None).detect()
+    assert d2["installed"] is False and d2["daemon_up"] is False
+
+
+def test_ensure_serve_starts_only_when_down_and_owns_it():
+    up = _ctl(tags_up=True)
+    assert up.ensure_serve() is True
+    assert up._owned is False and up._serve_calls["serves"] == 0  # already up -> not owned
+
+    proc = _FakeProc()
+    down = _ctl(tags_up=False, proc=proc)
+    # daemon is down at first probe; mark it up after the spawn so the poll succeeds
+    down._daemon_up = lambda: down._serve_calls["serves"] > 0
+    assert down.ensure_serve() is True
+    assert down._owned is True and down._serve_calls["serves"] == 1
+
+
+def test_stop_owned_only_kills_what_we_started():
+    proc = _FakeProc()
+    down = _ctl(tags_up=False, proc=proc)
+    down._daemon_up = lambda: down._serve_calls["serves"] > 0
+    down.ensure_serve()
+    down.stop_owned()
+    assert proc.terminated is True
+
+    up = _ctl(tags_up=True)
+    up.ensure_serve()
+    up.stop_owned()  # nothing owned -> no-op, must not raise
+
+
+def test_pull_streams_progress_callbacks():
+    lines = [
+        {"status": "pulling", "completed": 1, "total": 4},
+        {"status": "pulling", "completed": 4, "total": 4},
+        {"status": "success"},
+    ]
+    ctl = _ctl(pull_lines=lines)
+    seen = []
+    ok, detail = ctl.pull("qwen2.5-coder:7b", on_progress=lambda s, c, t: seen.append((s, c, t)))
+    assert ok is True
+    assert seen[0] == ("pulling", 1, 4) and seen[-1][0] == "success"
+
+
+def test_list_models_returns_installed_tags():
+    ctl = _ctl(tags_up=True)
+    models = ctl.list_models()
+    assert {"tag": "qwen2.5-coder:7b", "size_bytes": 5_000_000_000} in models
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_ollama_ctl.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.ollama_ctl'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/ollama_ctl.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Ollama lifecycle control — the terminal's managed view of the local daemon.
+
+Talks to the Ollama HTTP API (``/api/tags``, ``/api/pull`` stream, ``/api/ps``,
+``/api/delete``) and supervises a ``serve`` subprocess we may own. Every IO seam
+(HTTP GET, HTTP streaming POST, ``Popen``, ``which``, ``sleep``, download, run)
+is injectable so the whole surface is unit-testable offline. ``install`` (Task 4)
+is the only path that downloads; it is consent-gated + https/official-host-pinned.
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable, Iterator, Optional
+
+from aether_agent.adapter import DEFAULT_HOST
+
+_PROBE_TIMEOUT = 4.0
+_SERVE_READY_TIMEOUT = 30.0
+_SERVE_POLL_INTERVAL = 0.4
+
+OFFICIAL_HOSTS = ("ollama.com", "www.ollama.com", "github.com")
+_WIN_INSTALLER = "https://ollama.com/download/OllamaSetup.exe"
+_UNIX_INSTALL_SH = "https://ollama.com/install.sh"
+_MANUAL_LINK = "https://ollama.com/download"
+
+ProgressFn = Callable[[str, float, float], None]
+
+
+def is_official_url(url: str) -> bool:
+    """True only for an https URL whose host is an official Ollama host."""
+    try:
+        p = urllib.parse.urlsplit(url)
+    except ValueError:
+        return False
+    if p.scheme != "https":
+        return False
+    return (p.hostname or "").lower() in OFFICIAL_HOSTS
+
+
+def _default_installer_url() -> str:
+    return _WIN_INSTALLER if platform.system() == "Windows" else _UNIX_INSTALL_SH
+
+
+class OllamaCtl:
+    def __init__(
+        self,
+        host: str = DEFAULT_HOST,
+        *,
+        http_get: Optional[Callable[[str], Any]] = None,
+        http_post_stream: Optional[Callable[[str, dict], Iterator[dict]]] = None,
+        popen: Optional[Callable[[list[str]], Any]] = None,
+        which: Optional[Callable[[str], Optional[str]]] = None,
+        sleep: Optional[Callable[[float], None]] = None,
+        installer_url: Optional[Callable[[], str]] = None,
+        downloader: Optional[Callable[[str], bytes]] = None,
+        runner: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self.host = host.rstrip("/")
+        self._get = http_get or self._default_get
+        self._post_stream = http_post_stream or self._default_post_stream
+        self._popen = popen or (lambda args: subprocess.Popen(args))
+        self._which = which or shutil.which
+        self._sleep = sleep or time.sleep
+        self._installer_url = installer_url or _default_installer_url
+        self._download = downloader or self._default_download
+        self._run_installer = runner or self._default_run_installer
+        self._owned = False
+        self._proc: Any = None
+
+    # --- detection ---------------------------------------------------------
+    def _daemon_up(self) -> bool:
+        try:
+            self._get("/api/tags")
+            return True
+        except Exception:  # noqa: BLE001 — any failure means "not up"
+            return False
+
+    def detect(self) -> dict:
+        return {"installed": bool(self._which("ollama")), "daemon_up": self._daemon_up()}
+
+    # --- serve lifecycle ---------------------------------------------------
+    def ensure_serve(self) -> bool:
+        """Ensure the daemon is up. Start it (and mark OWNED) only if it is down.
+        Returns True when reachable, False on a start timeout."""
+        if self._daemon_up():
+            self._owned = False
+            return True
+        self._proc = self._popen(["ollama", "serve"])
+        self._owned = True
+        waited = 0.0
+        while waited < _SERVE_READY_TIMEOUT:
+            if self._daemon_up():
+                return True
+            self._sleep(_SERVE_POLL_INTERVAL)
+            waited += _SERVE_POLL_INTERVAL
+        return False
+
+    def stop_owned(self) -> None:
+        """Terminate the serve subprocess only if we started it."""
+        if self._owned and self._proc is not None:
+            try:
+                self._proc.terminate()
+            except Exception:  # noqa: BLE001 — teardown is best-effort
+                pass
+            self._owned = False
+            self._proc = None
+
+    # --- model ops ---------------------------------------------------------
+    def list_models(self) -> list[dict]:
+        try:
+            payload = self._get("/api/tags") or {}
+        except Exception:  # noqa: BLE001
+            return []
+        out = []
+        for m in payload.get("models", []) if isinstance(payload, dict) else []:
+            if isinstance(m, dict) and m.get("name"):
+                out.append({"tag": str(m["name"]), "size_bytes": int(m.get("size", 0) or 0)})
+        return out
+
+    def ps(self) -> list[dict]:
+        try:
+            payload = self._get("/api/ps") or {}
+        except Exception:  # noqa: BLE001
+            return []
+        return payload.get("models", []) if isinstance(payload, dict) else []
+
+    def pull(self, tag: str, on_progress: Optional[ProgressFn] = None) -> tuple[bool, str]:
+        """Pull/update a model, streaming NDJSON progress to ``on_progress``."""
+        last = ""
+        try:
+            for obj in self._post_stream("/api/pull", {"name": tag, "stream": True}):
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("error"):
+                    return False, str(obj["error"])
+                last = str(obj.get("status", ""))
+                if on_progress is not None:
+                    on_progress(last, float(obj.get("completed", 0) or 0), float(obj.get("total", 0) or 0))
+        except Exception as e:  # noqa: BLE001 — surface as a clean failure
+            return False, str(e)
+        return True, last or "done"
+
+    def remove(self, tag: str) -> tuple[bool, str]:
+        try:
+            self._default_delete("/api/delete", {"name": tag})
+            return True, "removed"
+        except Exception as e:  # noqa: BLE001
+            return False, str(e)
+
+    # --- install (consent-gated, host-pinned) ------------------------------
+    def install(self, *, consent: bool) -> tuple[bool, str]:
+        if not consent:
+            return False, f"install needs consent; get it yourself: {_MANUAL_LINK}"
+        url = self._installer_url()
+        if not is_official_url(url):
+            return False, f"refusing non-official installer url ({url}); use {_MANUAL_LINK}"
+        try:
+            blob = self._download(url)
+        except Exception as e:  # noqa: BLE001
+            return False, f"download failed ({e}); install manually: {_MANUAL_LINK}"
+        if not blob:
+            return False, f"empty download; install manually: {_MANUAL_LINK}"
+        suffix = ".exe" if url.endswith(".exe") else ".sh"
+        fd, path = tempfile.mkstemp(prefix="ollama-install-", suffix=suffix)
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(blob)
+            self._run_installer(path)
+        except Exception as e:  # noqa: BLE001
+            return False, f"installer failed ({e}); install manually: {_MANUAL_LINK}"
+        if not self._which("ollama"):
+            return False, f"install ran but ollama still not found; see {_MANUAL_LINK}"
+        return True, "ollama installed"
+
+    # --- default IO seams (real urllib / subprocess) -----------------------
+    def _default_get(self, path: str) -> Any:
+        req = urllib.request.Request(self.host + path, method="GET")
+        with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+
+    def _default_post_stream(self, path: str, body: dict) -> Iterator[dict]:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            self.host + path, data=data, method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=_SERVE_READY_TIMEOUT * 20) as resp:  # noqa: S310
+            for raw in resp:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except ValueError:
+                    continue
+
+    def _default_delete(self, path: str, body: dict) -> None:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            self.host + path, data=data, method="DELETE",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT) as resp:  # noqa: S310
+            resp.read()
+
+    def _default_download(self, url: str) -> bytes:
+        if not is_official_url(url):  # defense in depth — never fetch a non-official url
+            raise ValueError("non-official url")
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 — pinned official host
+            return resp.read()
+
+    def _default_run_installer(self, path: str) -> None:
+        if path.endswith(".exe"):
+            subprocess.run([path, "/VERYSILENT"], check=False, timeout=600)
+        else:
+            subprocess.run(["sh", path], check=False, timeout=600)
+
+
+__all__ = ["OllamaCtl", "ProgressFn", "OFFICIAL_HOSTS", "is_official_url"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_ollama_ctl.py -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/ollama_ctl.py tests/test_ollama_ctl.py
+git commit -m "feat(ollama): ollama_ctl.py — detect/serve(owned)/list/pull/ps/remove over the HTTP API"
+```
+
+---
+
+## Task 4: install security tests (the installer shipped in Task 3)
+
+**Files:**
+- Test: `tests/test_install_security.py` (exercises `OllamaCtl.install` + `is_official_url` from Task 3)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_install_security.py
+from aether_agent.ollama_ctl import OllamaCtl, is_official_url
+
+
+def test_official_url_pinning():
+    assert is_official_url("https://ollama.com/download/OllamaSetup.exe") is True
+    assert is_official_url("https://github.com/ollama/ollama/releases/x") is True
+    assert is_official_url("http://ollama.com/x") is False          # https only
+    assert is_official_url("https://evil.example.com/OllamaSetup.exe") is False
+
+
+def test_install_refuses_without_consent():
+    calls = []
+    ctl = OllamaCtl(downloader=lambda url: calls.append(url) or b"",
+                    runner=lambda path: calls.append(("run", path)))
+    ok, detail = ctl.install(consent=False)
+    assert ok is False and "consent" in detail.lower()
+    assert calls == []  # nothing downloaded, nothing run
+
+
+def test_install_refuses_non_official_url():
+    ctl = OllamaCtl(installer_url=lambda: "https://evil.example.com/x.exe",
+                    downloader=lambda url: b"X", runner=lambda p: None)
+    ok, detail = ctl.install(consent=True)
+    assert ok is False and "official" in detail.lower()
+
+
+def test_install_runs_official_with_consent():
+    ran = {}
+    ctl = OllamaCtl(
+        installer_url=lambda: "https://ollama.com/download/OllamaSetup.exe",
+        downloader=lambda url: b"INSTALLER-BYTES",
+        runner=lambda path: ran.setdefault("path", path),
+        which=lambda n: "ollama",  # re-detect succeeds after install
+    )
+    ok, detail = ctl.install(consent=True)
+    assert ok is True and ran["path"].endswith(".exe")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_install_security.py -q`
+Expected: PASS already IF Task 3 shipped `install`/`is_official_url`. If you split Task 3 without `install`, this FAILS with `ImportError: cannot import name 'is_official_url'` — go back and add the install block from Task 3.
+
+- [ ] **Step 3: (No new impl — install shipped in Task 3.)** If any assertion fails, fix `install`/`is_official_url` minimally in `ollama_ctl.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_install_security.py tests/test_ollama_ctl.py -q`
+Expected: PASS (9 passed total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_install_security.py
+git commit -m "test(ollama): install security — consent gate, https+official-host pin, manual fallback"
+```
+
+---
+
+## Task 5: `onboarding.py` — preflight state machine + doctor
+
+**Files:**
+- Create: `aether_agent/onboarding.py`
+- Test: `tests/test_onboarding.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_onboarding.py
+from aether_agent import onboarding
+from aether_agent.onboarding import Preflight
+
+
+class _Ctl:
+    def __init__(self, installed=True, daemon=True, models=None, pull_ok=True):
+        self._installed, self._daemon = installed, daemon
+        self._models = models if models is not None else ["qwen2.5-coder:7b"]
+        self._pull_ok = pull_ok
+        self.installed_called = self.served = self.pulled = None
+    def detect(self):
+        return {"installed": self._installed, "daemon_up": self._daemon}
+    def install(self, *, consent):
+        self.installed_called = consent
+        self._installed = consent
+        return (consent, "ok" if consent else "declined")
+    def ensure_serve(self):
+        self.served = True
+        self._daemon = True
+        return True
+    def list_models(self):
+        return [{"tag": t, "size_bytes": 1} for t in self._models]
+    def pull(self, tag, on_progress=None):
+        self.pulled = tag
+        if self._pull_ok:
+            self._models.append(tag)
+        return (self._pull_ok, "success" if self._pull_ok else "boom")
+    def stop_owned(self):
+        pass
+
+
+def test_preflight_healthy_is_silent_noop():
+    ctl = _Ctl(installed=True, daemon=True, models=["qwen2.5-coder:7b"])
+    pf = onboarding.preflight(ctl, resources=lambda: ("qwen2.5-coder:7b", "ok"),
+                              prompt=lambda q: "")  # never prompted
+    assert pf.ok is True and pf.chosen_model == "qwen2.5-coder:7b"
+    assert ctl.served is None and ctl.pulled is None  # nothing to do
+
+
+def test_preflight_full_path_installs_serves_picks_pulls():
+    ctl = _Ctl(installed=False, daemon=False, models=[])
+    answers = iter(["y", ""])  # y to install, Enter to accept the pick
+    pf = onboarding.preflight(ctl, resources=lambda: ("qwen2.5-coder:7b", "16 GB -> 7b"),
+                              prompt=lambda q: next(answers))
+    assert ctl.installed_called is True
+    assert ctl.served is True
+    assert ctl.pulled == "qwen2.5-coder:7b"
+    assert pf.ok is True and pf.chosen_model == "qwen2.5-coder:7b"
+
+
+def test_preflight_declined_install_exits_clean():
+    ctl = _Ctl(installed=False, daemon=False, models=[])
+    pf = onboarding.preflight(ctl, resources=lambda: ("qwen2.5-coder:7b", "x"),
+                              prompt=lambda q: "n")
+    assert pf.ok is False and ctl.served is None
+    assert "manual" in pf.message.lower() or "install" in pf.message.lower()
+
+
+def test_doctor_reports_each_check():
+    ctl = _Ctl(installed=True, daemon=True, models=["qwen2.5-coder:7b"])
+    report = onboarding.doctor(ctl, resources=lambda: ("qwen2.5-coder:7b", "ok"))
+    assert "ollama" in report.lower() and "model" in report.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_onboarding.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'aether_agent.onboarding'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# aether_agent/onboarding.py
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""First-run / preflight state machine for the Ollama-managed terminal.
+
+``preflight(ctl, ...)`` runs detect -> (install?) -> serve -> pick -> pull and
+returns a typed :class:`Preflight`. Silent and instant when everything is already
+healthy. ``prompt``/``resources``/``emit`` are injected so the flow is testable
+with no TTY, no network, no real Ollama. ``emit`` defaults to a no-op (quiet
+tests); ``repl.py`` passes a real writer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from aether_agent import hardware, progress
+
+Prompt = Callable[[str], str]
+Emit = Callable[[str], None]
+ResourcePick = Callable[[], "tuple[str, str]"]
+
+
+@dataclass
+class Preflight:
+    ok: bool
+    chosen_model: str | None = None
+    message: str = ""
+    steps: list[str] = field(default_factory=list)
+
+
+def _default_pick() -> "tuple[str, str]":
+    return hardware.best_fit(hardware.detect_resources())
+
+
+def preflight(
+    ctl: Any,
+    *,
+    resources: ResourcePick | None = None,
+    prompt: Prompt = lambda q: "",
+    emit: Emit = lambda s: None,
+) -> Preflight:
+    pick = resources or _default_pick
+    steps: list[str] = []
+
+    if not ctl.detect().get("installed"):
+        ans = prompt("Ollama not found. Install it now? [y/N] ").strip().lower()
+        if ans not in ("y", "yes"):
+            return Preflight(False, None, "Install Ollama manually: https://ollama.com/download", steps)
+        ok, detail = ctl.install(consent=True)
+        steps.append(progress.step("install ollama", ok))
+        emit(steps[-1] + "\n")
+        if not ok:
+            return Preflight(False, None, detail, steps)
+
+    if not ctl.detect().get("daemon_up"):
+        ok = ctl.ensure_serve()
+        steps.append(progress.step("start ollama serve", ok))
+        emit(steps[-1] + "\n")
+        if not ok:
+            return Preflight(False, None, "could not start ollama serve", steps)
+
+    installed = {m["tag"] for m in ctl.list_models()}
+    if installed:
+        return Preflight(True, sorted(installed)[0], "", steps)
+
+    tag, reason = pick()
+    emit(f"  recommended: {tag}  ({reason})\n")
+    ans = prompt(f"Pull {tag}? [Enter=yes / tag <x>] ").strip()
+    if ans.lower().startswith("tag "):
+        tag = ans[4:].strip() or tag
+    ok, detail = ctl.pull(tag, on_progress=lambda s, c, t: emit("\r" + progress.pull_line(tag, c, t)))
+    emit("\n" + progress.step(f"pull {tag}", ok) + "\n")
+    if not ok:
+        return Preflight(False, None, f"pull failed: {detail}", steps)
+    return Preflight(True, tag, "", steps)
+
+
+def doctor(ctl: Any, *, resources: ResourcePick | None = None) -> str:
+    """Report-only health check with exact fixes. Never starts/installs anything."""
+    pick = resources or _default_pick
+    det = ctl.detect()
+    models = [m["tag"] for m in ctl.list_models()] if det.get("daemon_up") else []
+    tag, reason = pick()
+    lines = [
+        "aether doctor",
+        progress.step("ollama installed", det.get("installed", False)),
+        progress.step("ollama daemon up", det.get("daemon_up", False)),
+        progress.step(f"a model is pulled ({len(models)})", bool(models)),
+        f"  recommended for this machine: {tag}  ({reason})",
+    ]
+    if not det.get("installed"):
+        lines.append("  fix: install -> https://ollama.com/download (or run /setup)")
+    elif not det.get("daemon_up"):
+        lines.append("  fix: start it -> run /setup (or `ollama serve`)")
+    elif not models:
+        lines.append(f"  fix: pull a model -> /pull {tag}")
+    return "\n".join(lines)
+
+
+__all__ = ["Preflight", "preflight", "doctor"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_onboarding.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/onboarding.py tests/test_onboarding.py
+git commit -m "feat(ollama): onboarding.py — preflight state machine + doctor report"
+```
+
+---
+
+## Task 6: `slash.py` — `/pull /setup /doctor /serve` + local-aware `/models`
+
+**Files:**
+- Modify: `aether_agent/slash.py` (add `ollama` to `SlashContext`; new handlers; registry; help)
+- Test: `tests/test_slash_ollama.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_slash_ollama.py
+from aether_agent.slash import SlashContext, dispatch
+
+
+class _Ctl:
+    def detect(self):
+        return {"installed": True, "daemon_up": True}
+    def list_models(self):
+        return [{"tag": "qwen2.5-coder:7b", "size_bytes": 5_000_000_000}]
+    def ps(self):
+        return []
+    def pull(self, tag, on_progress=None):
+        return (True, "success")
+
+
+def _ctx():
+    return SlashContext(api=None, authed=False, model="qwen2.5-coder:7b", ollama=_Ctl())
+
+
+def test_models_local_lists_installed_with_marker():
+    out = dispatch(_ctx(), "/models")["text"]
+    assert "qwen2.5-coder:7b" in out and "›" in out
+
+
+def test_doctor_dispatch():
+    assert "ollama" in dispatch(_ctx(), "/doctor")["text"].lower()
+
+
+def test_pull_dispatch_reports_result():
+    assert "qwen2.5-coder:7b" in dispatch(_ctx(), "/pull qwen2.5-coder:7b")["text"]
+
+
+def test_serve_dispatch_shows_daemon_state():
+    out = dispatch(_ctx(), "/serve")["text"].lower()
+    assert "up" in out or "running" in out
+
+
+def test_setup_dispatch_recognized_not_unknown():
+    res = dispatch(_ctx(), "/setup")
+    assert "text" in res and "unknown" not in res["text"].lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_slash_ollama.py -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'ollama'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/slash.py`)
+
+Add `ollama` field to `SlashContext` (immediately after the `web: Any = None` line):
+
+```python
+    ollama: Any = None  # an ollama_ctl.OllamaCtl (local lifecycle); None when cloud-only
+```
+
+Replace the existing `_models` function body with a local-first version, and add the new handlers (place after `_web`):
+
+```python
+def _models(ctx: SlashContext, arg: str) -> SlashResult:
+    if not ctx.authed and ctx.ollama is not None:
+        return _ollama_models(ctx)
+    if not ctx.authed:
+        return _text("(local Ollama — set a model with /model <tag>)")
+    payload = ctx.api.get_json(MODELS_PATH)
+    models = _items(payload, "models")
+    tier = (payload or {}).get("tier", "") if isinstance(payload, dict) else ""
+    lines: list[str] = []
+    if tier:
+        lines.append(f"tier: {tier}")
+    for i, m in enumerate(models, 1):
+        mid = str(m.get("id", ""))
+        label = str(m.get("label", "") or "")
+        mark = "›" if mid and mid == ctx.model else " "
+        lines.append(f"{mark} {i:>2}. {mid}\t{label}".rstrip())
+    lines.append("switch: /model <tag>")
+    return _text("\n".join(lines))
+
+
+def _ollama_models(ctx: SlashContext) -> SlashResult:
+    from aether_agent.hardware import CATALOG, best_fit, detect_resources
+
+    ctl = ctx.ollama
+    installed = {m["tag"] for m in ctl.list_models()} if ctl else set()
+    rec, _ = best_fit(detect_resources())
+    lines = ["local models (* installed, › current, ! recommended):"]
+    for m in CATALOG:
+        dot = "*" if m.tag in installed else " "
+        cur = "›" if m.tag == ctx.model else " "
+        star = "!" if m.tag == rec else " "
+        note = f"  [{m.license_note}]" if m.license_note else ""
+        lines.append(f"{dot}{cur}{star} {m.tag}\t{m.size_gb:g}GB\t{m.blurb}{note}")
+    for tag in sorted(installed):
+        if all(tag != m.tag for m in CATALOG):
+            cur = "›" if tag == ctx.model else " "
+            lines.append(f"*{cur}  {tag}\t(installed)")
+    lines.append("switch: /model <tag>   ·   pull: /pull <tag>")
+    return _text("\n".join(lines))
+
+
+def _pull(ctx: SlashContext, arg: str) -> SlashResult:
+    tag = arg.strip()
+    if not tag:
+        return _text("usage: /pull <tag>")
+    if ctx.ollama is None:
+        return _text("(pull is a local-Ollama command)")
+    ok, detail = ctx.ollama.pull(tag)
+    return _text(f"pull {tag}: {'ok' if ok else 'failed'} ({detail})")
+
+
+def _doctor(ctx: SlashContext, arg: str) -> SlashResult:
+    if ctx.ollama is None:
+        return _text("(doctor checks the local Ollama; not available in cloud-only mode)")
+    from aether_agent import onboarding
+    return _text(onboarding.doctor(ctx.ollama))
+
+
+def _serve(ctx: SlashContext, arg: str) -> SlashResult:
+    if ctx.ollama is None:
+        return _text("(serve status is a local-Ollama command)")
+    det = ctx.ollama.detect()
+    owned = bool(getattr(ctx.ollama, "_owned", False))
+    state = "up" if det.get("daemon_up") else "down"
+    return _text(f"ollama daemon: {state}{' (owned by this session)' if owned else ''}")
+
+
+def _setup(ctx: SlashContext, arg: str) -> SlashResult:
+    return {"setup": True, "text": "re-running setup…"}
+```
+
+Delete the OLD `_models` definition (there must be exactly one). Register the new commands in `REGISTRY` (after `"web": _web,`):
+
+```python
+    "pull": _pull,
+    "doctor": _doctor,
+    "serve": _serve,
+    "setup": _setup,
+```
+
+Add to `_HELP_LINES` (after the `/web` line):
+
+```python
+    "/pull <tag>        download/update a local model",
+    "/doctor            check the local Ollama setup",
+    "/serve             show the Ollama daemon state",
+    "/setup             re-run first-run setup",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_slash_ollama.py tests/test_slash.py -q`
+Expected: PASS (existing `test_slash.py` still green; new file green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/slash.py tests/test_slash_ollama.py
+git commit -m "feat(ollama): slash /pull /doctor /serve /setup + local-aware /models"
+```
+
+---
+
+## Task 7: `repl.py` — preflight on launch + tidy teardown + ctx.ollama
+
+**Files:**
+- Modify: `aether_agent/repl.py` (`main()`, `_make_ctx`, add `_build_ollama`/`_preflight` seams)
+- Test: `tests/test_repl_preflight.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_repl_preflight.py
+import io
+
+from aether_agent import repl
+
+
+def test_make_ctx_carries_ollama():
+    ctx = repl._make_ctx(authed=False, api=None, model="m", ollama="OLLAMA_SENTINEL")
+    assert ctx.ollama == "OLLAMA_SENTINEL"
+
+
+def test_main_runs_preflight_then_stops_owned(monkeypatch):
+    calls = {"preflight": 0, "stopped": 0}
+
+    class _Ctl:
+        def stop_owned(self):
+            calls["stopped"] += 1
+
+    monkeypatch.setattr(repl, "_build_ollama", lambda backend, authed: _Ctl())
+
+    def fake_preflight(c, **kw):
+        calls["preflight"] += 1
+        from aether_agent.onboarding import Preflight
+        return Preflight(True, "qwen2.5-coder:7b", "", [])
+
+    monkeypatch.setattr(repl, "_preflight", fake_preflight)
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))  # immediate EOF -> loop exits
+
+    rc = repl.main([])
+    assert rc == 0
+    assert calls["preflight"] == 1
+    assert calls["stopped"] == 1  # teardown ran in finally
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_repl_preflight.py -q`
+Expected: FAIL — `AttributeError: module 'aether_agent.repl' has no attribute '_build_ollama'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/repl.py`)
+
+Add imports near the other `aether_agent` imports:
+
+```python
+from aether_agent.ollama_ctl import OllamaCtl
+from aether_agent.onboarding import preflight as _preflight_impl
+```
+
+Add seams (module level, e.g. just above `_make_ctx`):
+
+```python
+def _build_ollama(backend: str, authed: bool) -> Any:
+    """The local Ollama controller, only when this session will serve locally."""
+    b = (backend or "auto").strip().lower()
+    if b == "cloud" or (b == "auto" and authed):
+        return None  # cloud session — no local daemon to manage
+    return OllamaCtl()
+
+
+def _preflight(ctl: Any, **kw: Any) -> Any:
+    return _preflight_impl(ctl, **kw)
+```
+
+Change `_make_ctx` to carry `ollama`:
+
+```python
+def _make_ctx(authed: bool, api: Any, model: str, ollama: Any = None) -> SlashContext:
+    return SlashContext(api=api, authed=authed, model=model, ollama=ollama)
+```
+
+In `main()`, replace everything from the splash write (`label = _backend_label(...)`) through the end of the `while True:` loop with the block below (adds preflight before the splash, threads `chosen_model`/`ollama`, wraps the loop in try/finally, and handles the `/setup` flag):
+
+```python
+    ollama = _build_ollama(backend, authed)
+    chosen_model = model
+    if ollama is not None:
+        pf = _preflight(ollama, emit=lambda s: _safe_write(out, s))
+        if not pf.ok:
+            _safe_write(out, f"\n{pf.message}\n")
+            ollama.stop_owned()
+            return 1
+        chosen_model = pf.chosen_model or model
+
+    label = _backend_label(backend, authed)
+    short_backend = "cloud" if "cloud" in label else "local"
+    _safe_write(out, render_splash(VERSION, chosen_model or "auto", short_backend) + "\n\n")
+    _safe_write(out, "Type a prompt, or /help for commands. /exit to quit.\n\n")
+
+    ctx = _make_ctx(authed, api, chosen_model, ollama)
+    is_tty = bool(getattr(sys.stdin, "isatty", lambda: False)())
+    if is_tty:
+        _enable_readline_history()
+
+    try:
+        while True:
+            try:
+                line = input(_PROMPT) if is_tty else _read_line()
+            except KeyboardInterrupt:
+                out.write("\n")
+                return 0
+            except EOFError:
+                out.write("\n")
+                return 0
+            if line is None:
+                return 0
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("/"):
+                res = dispatch(ctx, line)
+                if res.get("exit"):
+                    return 0
+                text = res.get("text")
+                if text:
+                    _safe_write(out, text + "\n")
+                if res.get("setup") and ollama is not None:
+                    pf = _preflight(ollama, emit=lambda s: _safe_write(out, s))
+                    ctx.model = pf.chosen_model or ctx.model
+                if res.get("restart"):
+                    ctx.authed = store.get() is not None
+                    _safe_write(out, "(session restarted — context cleared)\n")
+                continue
+            brain = select_brain(
+                authed=store.get() is not None,
+                backend=backend,
+                api=api,
+                model=ctx.model or chosen_model or "",
+            )
+            _run_turn(brain, line, out)
+            out.write("\n")
+    finally:
+        if ollama is not None:
+            ollama.stop_owned()
+```
+
+(`return` statements inside the `try` still run the `finally`, so teardown always fires.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_repl_preflight.py tests/test_cli_dispatch.py -q`
+Expected: PASS (preflight test green; existing REPL/cli tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/repl.py tests/test_repl_preflight.py
+git commit -m "feat(ollama): REPL preflight on launch + tidy serve teardown + ctx.ollama"
+```
+
+---
+
+## Task 8: `cli.py` — `aether doctor` / `aether setup`
+
+**Files:**
+- Modify: `aether_agent/cli.py` (`_SUBCOMMANDS`, dispatch, handlers, help)
+- Test: `tests/test_cli_doctor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cli_doctor.py
+from aether_agent import cli
+
+
+def test_doctor_subcommand_prints_report(capsys, monkeypatch):
+    class _Ctl:
+        def detect(self):
+            return {"installed": True, "daemon_up": True}
+        def list_models(self):
+            return [{"tag": "qwen2.5-coder:7b", "size_bytes": 1}]
+    monkeypatch.setattr(cli, "_ollama_ctl", lambda: _Ctl())
+    rc = cli.main(["doctor"])
+    out = capsys.readouterr().out.lower()
+    assert rc == 0 and "ollama" in out and "model" in out
+
+
+def test_setup_subcommand_runs_preflight(capsys, monkeypatch):
+    seen = {"preflight": 0}
+
+    class _Ctl:
+        def stop_owned(self):
+            pass
+    monkeypatch.setattr(cli, "_ollama_ctl", lambda: _Ctl())
+
+    def fake_preflight(ctl, **kw):
+        seen["preflight"] += 1
+        from aether_agent.onboarding import Preflight
+        return Preflight(True, "qwen2.5-coder:7b", "", [])
+    monkeypatch.setattr(cli, "_preflight", fake_preflight)
+    rc = cli.main(["setup"])
+    assert rc == 0 and seen["preflight"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_cli_doctor.py -q`
+Expected: FAIL — `AttributeError: module 'aether_agent.cli' has no attribute '_ollama_ctl'`
+
+- [ ] **Step 3: Write minimal implementation** (edit `aether_agent/cli.py`)
+
+Change `_SUBCOMMANDS` to include the two new commands:
+
+```python
+_SUBCOMMANDS = frozenset({"code", "brain", "auth", "models", "config", "doctor", "setup"})
+```
+
+Add seams + handlers (near the other `_cmd_*` functions):
+
+```python
+def _ollama_ctl():
+    from aether_agent.ollama_ctl import OllamaCtl
+    return OllamaCtl()
+
+
+def _preflight(ctl, **kw):
+    from aether_agent.onboarding import preflight
+    return preflight(ctl, **kw)
+
+
+def _cmd_doctor(rest: list[str]) -> int:
+    from aether_agent.onboarding import doctor
+    print(doctor(_ollama_ctl()))
+    return 0
+
+
+def _cmd_setup(rest: list[str]) -> int:
+    ctl = _ollama_ctl()
+    pf = _preflight(ctl, emit=lambda s: sys.stdout.write(s))
+    if not pf.ok:
+        print(f"\n{pf.message}", file=sys.stderr)
+        return 1
+    print(f"\nready — model: {pf.chosen_model}")
+    return 0
+```
+
+Wire into `main()` dispatch (after the `config` branch, before the `head.startswith("-")` check):
+
+```python
+    if head == "doctor":
+        return _cmd_doctor(args[1:])
+    if head == "setup":
+        return _cmd_setup(args[1:])
+```
+
+Add two lines to `_print_help()` (after the `config` line in the list):
+
+```python
+                "  aether doctor                check the local Ollama setup",
+                "  aether setup                 run first-run setup (install/serve/pull)",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/Scripts/python.exe -m pytest tests/test_cli_doctor.py tests/test_cli_dispatch.py -q`
+Expected: PASS (new green; existing cli dispatch tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aether_agent/cli.py tests/test_cli_doctor.py
+git commit -m "feat(ollama): aether doctor + aether setup subcommands"
+```
+
+---
+
+## Task 9: Full-suite green + boot smoke + push
+
+**Files:** full suite
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `.venv/Scripts/python.exe -m pytest -q`
+Expected: PASS — all prior tests (445+) plus the ~31 new tests from Tasks 1–8. Zero regressions.
+
+- [ ] **Step 2: Boot smoke (no Ollama needed — report path)**
+
+Run (bash): `AETHER_CONFIG_DIR="$(mktemp -d)" .venv/Scripts/python.exe -m aether_agent.cli doctor`
+Expected: an `aether doctor` report — `ollama installed`, `ollama daemon up`, `a model is pulled (N)`, a recommended model — no crash, exit 0.
+
+- [ ] **Step 3: Fix any cross-module wiring that is red, re-run**
+
+Common pitfalls: `SlashContext` field order (keep `ollama` last so existing positional callers are unaffected); `repl.main` early-returns must still hit the `finally` (they do — `return` inside `try`); the old `_models` left duplicated (there must be exactly one).
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "test(ollama): full-suite green after Ollama-wrapped terminal (sub-project A)"
+```
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin feat/ollama-wrapped-terminal
+```
+
+---
+
+## Self-review (author checklist — completed)
+
+- **Spec coverage:** full-manage ownership (Tasks 3,7) · consent-gated install (Tasks 3,4) · auto hardware-aware pick (Tasks 2,5) · tidy serve lifecycle (Task 3 `ensure_serve`/`stop_owned` + Task 7 `finally`) · onboarding flow (Task 5) · control surface (Task 3) · catalog/best-fit (Task 2) · TUI progress (Task 1) · slash `/models /model /pull /setup /doctor /serve` (Task 6) · install security (Tasks 3,4) · `/doctor` folds in the old doctor (Task 5) · per-unit offline tests (every task). All spec sections map to a task.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code. The full picker UI is an explicit scoped cut (Enter / `tag <x>` ships now), not a placeholder.
+- **Type consistency:** `OllamaCtl` methods (`detect/ensure_serve/stop_owned/list_models/pull/ps/remove/install`) identical across Tasks 3–8; `Preflight(ok, chosen_model, message, steps)` consistent in Tasks 5,7,8; `progress.step/pull_line/progress_bar` signatures match Tasks 1,5; `SlashContext(..., ollama=None)` matches Tasks 6,7; `_build_ollama`/`_preflight` seam names match Task 7 test + impl; `_ollama_ctl`/`_preflight` match Task 8 test + impl.
+- **Scope:** sub-project A only; B/C/D explicitly out.
+```

--- a/docs/superpowers/specs/2026-06-15-custom-commands-design.md
+++ b/docs/superpowers/specs/2026-06-15-custom-commands-design.md
@@ -1,0 +1,128 @@
+# Design Spec — Custom Local Commands (sub-project C)
+
+**Date:** 2026-06-15
+**Repo:** `unlimited-context-llm` (Python) · build branch (later): `feat/custom-commands` (off `main`)
+
+## Sub-project C of 4
+
+Part of "Claude Code for local". A = Ollama-wrapped terminal (merged). B = custom local agents (merged;
+reserved a per-agent `commands` dict, currently validated-empty). **C = custom command authoring**:
+users -- and the agent itself, via a tool -- create reusable slash commands for an agent. **D**
+(multi-agent `/agents` column dashboard + concurrent runs) is the separate next build.
+
+## Goal
+
+Let a user (or an agent) save a reusable **prompt-macro** on an agent -- a templated instruction that
+expands into an agent turn -- and invoke it as a plain slash command:
+
+```
+/agent jane cmd add review = Review $1 for bugs and suggest fixes
+# jane active:
+/review src/api.py   ->   runs jane on "Review src/api.py for bugs and suggest fixes"
+```
+
+## Locked decisions (from brainstorm)
+
+1. **Prompt-macro only.** A command = a string template that expands into an agent turn. No shell/script
+   bindings (no new execution surface). The expanded turn is still gated by the agent's tool-allowlist +
+   permission.
+2. **Both authoring paths.** Manual (`/agent <name> cmd add|list|remove`) AND a local-only
+   `define_command(name, template)` tool the agent may call mid-conversation (offered only when the
+   agent's `tools` include it). The tool writes only a macro (bounded self-modification).
+3. **Bare `/<name>` invocation, built-ins win.** Custom commands resolve as plain slashes only when an
+   agent is active AND the name is not a built-in. Built-ins always take precedence; an unknown name
+   with no matching custom command -> "unknown command". Cannot shadow a built-in.
+4. stdlib-only, cp1252-safe, ruff-clean. Reuses B (`agent_profile`, `agent_store`, `agent_slash`,
+   `agent_runner`, `slash`).
+
+## Architecture
+
+| File | Change |
+|---|---|
+| `aether_agent/agent_commands.py` | **New**: `valid_name(name)` (slug + not a reserved built-in), `expand(template, args)->str`, `add(agent, name, template)->Agent` / `remove(agent, name)->Agent` / `list_commands(agent)->dict`. |
+| `aether_agent/agent_profile.py` | **Mod**: `commands` becomes a validated `dict[str, str]` (name->template); drop the "must be empty" rule; add `ALLOWED_AGENT_TOOLS = tuple(TOOLS) + ("define_command",)` so an agent may list `define_command` in `tools` without breaking the bridge's canonical 8. |
+| `aether_agent/agent_slash.py` | **Mod**: add the `cmd` verb -> `/agent <name> cmd add|list|remove`; and `/agent <name> run <cmd> [args]` (run a command without switching). |
+| `aether_agent/slash.py` `dispatch` | **Mod**: when `cmd` is not in `REGISTRY` and `ctx.active_agent` is set and the active agent has a command of that name -> return `{"run_agent": {"name": active, "task": expand(template, args)}}`. Built-ins resolve first; truly-unknown still returns the friendly note. |
+| `aether_agent/agent_runner.py` | **Mod**: when `"define_command" in agent.tools`, inject its schema into the offered tools and handle the call in `_PolicyTools` (write the macro to the running agent's file via `agent_commands.add` + `agent_store.save`, then return a confirmation). `define_command` is **local-only** -- NOT added to `protocol.TOOLS` (the 8-tool bridge stays lockstep with aether-code). |
+
+## Command storage + schema
+
+`Agent.commands` = `{name: template}`:
+- `name`: a slug (`[a-z0-9][a-z0-9_-]*`) and **not** a reserved built-in. Reserved set (rejected):
+  `help, models, model, agents, agent, new-agent, orchestrator, orchestrators, tier, audit, web, clear,
+  exit, quit, pull, doctor, serve, setup, config`.
+- `template`: a non-empty string. Placeholders: `$1..$9` (positional args), `$*`/`$@` (all args joined
+  by space), `$$` -> literal `$`. Any unfilled `$N` -> empty string.
+
+`agent_profile.validate` now accepts a non-empty `commands` only if every key passes `valid_name` and
+every value is a non-empty string (else a problem is reported). The `define_command` tool is allowed in
+`tools` via `ALLOWED_AGENT_TOOLS` (the bridge schema in `headless.py` still advertises only the 8).
+
+## Template expansion (`agent_commands.expand`)
+
+`expand(template: str, args: list[str]) -> str`:
+- `$$` -> `$` (done first, protected).
+- `$1`..`$9` -> the i-th arg (1-based) or `""` if absent.
+- `$*` and `$@` -> all args joined by a single space.
+- Everything else is literal.
+- Pure, deterministic, no shell/eval. Result is the user-turn text passed to the agent.
+
+## Manual authoring (`agent_slash`, `cmd` verb)
+
+- `/agent jane cmd add <name> = <template>` (everything after `=` is the template; `=` required).
+- `/agent jane cmd list` -> the agent's commands (`name -> template`), or "(none)".
+- `/agent jane cmd remove <name>`.
+Each mutates the loaded `Agent` via `agent_commands` and saves through `agent_store`. Invalid name /
+empty template / reserved name -> a friendly error, no crash, no save.
+
+## Agent authoring (`define_command` tool)
+
+- Offered to the model ONLY when `"define_command" in agent.tools` (default agents do NOT include it;
+  the user opts in via `/agent jane set tools "<8 tools> define_command"`).
+- Signature advertised to the model: `define_command(name: str, template: str)`.
+- Handled in `agent_runner._PolicyTools.execute` (it knows the running agent): validates name+template,
+  writes via `agent_commands.add` + `agent_store.save`, reloads so the command is usable immediately,
+  returns `"[defined command /<name>]"` or `"[define_command refused: <reason>]"`.
+- **Bounded self-modification:** it can ONLY add a prompt-macro to the agent's own `commands` -- it
+  cannot change model/tools/permission/pool, and a macro grants no new execution capability (the macro's
+  turn is still gated by the agent's existing allowlist + permission).
+
+## Invocation (`slash.dispatch`)
+
+Resolution order for a `/<word> args` line:
+1. If `<word>` is a built-in in `REGISTRY` -> run it (built-ins always win).
+2. Else if `ctx.active_agent` is set and the active agent's `commands` has `<word>` ->
+   `{"run_agent": {"name": active, "task": expand(template, args)}}` (the REPL runs one turn).
+3. Else -> "(unknown command: /<word>) - try /help".
+`/agent <name> run <cmd> [args]` runs `<name>`'s command without switching (same expansion).
+
+## Security
+
+- Macros are templated **prompts** -- no shell, no eval, no file/network side effects at expansion time.
+- The resulting turn runs through `agent_runner` -> still bounded by the agent's tool-allowlist +
+  permission gate + the `Tools` cwd path-jail + `web` SSRF guard.
+- `define_command` is opt-in (allowlist), macro-only, and cannot escalate the agent's capabilities.
+- Reserved-name list prevents a custom command (user- or agent-authored) from shadowing a built-in.
+- cp1252-safe rendering throughout.
+
+## Testing (`pytest -q` + ruff, offline)
+
+- `tests/test_agent_commands.py` -- `valid_name` (slug ok; reserved rejected; bad chars rejected);
+  `expand` matrix (`$1..$9`, `$*`, `$@`, `$$`, missing args, no placeholders); `add`/`remove`/`list`
+  return new Agents and round-trip.
+- `tests/test_agent_profile_commands.py` -- `validate` accepts a good `{name: template}` map; rejects a
+  reserved name, an empty template, a non-string value; `define_command` is accepted in `tools`.
+- `tests/test_agent_slash_cmd.py` -- `/agent jane cmd add|list|remove`; reserved/invalid -> friendly
+  error, no save; `/agent jane run review x` -> run_agent with expanded task.
+- `tests/test_slash_custom_invoke.py` -- built-in wins over a custom of the same name; active agent's
+  custom `/review x` -> run_agent expansion; no active agent -> unknown; unknown name -> unknown.
+- `tests/test_agent_runner_define_command.py` -- `define_command` injected only when allowed; writes +
+  reloads the agent; refused (string, no save) when not in `tools`; cannot alter other fields.
+
+## Out of scope (C)
+
+- Shell/script command bindings (macro-only).
+- Global (non-agent) commands.
+- Named/typed/optional args (positional `$1..$9` + `$*` only).
+- Multi-agent concurrency + `/agents` columns (**D**).
+- Sharing a command separately from its agent (commands travel inside the agent JSON).

--- a/docs/superpowers/specs/2026-06-15-custom-local-agents-design.md
+++ b/docs/superpowers/specs/2026-06-15-custom-local-agents-design.md
@@ -1,0 +1,175 @@
+# Design Spec — Custom Local Agents (sub-project B)
+
+**Date:** 2026-06-15
+**Repo:** `unlimited-context-llm` (Python) · branch `feat/custom-local-agents` (off `main`, which now
+has sub-project A merged)
+
+## Sub-project B of 4
+
+Part of the "Claude Code for local" vision. A = Ollama-wrapped terminal (**merged to main**). This is
+**B = custom local agents**: a user creates named, shareable agents, each with its own model, its own
+Unlimited-Context memory pool, a persona, a visual identity, and tool/permission guardrails.
+
+- **C** (custom local *command* authoring) and **D** (multi-agent `/agents` column dashboard +
+  concurrent `/agent n1 [t] \ /agent n2 [t]`) are **separate later builds**. B keeps the `commands`
+  field as a reserved empty map and ships a simple `/agents` list, so C/D layer on cleanly.
+
+## Goal
+
+Let a user run `/new-agent jane`, customize her (model, memory, persona, look, tools), and then
+`/agent jane <task>` or switch to her — each agent a self-contained, shareable file with its own
+persistent memory. Also expose an `Agent` library API so apps embed agents in two lines.
+
+## Locked decisions (from brainstorm)
+
+1. **One file per agent.** Definition at `~/.config/aether/agents/<name>.json` (human-editable,
+   shareable by copying one small file). Memory pool is **separate local state** at
+   `~/.config/aether/agents/<name>/pool/` (not shared by default — it's big).
+2. **Customization surface:** persona+behavior, visual identity (accent / prompt symbol / banner),
+   and tool+permission policy. **No full color theme** (single accent suffices).
+3. **No effort tiers on local agents** — effort (`low/med/max/codepro`) is an **AetherCloud-only**
+   concept; `max_steps` is the local depth knob.
+4. **Unified `/agent <name> <verb>` grammar** (scales to C/D).
+5. stdlib-only, no new runtime deps. cp1252-safe output. Reuses the engine (`Session` per-agent
+   `pool_dir`/`pool_gb`/`separate`), `brains`, `Tools`, and A's `onboarding`/`ollama_ctl`.
+
+## Architecture — new `aether_agent/` modules
+
+| Module | Responsibility |
+|---|---|
+| `agent_profile.py` | `Agent` dataclass (all fields + defaults) + `from_dict`/`to_dict` + `validate()`. The library API surface. |
+| `agent_store.py` | path helpers (`agents_dir`, `agent_path(name)`, `agent_pool_dir(name)`) + `create/load/save/list/delete/exists` (file-per-agent, fail-soft on corrupt). |
+| `agent_runner.py` | build `Session(pool_dir=<agent pool>, pool_gb, pool_mode="separate")` + `Tools(allowlist)` + persona; run a task -> event stream (reusing `brains`/`agent.run_agent_events`); enforce `permission` + `max_steps`. |
+| `agent_slash.py` | parse + handle `/new-agent`, `/agents`, `/agent <name> [verb ...]`. Pure handlers returning `SlashResult`. |
+
+Wires into: `slash.py` (register the new commands + add `agents`/`active_agent` to `SlashContext`),
+`repl.py` (active-agent state; apply persona/accent/prompt/banner on switch; status bar shows the
+active agent). Re-export `Agent` from `aether_agent/__init__.py` for `from aether_agent import Agent`.
+
+## Agent definition (`agent_profile.py`)
+
+`~/.config/aether/agents/<name>.json`, every field default-filled on load (forward-compat). Synthetic
+example values shown:
+
+```json
+{
+  "name": "jane",
+  "model": "qwen2.5-coder:7b",
+  "pool_gb": 5,
+  "persona": "You are Jane, a blunt coding assistant.",
+  "verbosity": "normal",
+  "show_tools": true,
+  "accent": "cyan",
+  "prompt": "jane > ",
+  "banner": "~ Jane ~",
+  "tools": ["read_file", "write_file", "run_shell", "run_tests", "repo_search", "git_commit", "web_search", "web_fetch"],
+  "permission": "ask",
+  "max_steps": 40,
+  "commands": {}
+}
+```
+
+`validate(agent) -> list[str]` (returns problems; empty = ok):
+- `name` = a slug (`[a-z0-9][a-z0-9_-]*`), non-empty.
+- `model` = non-empty string.
+- `pool_gb` = int >= 1.
+- `verbosity` in `{terse, normal, verbose}`; `permission` in `{ask, auto, skip}`.
+- `accent` in a fixed palette (`{cyan, green, magenta, yellow, blue, red, white, dim}`).
+- `tools` subset of the canonical 8 (`protocol.TOOLS`); unknown tool = error.
+- `max_steps` = int in `[1, 500]`.
+- `prompt`/`banner`/`persona` = strings; rendered cp1252-safe.
+- `commands` = dict (reserved for C; must be empty in B — a non-empty `commands` is allowed to load
+  but is ignored by B and flagged as "reserved for a future release").
+
+No `effort` field. `Agent` is a frozen dataclass with `set(**fields)` returning a NEW validated copy
+(immutability per house style).
+
+## Per-agent memory pool (`agent_store.py` + `agent_runner.py`)
+
+- `agent_pool_dir(name)` = `agents_dir()/<name>/pool/` (created lazily on first run).
+- `agent_runner.run(agent, task, ...)` opens `Session(model=f"ollama/{agent.model}", pool_gb=agent.pool_gb,
+  pool_dir=agent_pool_dir(agent.name), pool_mode="separate")` -> each agent has its **own persistent
+  Unlimited-Context memory** across sessions (the engine reopens the pool dir).
+- `/agent <name> set memory <gb>` updates `pool_gb` and saves; the engine re-indexes non-destructively
+  on next open (it already supports resize/reopen).
+- Deleting an agent removes its `<name>.json`; its `<name>/pool/` is kept unless `delete ... --purge`.
+
+## Commands (`agent_slash.py`)
+
+| Command | Action |
+|---|---|
+| `/new-agent <name>` | Create with defaults if absent (then customize via `set`); error if the name exists or is invalid. |
+| `/agents` | List agents: `name  -  model  -  Npool GB  -  * active`. Simple list (D adds columns). |
+| `/agent <name>` | Switch the active agent -> REPL applies its persona/model/accent/prompt/banner. |
+| `/agent <name> <task>` | Run `<task>` once on `<name>` **without switching** (build a runner, render the event stream). The seam **D** parallelizes. |
+| `/agent <name> set <key> <val>` | Configure (`model, memory->pool_gb, persona, accent, prompt, banner, verbosity, show_tools, permission, max_steps, tools`); validate, save, report. |
+| `/agent <name> edit` | Open `<name>.json` in `$EDITOR` (best-effort; fallback: print the path). |
+| `/agent <name> show` | Print the agent's resolved config. |
+| `/agent <name> delete [--purge]` | Remove the agent file (and its pool with `--purge`); confirm-gated. |
+
+Grammar parse: split the line after `/agent` into `name` + `rest`. If `rest` is empty -> switch. If
+`rest[0]` in known verbs (`set/edit/show/delete`) -> that verb. Else -> treat `rest` as a one-shot task.
+Unknown agent name -> helpful error (never raises). Handlers are pure (return `SlashResult`), so the
+whole surface is unit-testable with no TTY/Ollama.
+
+## Customizable UX application (`repl.py`)
+
+On `/agent <name>` switch, the REPL stores the active agent and applies:
+- **prompt** symbol (`agent.prompt`) replaces the default `aether > `.
+- **accent** -> an ANSI color from the fixed palette (cp1252-safe; degrades to no-color on dumb terms).
+- **banner** printed once on switch (cp1252-safe; skipped if empty).
+- **persona** -> the system prompt for that agent's turns.
+- **verbosity** + **show_tools** -> render filter (terse hides tool lines + trims monologue; verbose
+  shows reasoning).
+- **tools** / **permission** / **max_steps** -> passed into `agent_runner`.
+With no active agent, the REPL behaves exactly as today (the A baseline). The status bar shows the
+active agent name + model + pool.
+
+## Library API (`from aether_agent import Agent`)
+
+```python
+a = Agent.create("jane", model="qwen2.5-coder:7b", pool_gb=10, persona="...")  # validates + saves
+a = Agent.load("jane")
+a = a.set(pool_gb=10, permission="auto"); a.save()
+for ev in a.run("summarize the repo"): ...   # its own persistent memory; yields brain events
+names = Agent.list()                          # -> ["jane", "neo"]
+a.delete(purge=False)
+```
+
+`Agent.run` builds a runner under the hood; `create`/`load`/`save`/`list`/`delete` proxy `agent_store`.
+Two-line embed for an app: `Agent.load("jane").run(task)`.
+
+## Permission modes (`agent_runner.py` tool loop)
+
+- `ask` — confirm before `write_file` / `run_shell` / `git_commit` (TTY prompt; non-TTY -> deny + note).
+- `auto` — read-class tools run freely; destructive tools confirmed (TTY) or denied (non-TTY).
+- `skip` — fully autonomous (no prompts).
+The existing `Tools` path-jail (cwd) and `web` SSRF guards still apply underneath, regardless of mode.
+The library default uses the agent's stored mode.
+
+## Testing (`pytest -q`, offline — no Ollama/network)
+
+- `tests/test_agent_profile.py` — defaults fill-in; `validate()` catches bad enum / non-subset tools /
+  `pool_gb<1` / bad name / `max_steps` out of range; `from_dict`/`to_dict` roundtrip; `set()` returns a
+  new validated copy; an `effort` key (if present in a file) is ignored.
+- `tests/test_agent_store.py` — `create/load/save/list/delete/exists` under a tmp `AETHER_CONFIG_DIR`;
+  path layout (`<name>.json`, `<name>/pool/`); corrupt JSON -> fail-soft (raises a clear error, not a
+  crash); `delete --purge` removes the pool dir, default keeps it.
+- `tests/test_agent_runner.py` — builds a `Session` with the right `pool_dir`/`pool_gb`/`separate`
+  (inject a fake `Session` + fake brain); `tools` allowlist is enforced (a disallowed tool is refused);
+  `permission=skip` runs without prompting; `max_steps` is passed through.
+- `tests/test_agent_slash.py` — grammar matrix: `/agent jane` (switch), `/agent jane "task"` (run),
+  `/agent jane set memory 10` (config+save), `/agent jane set tools ...`, `/new-agent jane`, `/agents`,
+  unknown verb/name; dispatch with a fake store + fake runner (no Ollama).
+- `tests/test_agent_library.py` — `Agent.create/load/list/set/save/delete` roundtrip; `run()` over a
+  fake runner yields events.
+- `tests/test_repl_agent_switch.py` — light: switching applies the agent's prompt + accent + persona
+  (monkeypatched store/runner, no real turn).
+
+## Out of scope (B)
+
+- Custom command **authoring** UX (**C**) — the `commands` field exists but is empty/ignored.
+- Multi-agent concurrency + `/agents` **column dashboard** (**D**) — B ships a simple list.
+- Full per-role color theme (deferred; single accent only).
+- Effort tiers (**AetherCloud-only**, never local).
+- Sharing/installing an agent FROM a URL/registry (just copy the JSON file in v1).

--- a/docs/superpowers/specs/2026-06-15-multi-agent-design.md
+++ b/docs/superpowers/specs/2026-06-15-multi-agent-design.md
@@ -1,0 +1,132 @@
+# Design Spec — Multi-Agent (sub-project D)
+
+**Date:** 2026-06-15
+**Repo:** `unlimited-context-llm` (Python) · build branch (later): `feat/multi-agent` (off `main`)
+
+## Sub-project D of 4 (final)
+
+Part of "Claude Code for local". A = Ollama-wrapped terminal (merged). B = custom local agents (merged).
+C = custom commands (spec+plan written). **D = multi-agent**: (1) `/agents` shows a **column dashboard**
+of the user's agents, and (2) run **several agents at once** concurrently with live labeled output.
+
+## Goal
+
+```
+/agents                                  -> a column dashboard of all agents + stats
+/agent jane fix the tests \ /agent neo write the docs
+   -> jane and neo run AT THE SAME TIME, output streamed live, labeled per agent
+```
+
+## Locked decisions (from brainstorm)
+
+1. **Labeled interleaved stream** for concurrent output. Run N agents in daemon **threads** (`OllamaChat`
+   is HTTP I/O-bound -> the GIL releases during the request -> real parallelism, the same pattern the
+   engine's prefetch already uses). Each event is printed `[name] ...` colored by the agent's accent,
+   streamed live; a per-agent summary at the end. **No full-screen pane TUI** (the line-based REPL has no
+   raw-mode renderer; that lives in the TS host).
+2. **Shared cwd, write-gated.** Concurrent agents share one cwd; reads/search/web run free in parallel,
+   but `write_file`/`run_shell`/`git_commit` are serialized through one shared lock (one writer at a
+   time) so edits can't interleave mid-write. Each agent keeps its **own** memory pool (isolated).
+3. **`/agents` = static columns** (agent cards side by side). **Grammar** = ` \ `-separated
+   `/agent <name> <task>` segments launch concurrently.
+4. Cap concurrent agents at **8**. stdlib-only (`threading`, `queue`), cp1252-safe, ruff-clean. Reuses
+   B/C (`agent_profile`, `agent_store`, `agent_runner`, `agent_slash`, `repl`, `ACCENTS`).
+
+## Architecture
+
+| File | Change |
+|---|---|
+| `aether_agent/agents_view.py` | **New**: pure `render_agents_columns(rows, active, width)` -- side-by-side agent cards (`name`/`model`/`Npool GB`/`Ncmds`/`* active`), wrapped N-per-row to terminal width. |
+| `aether_agent/multi_runner.py` | **New**: `run_many(jobs, emit, confirm)` -- a daemon thread per `(agent, task)` running `agent_runner.run(..., write_lock=shared)`, pushing `(label, event)` to a `queue.Queue`; the caller's `emit(label, event)` is called on the main thread as events drain; returns per-agent summaries. Caps at 8. |
+| `aether_agent/agent_runner.py` | **Mod**: `run(..., write_lock=None)`; `_PolicyTools` takes `write_lock` and acquires it around DESTRUCTIVE tools when set. |
+| `aether_agent/agent_slash.py` | **Mod**: `/agents` returns `agents_view.render_agents_columns(...)` instead of the B simple list. |
+| `aether_agent/repl.py` | **Mod**: split a REPL line on ` \ `; if >=2 segments parse to `/agent <name> <task>` runs, launch them via `multi_runner.run_many` with labeled rendering; otherwise the existing single path. |
+
+## Concurrency model (`multi_runner.py`)
+
+`run_many(jobs: list[tuple[Agent, str]], *, emit, confirm=None, cwd=".") -> list[dict]`:
+- `jobs` capped to the first 8.
+- one shared `write_lock = threading.Lock()` and a `queue.Queue()`.
+- per job, a daemon thread runs:
+  `for ev in agent_runner.run(agent, task, cwd=cwd, confirm=confirm or _deny, write_lock=write_lock): q.put((agent.name, ev))`,
+  then `q.put((agent.name, {"type": "_thread_done"}))`.
+- the main thread drains `q`: for each `(label, ev)` with a real type, call `emit(label, ev)`; track
+  `_thread_done` to know when all threads finished; collect a small summary per agent (final `done`
+  text + a tool-call count).
+- returns `[{"name", "ok", "summary", "tool_calls"}]`.
+- `emit` runs on the MAIN thread only (no concurrent terminal writes) -- the queue is the single
+  serialization point, so rendering is race-free.
+
+## Write-gating (`agent_runner._PolicyTools`)
+
+- `run(agent, task, *, ..., write_lock=None)` threads `write_lock` into `_PolicyTools`.
+- `_PolicyTools.execute`: for a DESTRUCTIVE tool (`write_file`/`run_shell`/`git_commit`), if a
+  `write_lock` is set, wrap the inner `execute` in `with self._write_lock:` so only one concurrent agent
+  writes at a time. Reads/search/web are NOT locked (parallel). When `write_lock` is None (single-agent
+  path), behavior is unchanged.
+- The existing per-agent permission gate + `Tools` cwd path-jail still apply underneath.
+
+## Labeled rendering (`repl.py`)
+
+`emit(label, ev)` -> `_render_labeled(label, ev, accent_ansi, out)`:
+- prefix every output line with `[label] ` where `[label]` is colored by the agent's accent (reuse
+  `agent_profile.ACCENTS`), reset after.
+- render `monologue`/`tool_call`/`tool_result`/`done` the same way single runs do, but prefixed.
+- cp1252-safe (`_safe_write`).
+After `run_many` returns, print a `--- done ---` block: one line per agent (`name: <summary>`).
+
+## `/agents` dashboard (`agents_view.py`)
+
+`render_agents_columns(rows: list[dict], active: str = "", width: int = 80) -> str`:
+- `rows` = `[{"name", "model", "pool_gb", "n_commands"}]` (built by `agent_slash._agents` from
+  `agent_store.list_agents()` + `load`).
+- each agent = a fixed-width card (e.g. 24 cols):
+  ```
+  * jane            <- accent, * = active
+    qwen2.5-coder:7b
+    5 GB . 2 cmds
+  ```
+- lay cards side by side, `floor(width / card_width)` per row, wrapping to more rows as needed.
+- pure + deterministic + cp1252-safe (ASCII separators). No live refresh.
+
+## Grammar (`repl.py`)
+
+- Split the raw line on ` \ ` (space-backslash-space). If the result has >=2 parts AND each part (after
+  trimming a leading `/`) starts with `agent <name> <task...>` (a run, not a verb like set/show) ->
+  build `jobs` = `[(Agent.load(name), task)]` and call `run_many`.
+- A single `/agent <name> <task>` (no ` \ `) stays the existing B single-run path.
+- A bad segment (unknown agent / not a run) -> a friendly error for that segment; the valid ones still
+  run. If <2 valid run-jobs, fall back to dispatching each segment normally (sequential).
+
+## Security / safety
+
+- Concurrency is bounded (<=8) so a stray line can't fork 50 Ollama calls.
+- The shared write-lock prevents torn/interleaved file writes; per-agent permission + path-jail + web
+  SSRF guard are unchanged and still enforced inside each thread.
+- All terminal writes happen on the main thread (queue-serialized) -- no interleaved/garbled output.
+- Each agent's memory pool is separate (`pool_mode="separate"`, distinct `pool_dir`) -- no cross-agent
+  memory bleed.
+- cp1252-safe throughout.
+
+## Testing (`pytest -q` + ruff, offline)
+
+- `tests/test_agents_view.py` -- `render_agents_columns`: single + multiple agents, active marker, width
+  wrapping (cards per row), empty list, cp1252 encodability. Pure, deterministic.
+- `tests/test_agent_runner_lock.py` -- with a `write_lock` injected (a recording lock), a DESTRUCTIVE
+  tool acquires it and a read tool does not; without a lock, behavior is unchanged.
+- `tests/test_multi_runner.py` -- `run_many` with a FAKE `agent_runner.run` (monkeypatched) yielding a
+  scripted event list per agent: assert every agent's events reach `emit` labeled with its name, all
+  agents complete, summaries returned; the >8 cap drops extras; a fake destructive tool through a shared
+  recording lock proves one-writer-at-a-time.
+- `tests/test_repl_multi.py` -- a ` \ `-joined line parses into 2 jobs and calls `run_many`
+  (monkeypatched); a single `/agent` line does NOT; an unknown-agent segment degrades gracefully.
+- `tests/test_agent_slash_agents_columns.py` -- `/agents` returns the column view containing each
+  agent's name + model.
+
+## Out of scope (D)
+
+- Live full-screen column **panes** (raw-mode TUI) -- labeled-interleaved instead.
+- Per-agent worktree isolation (shared cwd + write-lock instead).
+- More than 8 concurrent agents.
+- Cross-agent coordination/messaging (each runs its task independently).
+- A live-refreshing dashboard (static snapshot only).

--- a/docs/superpowers/specs/2026-06-15-ollama-wrapped-terminal-design.md
+++ b/docs/superpowers/specs/2026-06-15-ollama-wrapped-terminal-design.md
@@ -1,0 +1,174 @@
+# Design Spec — Ollama-wrapped Terminal ("Claude Code for local")
+
+**Date:** 2026-06-15
+**Repo:** `unlimited-context-llm` (Python) · branch `feat/ollama-wrapped-terminal`
+**Base:** stacked on `feat/native-terminal-mirror` (uses its `aether_agent/repl.py`, `slash.py`,
+`statusbar.py`, `splash.py`, `adapter.py`). Land/rebase that branch first, or keep stacked.
+
+## Sub-project A of 4
+
+This is the **foundation** of a larger vision ("Claude Code for local"): a beautiful, clean local
+agent terminal. The full vision decomposes into:
+
+- **A — Ollama-wrapped terminal (THIS SPEC):** the terminal owns the whole Ollama lifecycle so the
+  user never touches raw Ollama.
+- B — Custom local agents (saved/shareable profile + own memory pool + effort + persona).
+- C — Custom local commands (user/agent-defined slash commands).
+- D — Multi-agent concurrency + `/agents` column dashboard (run several agents at once).
+
+B/C/D are **out of scope here** and get their own spec → plan → build. A ships standalone.
+
+## Goal
+
+Make `aether` (the Python terminal in `aether_agent/`) **own the full Ollama lifecycle** and feel like
+Claude Code: detect/install Ollama, supervise the daemon, pick a model that fits the machine, pull it
+with a live progress bar, and drop the user into a clean REPL — **zero second terminal, zero raw
+`ollama` commands required**.
+
+## Locked decisions (from brainstorm)
+
+1. **Ownership = full manage.** Terminal detects Ollama; if missing, offers a **consent-gated** install;
+   supervises `ollama serve` (starts if down); pulls/switches/removes models. Install + serve are always
+   shown before they run.
+2. **Model onboarding = auto, hardware-aware.** Detect RAM/VRAM → pick best-fitting curated model →
+   one keystroke to accept + pull → change later with `/model`.
+3. **serve lifecycle = tidy.** If the daemon was already running, leave it. If WE started it, stop it on
+   exit (track ownership). No orphan daemons, no surprise.
+4. **Scope = UCL (Python) only.** The TS `aether-code` already connects to a user-run Ollama; managing
+   the daemon from Node is a separate later mirror if wanted.
+5. stdlib-only, no new runtime deps.
+
+## Architecture — new `aether_agent/` modules
+
+| Module | Purpose | Talks to |
+|---|---|---|
+| `ollama_ctl.py` | Lifecycle surface: `detect()`, `install(consent)`, `ensure_serve()` / `stop_owned()`, `list_models()`, `pull(tag, on_progress)`, `ps()`, `remove(tag)` | HTTP `:11434` (`/api/tags`, `/api/pull` stream, `/api/ps`, `/api/delete`) + `subprocess` (install, `serve`) |
+| `hardware.py` | RAM/VRAM detection (fail-soft) + curated model catalog + `best_fit(ram, vram) -> (tag, reason)` | OS only |
+| `onboarding.py` | First-run / preflight state machine: detect → (install?) → serve → pick → pull → ready; idempotent (`/setup`, `aether doctor`) | the two above |
+| `progress.py` | cp1252-safe progress bar + spinner + step lines; single-line live `\r` updates | — |
+
+Wires into existing: `repl.py` (preflight on launch, silent when healthy; status bar; exit hook for
+`stop_owned`), `slash.py` (new commands), `statusbar.py` (daemon+model fields), `adapter.py` (reuses
+`OllamaChat`, `DEFAULT_HOST`). New CLI entry behavior in `cli.py`: `aether doctor` / `aether setup`.
+
+### Reuse (do not duplicate)
+- `adapter.DEFAULT_HOST` (`http://localhost:11434`), `OllamaChat`.
+- `smoke._ollama_up` probe pattern (lift the health-probe helper into `ollama_ctl`).
+- README tier math + `adapter.py` model notes (Gemma3 license caveat) for the catalog.
+- The existing `aether-context doctor` logic (Ollama/model/disk/RAM) — fold its checks into `/doctor`.
+
+## Preflight / onboarding flow (`onboarding.py`)
+
+Runs on every launch; **silent and instant when everything is green**.
+
+```
+detect ollama -- installed? --no--> [Install Ollama? y/N]
+     | yes                                |  y                   |  n
+     |                                    install(consent)       print manual link, exit clean (rc 0)
+     |                                    (official src, see Install Security)
+     v
+ensure serve -- up? --no--> start `serve` (mark OWNED) --> health-poll until ready (timeout->clean error)
+     | yes (not owned)
+     v
+model present? --no--> hardware.best_fit() --> [Enter pull . m pick . tag <x>] --> pull(stream %)
+     | yes
+     v
+ready --> REPL (status bar: model . daemon . pool)
+exit  --> if OWNED: stop_owned() . else: leave running
+```
+
+- Re-runnable as `/setup`.
+- `/doctor` = the same checks, **report-only**, prints exact fixes (e.g. `ollama pull <tag>`, disk free,
+  RAM/VRAM, pool reach) — supersedes/folds in `aether-context doctor`.
+- State machine returns a typed result `(ok: bool, steps: list[Step], chosen_model: str|None)` so it is
+  testable without a TTY and so `repl.py` can render it.
+
+## Ollama control surface (`ollama_ctl.py`)
+
+- `detect()` -> `{installed: bool, version: str|None, daemon_up: bool}`. `installed` = `ollama` on PATH
+  (or known install dir); `daemon_up` = `/api/tags` answers.
+- `ensure_serve()` -> probe `/api/tags`; if down, `subprocess.Popen(["ollama","serve"])`, set
+  `self._owned = True`, poll `/api/tags` until healthy (bounded; clean error on timeout). If already up,
+  `self._owned = False`. `stop_owned()` terminates the child **only if** `_owned`.
+- `pull(tag, on_progress)` -> POST `/api/pull` `{name:tag, stream:true}`; read NDJSON lines
+  `{status, completed?, total?}`; call `on_progress(status, completed, total)` per line -> drives the bar.
+  Returns ok/err; never raises into the UI loop.
+- `list_models()` -> `/api/tags` -> installed `[{tag, size_bytes}]`. `ps()` -> `/api/ps` (loaded models).
+  `remove(tag)` -> `/api/delete`.
+- `install(consent: bool)` -> see Install Security. Returns `(ok, detail)`; refuses without consent.
+
+All HTTP via `urllib` (stdlib); all subprocess via `subprocess`. HTTP + `Popen` are **injectable seams**
+(constructor args / module-level overridable) so tests run offline with no real Ollama.
+
+## Hardware-aware pick + catalog (`hardware.py`)
+
+- `detect_resources()` -> `{ram_gb: float, vram_gb: float|None, gpu: str|None}`, **fail-soft** ->
+  conservative default `{8.0, None, None}` on any error. Stdlib only:
+  - Windows: RAM via `ctypes.windll.kernel32.GlobalMemoryStatusEx`; VRAM via `nvidia-smi` if present, else
+    `wmic path win32_VideoController get AdapterRAM` (best-effort).
+  - Linux: RAM `/proc/meminfo`; VRAM `nvidia-smi` / `/sys/class/drm/*/device/mem_info_vram_total`.
+  - macOS: RAM `sysctl hw.memsize`; VRAM `system_profiler SPDisplaysDataType` (best-effort).
+- **Catalog** (curated, ordered small->large), each entry:
+  `{tag, size_gb, min_ram_gb, gpu_pref: bool, license_note: str|None, blurb}`:
+  - `qwen2.5-coder:7b` — 4.7 GB — min 8 — universal, fits 8 GB GPU — **default floor**
+  - `gemma3n:e4b` — 3.3 GB — min 6 — light machines — *Gemma3 = custom license -> never auto-default*
+  - `qwen3-coder:30b` — ~24 GB — min 24 — depth build (256K ctx, Apache-2.0)
+  - (catalog is data — extendable; pin Apache/permissive as the auto-default-eligible set)
+- `best_fit(ram, vram)` -> largest catalog model whose `min_ram_gb <= effective_available`, where
+  `effective_available = vram if gpu_pref and vram else ram*0.7` (leave ~30 % headroom); skip
+  license-flagged models for the auto-pick; return `(tag, reason_str)`. Never returns a flagged or
+  oversized model as the auto-default.
+- Drives the onboarding pick **and** `/models` (catalog + installed + current + fit yes/no).
+
+## TUI + slash (`progress.py`, `slash.py`, `statusbar.py`)
+
+- `progress_bar(frac, width=24)` -> `[######------] 51%`; ASCII-safe (`#`/`-`), cp1252-safe.
+- `spinner()` frames + `step(label, ok)` -> `[ok] <label>` / `... <label>` (ASCII under cp1252).
+- Pull renderer: single-line live `\r` update — `qwen2.5-coder:7b   2.4 / 4.7 GB   51%` — no scroll spam.
+- Status bar (extend `statusbar.py`): `model . daemon(up|owned) . pool reach . hit%`.
+- New slash commands (registered in `slash.py`, dispatch-pure where possible):
+  - `/models` — catalog + installed + current + fit marks.
+  - `/model <tag>` — switch active model; pull-if-missing (progress); clears context.
+  - `/pull <tag>` — pull/update a model (progress bar).
+  - `/setup` — re-run onboarding.
+  - `/doctor` — health report + exact fixes.
+  - `/serve` — daemon status (up? owned? pid).
+- Aesthetic: muted palette (cyan accent, dim secondary), aligned columns, splash on entry showing the
+  active model + daemon state. Minimal color, ASCII-safe (consistent with the cp1252 rule already in
+  `splash.py`/`smoke.py`).
+
+## Install security (CRITICAL)
+
+- **Consent-gated, never silent.** The only auto-download is the **official** Ollama installer from a
+  **pinned official host** (`ollama.com` / official `github.com/ollama/ollama` releases), **https-only**.
+- Flow: detect missing -> show URL + version that will run -> require explicit `y` -> download to a temp
+  file -> verify (HTTPS + official host; checksum where the project publishes one) -> run installer ->
+  re-detect. No consent -> print the manual link and exit cleanly.
+- Windows: official `OllamaSetup.exe`. macOS/Linux: fetch the official `install.sh`, show its host, run on
+  consent — **no silent pipe-to-shell**. Always offer "I'll install it myself" with the link.
+- Reject any non-official URL/host/scheme. No elevation/sudo without telling the user. If verification is
+  unavailable on a platform -> fall back to the manual link (never run unverified).
+
+## Testing (`pytest -q`, offline — no real Ollama/network)
+
+- `tests/test_ollama_ctl.py` — inject HTTP + `Popen` seams: `detect`, `ensure_serve` (owned-tracking:
+  owned when we start it, not-owned when already up, `stop_owned` only kills owned), `pull` (NDJSON
+  stream -> progress callback sequence), `list_models`/`ps`/`remove`.
+- `tests/test_hardware.py` — inject the RAM/VRAM probes: `best_fit()` matrix (8 GB no-GPU -> 7b; 32 GB ->
+  30b; 6 GB -> e4b but never the license-flagged one as auto-default; GPU-preferred path) + fail-soft
+  default on probe error.
+- `tests/test_onboarding.py` — drive the state machine with fakes: full path (missing -> install-consent ->
+  serve -> pick -> pull -> ready), idempotent (healthy -> silent no-op), consent-decline -> clean exit (rc 0).
+- `tests/test_progress.py` — pure render (frac -> bar string; cp1252 encodability).
+- `tests/test_slash_ollama.py` — `/models`, `/model`, `/pull`, `/doctor`, `/serve` dispatch with a fake
+  `ollama_ctl` (no network).
+- `tests/test_install_security.py` — no consent -> no download; non-official host -> refused; verify-or-
+  fallback path.
+- Gate: `.venv/Scripts/python.exe -m pytest -q`. Follow-up: `aether-smoke` gains an `ollama-managed`
+  check (or `/doctor` covers it).
+
+## Out of scope (A)
+
+Sub-projects B/C/D (agents, custom commands, multi-agent columns); the TS `aether-code` daemon-manage
+mirror; GPU-accelerated model auto-tuning; non-Ollama local backends (llama.cpp/HF already exist in
+`aether_context.local_llm` but are not wrapped by this onboarding in v1).

--- a/tests/test_agent_commands.py
+++ b/tests/test_agent_commands.py
@@ -1,0 +1,36 @@
+# tests/test_agent_commands.py
+import pytest
+
+from aether_agent import agent_commands
+from aether_agent.agent_profile import Agent
+
+
+def test_valid_name():
+    assert agent_commands.valid_name("review")
+    assert not agent_commands.valid_name("help")       # reserved
+    assert not agent_commands.valid_name("Bad Name")   # not a slug
+
+
+def test_expand_positional_all_and_dollar():
+    assert agent_commands.expand("Review $1 and $2", ["a.py", "b.py"]) == "Review a.py and b.py"
+    assert agent_commands.expand("all: $*", ["x", "y", "z"]) == "all: x y z"
+    assert agent_commands.expand("all: $@", ["x", "y"]) == "all: x y"
+    assert agent_commands.expand("cost $$5 for $1", ["a"]) == "cost $5 for a"
+    assert agent_commands.expand("missing $3 here", ["a"]) == "missing  here"  # absent -> ""
+    assert agent_commands.expand("no placeholders", []) == "no placeholders"
+
+
+def test_add_remove_list_roundtrip():
+    a = Agent.from_dict({"name": "jane"})
+    a = agent_commands.add(a, "review", "Review $1 for bugs")
+    assert agent_commands.list_commands(a) == {"review": "Review $1 for bugs"}
+    a = agent_commands.remove(a, "review")
+    assert agent_commands.list_commands(a) == {}
+
+
+def test_add_rejects_bad_name_and_empty_template():
+    a = Agent.from_dict({"name": "jane"})
+    with pytest.raises(ValueError):
+        agent_commands.add(a, "help", "x")        # reserved
+    with pytest.raises(ValueError):
+        agent_commands.add(a, "ok", "   ")        # empty template

--- a/tests/test_agent_library.py
+++ b/tests/test_agent_library.py
@@ -1,0 +1,31 @@
+# tests/test_agent_library.py
+import pytest
+
+from aether_agent import Agent  # the public library API
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_create_load_list_set_save_delete_roundtrip():
+    a = Agent.create("jane", model="qwen2.5-coder:7b", pool_gb=8)
+    assert a.pool_gb == 8
+    assert Agent.list() == ["jane"]
+    b = Agent.load("jane").set(pool_gb=12)
+    b.save()
+    assert Agent.load("jane").pool_gb == 12
+    b.delete()
+    assert Agent.list() == []
+
+
+def test_run_streams_via_runner(monkeypatch):
+    Agent.create("jane")
+
+    def fake_run(agent, task, **kw):
+        yield {"type": "done", "text": f"{agent.name}:{task}"}
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    out = list(Agent.load("jane").run("hi"))
+    assert out[-1]["text"] == "jane:hi"

--- a/tests/test_agent_profile.py
+++ b/tests/test_agent_profile.py
@@ -1,0 +1,51 @@
+# tests/test_agent_profile.py
+from aether_agent import agent_profile
+from aether_agent.agent_profile import Agent
+
+
+def test_from_dict_fills_defaults_and_ignores_effort():
+    a = Agent.from_dict({"name": "jane", "effort": "codepro"})  # effort ignored
+    assert a.name == "jane"
+    assert a.model  # a default model
+    assert a.pool_gb == 5
+    assert a.permission == "ask"
+    assert set(a.tools)  # defaults to the canonical 8
+    assert not hasattr(a, "effort")
+
+
+def test_validate_catches_bad_fields():
+    bad = Agent.from_dict({
+        "name": "Bad Name!", "pool_gb": 0, "permission": "nope",
+        "tools": ["read_file", "made_up_tool"], "max_steps": 9999, "accent": "chartreuse",
+    })
+    problems = agent_profile.validate(bad)
+    joined = " ".join(problems).lower()
+    assert "name" in joined
+    assert "pool_gb" in joined or "pool" in joined
+    assert "permission" in joined
+    assert "tool" in joined
+    assert "max_steps" in joined or "step" in joined
+    assert "accent" in joined
+
+
+def test_valid_agent_has_no_problems():
+    a = Agent.from_dict({"name": "jane"})
+    assert agent_profile.validate(a) == []
+
+
+def test_roundtrip_and_set_returns_new_validated_copy():
+    a = Agent.from_dict({"name": "jane"})
+    d = a.to_dict()
+    assert d["name"] == "jane" and "commands" in d and "effort" not in d
+    b = a.set(pool_gb=10, accent="green")
+    assert b.pool_gb == 10 and b.accent == "green"
+    assert a.pool_gb == 5  # original unchanged (immutable)
+
+
+def test_set_with_invalid_value_raises():
+    a = Agent.from_dict({"name": "jane"})
+    try:
+        a.set(permission="bogus")
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "permission" in str(e).lower()

--- a/tests/test_agent_profile_commands.py
+++ b/tests/test_agent_profile_commands.py
@@ -1,0 +1,25 @@
+from aether_agent import agent_profile
+from aether_agent.agent_profile import Agent
+
+
+def test_commands_map_validates():
+    good = Agent.from_dict({"name": "jane", "commands": {"review": "Review $1 for bugs"}})
+    assert agent_profile.validate(good) == []
+
+
+def test_reserved_or_empty_command_rejected():
+    bad = Agent.from_dict({"name": "jane", "commands": {"help": "x"}})  # reserved name
+    assert any("command" in p.lower() for p in agent_profile.validate(bad))
+    empty = Agent.from_dict({"name": "jane", "commands": {"ok": "   "}})  # empty template
+    assert any("template" in p.lower() for p in agent_profile.validate(empty))
+
+
+def test_define_command_allowed_in_tools():
+    a = Agent.from_dict({"name": "jane", "tools": ["read_file", "define_command"]})
+    assert agent_profile.validate(a) == []  # define_command is an allowed agent tool
+
+
+def test_is_valid_command_name():
+    assert agent_profile.is_valid_command_name("review")
+    assert not agent_profile.is_valid_command_name("help")        # reserved
+    assert not agent_profile.is_valid_command_name("Bad Name")    # not a slug

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -1,0 +1,52 @@
+# tests/test_agent_runner.py
+from aether_agent import agent_runner
+from aether_agent.agent_profile import Agent
+from aether_agent.tools import Tools
+
+
+def test_policy_tools_blocks_disallowed_and_allows_allowed(tmp_path):
+    inner = Tools(str(tmp_path))
+    pt = agent_runner._PolicyTools(inner, allowed={"read_file"}, permission="skip", confirm=lambda n, a: True)
+    assert "not allowed" in pt.execute("write_file", {"path": "x", "content": "y"}).lower()
+    out = pt.execute("read_file", {"path": "missing"})
+    assert "no such file" in out.lower()  # delegated to inner
+
+
+def test_policy_tools_ask_denies_destructive_without_confirm(tmp_path):
+    inner = Tools(str(tmp_path))
+    pt = agent_runner._PolicyTools(inner, allowed={"write_file"}, permission="ask", confirm=lambda n, a: False)
+    assert "denied" in pt.execute("write_file", {"path": "x", "content": "y"}).lower()
+    pt2 = agent_runner._PolicyTools(inner, allowed={"write_file"}, permission="ask", confirm=lambda n, a: True)
+    assert "wrote" in pt2.execute("write_file", {"path": "x.txt", "content": "y"}).lower()
+
+
+def test_run_builds_session_with_agent_pool_and_streams(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    captured = {}
+
+    class _FakeSession:
+        def remember(self, *a, **k): pass
+        def status_dict(self): return {}
+        def close(self): captured["closed"] = True
+
+    def fake_session_factory(agent):
+        captured["pool_gb"] = agent.pool_gb
+        captured["model"] = agent.model
+        return _FakeSession()
+
+    class _FakeLLM:
+        def chat(self, messages, tools=None):
+            captured["system"] = messages[0]["content"]
+            captured["schema_names"] = [t["function"]["name"] for t in (tools or [])]
+            return {"role": "assistant", "content": "done", "tool_calls": []}
+
+    a = Agent.from_dict({"name": "jane", "pool_gb": 9, "persona": "You are Jane.",
+                         "tools": ["read_file", "web_search"], "permission": "skip"})
+    events = list(agent_runner.run(
+        a, "hello", cwd=str(tmp_path), llm=_FakeLLM(), session_factory=fake_session_factory,
+    ))
+    assert captured["pool_gb"] == 9 and captured["model"] == a.model
+    assert captured["system"] == "You are Jane."
+    assert set(captured["schema_names"]) == {"read_file", "web_search"}
+    assert any(e["type"] == "done" for e in events)
+    assert captured.get("closed") is True

--- a/tests/test_agent_runner_define_command.py
+++ b/tests/test_agent_runner_define_command.py
@@ -1,0 +1,47 @@
+import pytest
+
+from aether_agent import agent_runner
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_define_command_schema_only_when_allowed():
+    with_tool = Agent.from_dict({"name": "jane", "tools": ["read_file", "define_command"]})
+    without = Agent.from_dict({"name": "jane", "tools": ["read_file"]})
+    assert "define_command" in agent_runner._offered_tool_names(with_tool)
+    assert "define_command" not in agent_runner._offered_tool_names(without)
+
+
+def test_define_command_writes_and_reloads():
+    from aether_agent import agent_store
+    a = Agent.from_dict({"name": "jane", "tools": ["read_file", "define_command"]})
+    agent_store.create(a)
+    pt = agent_runner._PolicyTools(
+        inner=None, allowed=set(a.tools), permission="skip", confirm=lambda n, x: True, agent_name="jane",
+    )
+    out = pt.execute("define_command", {"name": "review", "template": "Review $1 for bugs"})
+    assert "defined" in out.lower()
+    assert agent_store.load("jane").commands == {"review": "Review $1 for bugs"}
+
+
+def test_define_command_refused_when_not_allowed():
+    pt = agent_runner._PolicyTools(
+        inner=None, allowed={"read_file"}, permission="skip", confirm=lambda n, x: True, agent_name="jane",
+    )
+    out = pt.execute("define_command", {"name": "review", "template": "x"})
+    assert "not allowed" in out.lower()
+
+
+def test_define_command_rejects_reserved_name():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane", "tools": ["define_command"]}))
+    pt = agent_runner._PolicyTools(
+        inner=None, allowed={"define_command"}, permission="skip", confirm=lambda n, x: True, agent_name="jane",
+    )
+    out = pt.execute("define_command", {"name": "help", "template": "x"})
+    assert "refused" in out.lower()
+    assert agent_store.load("jane").commands == {}

--- a/tests/test_agent_runner_lock.py
+++ b/tests/test_agent_runner_lock.py
@@ -1,0 +1,37 @@
+# tests/test_agent_runner_lock.py
+from aether_agent import agent_runner
+
+
+class _RecordingLock:
+    def __init__(self):
+        self.acquired = 0
+    def __enter__(self):
+        self.acquired += 1
+        return self
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeInner:
+    test_cmd = ""
+    def execute(self, name, args):
+        return f"[ran {name}]"
+
+
+def test_destructive_acquires_lock_read_does_not():
+    lock = _RecordingLock()
+    pt = agent_runner._PolicyTools(
+        _FakeInner(), allowed={"write_file", "read_file"}, permission="skip",
+        confirm=lambda n, a: True, write_lock=lock,
+    )
+    pt.execute("read_file", {"path": "x"})
+    assert lock.acquired == 0          # reads are not locked
+    pt.execute("write_file", {"path": "x", "content": "y"})
+    assert lock.acquired == 1          # destructive acquired the lock
+
+
+def test_no_lock_means_no_locking():
+    pt = agent_runner._PolicyTools(
+        _FakeInner(), allowed={"write_file"}, permission="skip", confirm=lambda n, a: True,
+    )
+    assert "[ran write_file]" in pt.execute("write_file", {"path": "x", "content": "y"})

--- a/tests/test_agent_slash.py
+++ b/tests/test_agent_slash.py
@@ -1,0 +1,66 @@
+# tests/test_agent_slash.py
+import pytest
+
+from aether_agent import agent_slash
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def _mk(name="jane"):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": name}))
+
+
+def test_new_agent_creates():
+    res = agent_slash.dispatch_agent("/new-agent jane", active="")
+    assert "jane" in res["text"]
+    from aether_agent import agent_store
+    assert agent_store.exists("jane")
+
+
+def test_new_agent_duplicate_reports():
+    _mk()
+    res = agent_slash.dispatch_agent("/new-agent jane", active="")
+    assert "exist" in res["text"].lower()
+
+
+def test_agents_lists_with_active_marker():
+    _mk("jane")
+    _mk("neo")
+    res = agent_slash.dispatch_agent("/agents", active="neo")
+    assert "jane" in res["text"] and "neo" in res["text"]
+
+
+def test_agent_switch_returns_flag():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane", active="")
+    assert res.get("switch_agent") == "jane"
+
+
+def test_agent_run_returns_flag():
+    _mk()
+    res = agent_slash.dispatch_agent('/agent jane fix the bug', active="")
+    assert res.get("run_agent") == {"name": "jane", "task": "fix the bug"}
+
+
+def test_agent_set_persists():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane set memory 10", active="")
+    assert "10" in res["text"]
+    assert Agent.load("jane").pool_gb == 10
+
+
+def test_agent_set_invalid_reports_not_crash():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane set permission bogus", active="")
+    assert "permission" in res["text"].lower()
+    assert Agent.load("jane").permission == "ask"  # unchanged
+
+
+def test_unknown_agent_is_friendly():
+    res = agent_slash.dispatch_agent("/agent ghost", active="")
+    assert "no" in res["text"].lower() or "unknown" in res["text"].lower()

--- a/tests/test_agent_slash_agents_columns.py
+++ b/tests/test_agent_slash_agents_columns.py
@@ -1,0 +1,28 @@
+# tests/test_agent_slash_agents_columns.py
+import pytest
+
+from aether_agent import agent_slash
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_agents_renders_columns():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane", "model": "qwen2.5-coder:7b", "pool_gb": 5}))
+    agent_store.create(Agent.from_dict({"name": "neo", "model": "qwen3-coder:30b", "pool_gb": 10}))
+    out = agent_slash.dispatch_agent("/agents", active="neo")["text"]
+    assert "jane" in out and "neo" in out
+    assert "qwen2.5-coder:7b" in out and "qwen3-coder:30b" in out
+    assert "GB" in out  # the card stats line
+    # column-dashboard format (not the old B simple list):
+    assert "cmds" in out and " GB" in out
+    assert "* neo" in out  # active marker on its own card
+
+
+def test_agents_empty():
+    out = agent_slash.dispatch_agent("/agents", active="")["text"]
+    assert "no agents" in out.lower()

--- a/tests/test_agent_slash_cmd.py
+++ b/tests/test_agent_slash_cmd.py
@@ -1,0 +1,48 @@
+# tests/test_agent_slash_cmd.py
+import pytest
+
+from aether_agent import agent_slash
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def _mk(name="jane"):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": name}))
+
+
+def test_cmd_add_list_remove():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane cmd add review = Review $1 for bugs", active="")
+    assert "review" in res["text"]
+    assert Agent.load("jane").commands == {"review": "Review $1 for bugs"}
+    res2 = agent_slash.dispatch_agent("/agent jane cmd list", active="")
+    assert "review" in res2["text"]
+    agent_slash.dispatch_agent("/agent jane cmd remove review", active="")
+    assert Agent.load("jane").commands == {}
+
+
+def test_cmd_add_requires_equals_and_rejects_reserved():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane cmd add review Review $1", active="")  # no '='
+    assert "=" in res["text"]
+    res2 = agent_slash.dispatch_agent("/agent jane cmd add help = x", active="")  # reserved
+    assert "command" in res2["text"].lower()
+    assert Agent.load("jane").commands == {}  # nothing saved
+
+
+def test_run_verb_expands_to_run_agent():
+    _mk()
+    agent_slash.dispatch_agent("/agent jane cmd add review = Review $1 for bugs", active="")
+    res = agent_slash.dispatch_agent("/agent jane run review src/api.py", active="")
+    assert res.get("run_agent") == {"name": "jane", "task": "Review src/api.py for bugs"}
+
+
+def test_run_unknown_command_friendly():
+    _mk()
+    res = agent_slash.dispatch_agent("/agent jane run ghost x", active="")
+    assert "no" in res["text"].lower() or "unknown" in res["text"].lower()

--- a/tests/test_agent_store.py
+++ b/tests/test_agent_store.py
@@ -1,0 +1,56 @@
+# tests/test_agent_store.py
+import pytest
+
+from aether_agent import agent_store
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_create_load_list_exists():
+    a = Agent.from_dict({"name": "jane", "pool_gb": 7})
+    agent_store.create(a)
+    assert agent_store.exists("jane")
+    assert agent_store.list_agents() == ["jane"]
+    loaded = agent_store.load("jane")
+    assert loaded.name == "jane" and loaded.pool_gb == 7
+
+
+def test_create_duplicate_raises():
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    with pytest.raises(Exception):
+        agent_store.create(Agent.from_dict({"name": "jane"}))
+
+
+def test_load_missing_raises():
+    with pytest.raises(Exception):
+        agent_store.load("nope")
+
+
+def test_pool_dir_path_layout():
+    p = agent_store.agent_pool_dir("jane")
+    assert p.name == "pool" and p.parent.name == "jane"
+    assert "agents" in str(p)
+
+
+def test_delete_keeps_pool_unless_purge():
+    a = Agent.from_dict({"name": "jane"})
+    agent_store.create(a)
+    pool = agent_store.agent_pool_dir("jane")
+    pool.mkdir(parents=True, exist_ok=True)
+    agent_store.delete("jane", purge=False)
+    assert not agent_store.exists("jane")
+    assert pool.exists()  # pool kept
+    agent_store.create(a)
+    agent_store.delete("jane", purge=True)
+    assert not pool.exists()
+
+
+def test_corrupt_file_fails_soft():
+    agent_store.agent_path("broken").write_text("{ not json", encoding="utf-8")
+    with pytest.raises(Exception):
+        agent_store.load("broken")
+    assert "broken" in agent_store.list_agents()  # listing must not crash

--- a/tests/test_agents_view.py
+++ b/tests/test_agents_view.py
@@ -1,0 +1,27 @@
+from aether_agent import agents_view
+
+
+def _rows(*names):
+    return [{"name": n, "model": "qwen2.5-coder:7b", "pool_gb": 5, "n_commands": 2} for n in names]
+
+
+def test_empty():
+    assert "no agents" in agents_view.render_agents_columns([]).lower()
+
+
+def test_single_card_has_fields_and_active_marker():
+    out = agents_view.render_agents_columns(_rows("jane"), active="jane")
+    assert "jane" in out and "qwen2.5-coder:7b" in out
+    assert "5 GB" in out and "2 cmds" in out
+    assert "*" in out  # active marker
+
+
+def test_multiple_cards_wrap_to_width():
+    out = agents_view.render_agents_columns(_rows("a", "b", "c", "d"), width=50)
+    lines = out.splitlines()
+    assert any("a" in line and "b" in line for line in lines)  # a,b side by side
+    assert any("c" in line and "d" in line for line in lines)  # c,d on the next block
+
+
+def test_cp1252_safe():
+    agents_view.render_agents_columns(_rows("jane", "neo"), active="neo").encode("cp1252")

--- a/tests/test_brains.py
+++ b/tests/test_brains.py
@@ -12,7 +12,6 @@ from typing import Any, Iterator
 
 import pytest
 
-from aether_agent import brains
 from aether_agent.brains import CloudBrain, LocalBrain, select_brain
 
 

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -222,6 +222,8 @@ def test_repl_main_non_tty_runs_help_then_exit(monkeypatch: pytest.MonkeyPatch, 
 
     monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
     monkeypatch.delenv("AETHER_TOKEN", raising=False)
+    # Stay hermetic: never build/preflight a real local Ollama daemon.
+    monkeypatch.setattr(repl_mod, "_build_ollama", lambda backend, authed: None)
     # Force the non-TTY plain-line path with a scripted stdin.
     monkeypatch.setattr(repl_mod.sys, "stdin", io.StringIO("/help\n/exit\n"))
     code = repl_mod.main()

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,31 @@
+# tests/test_cli_doctor.py
+from aether_agent import cli
+
+
+def test_doctor_subcommand_prints_report(capsys, monkeypatch):
+    class _Ctl:
+        def detect(self):
+            return {"installed": True, "daemon_up": True}
+        def list_models(self):
+            return [{"tag": "qwen2.5-coder:7b", "size_bytes": 1}]
+    monkeypatch.setattr(cli, "_ollama_ctl", lambda: _Ctl())
+    rc = cli.main(["doctor"])
+    out = capsys.readouterr().out.lower()
+    assert rc == 0 and "ollama" in out and "model" in out
+
+
+def test_setup_subcommand_runs_preflight(capsys, monkeypatch):
+    seen = {"preflight": 0}
+
+    class _Ctl:
+        def stop_owned(self):
+            pass
+    monkeypatch.setattr(cli, "_ollama_ctl", lambda: _Ctl())
+
+    def fake_preflight(ctl, **kw):
+        seen["preflight"] += 1
+        from aether_agent.onboarding import Preflight
+        return Preflight(True, "qwen2.5-coder:7b", "", [])
+    monkeypatch.setattr(cli, "_preflight", fake_preflight)
+    rc = cli.main(["setup"])
+    assert rc == 0 and seen["preflight"] == 1

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,36 @@
+# tests/test_hardware.py
+from aether_agent import hardware
+from aether_agent.hardware import Resources
+
+
+def _fit(ram, vram=None, gpu=None):
+    res = hardware.detect_resources(
+        ram_probe=lambda: ram,
+        vram_probe=lambda: (vram, gpu),
+    )
+    return hardware.best_fit(res)[0]
+
+
+def test_best_fit_matrix():
+    assert _fit(16) == "qwen2.5-coder:7b"          # 16*0.7=11.2 -> 7b (min 8)
+    assert _fit(6) == "qwen2.5-coder:3b"           # 6*0.7=4.2 -> 3b (min 4)
+    assert _fit(48) == "qwen3-coder:30b"           # 48*0.7=33.6 -> 30b (min 24)
+    assert _fit(8, vram=24, gpu="NVIDIA") == "qwen3-coder:30b"  # VRAM wins
+
+
+def test_low_resources_falls_back_to_permissive_floor():
+    # 2 GB fits nothing -> the permissive floor, never the license-flagged Gemma.
+    assert _fit(2) == hardware.DEFAULT_FLOOR == "qwen2.5-coder:3b"
+
+
+def test_flagged_model_never_auto_selected():
+    # Even where Gemma (min 6) would "fit", best_fit must skip license-flagged.
+    tag = _fit(7)  # 7*0.7=4.9 -> 3b (min4); gemma(min6) excluded anyway
+    assert tag != "gemma3n:e4b"
+
+
+def test_detect_resources_failsoft_default():
+    def boom():
+        raise OSError("no probe")
+    res = hardware.detect_resources(ram_probe=boom, vram_probe=boom)
+    assert res == Resources(ram_gb=8.0, vram_gb=None, gpu=None)

--- a/tests/test_install_security.py
+++ b/tests/test_install_security.py
@@ -1,0 +1,37 @@
+# tests/test_install_security.py
+from aether_agent.ollama_ctl import OllamaCtl, is_official_url
+
+
+def test_official_url_pinning():
+    assert is_official_url("https://ollama.com/download/OllamaSetup.exe") is True
+    assert is_official_url("https://github.com/ollama/ollama/releases/x") is True
+    assert is_official_url("http://ollama.com/x") is False          # https only
+    assert is_official_url("https://evil.example.com/OllamaSetup.exe") is False
+
+
+def test_install_refuses_without_consent():
+    calls = []
+    ctl = OllamaCtl(downloader=lambda url: calls.append(url) or b"",
+                    runner=lambda path: calls.append(("run", path)))
+    ok, detail = ctl.install(consent=False)
+    assert ok is False and "consent" in detail.lower()
+    assert calls == []  # nothing downloaded, nothing run
+
+
+def test_install_refuses_non_official_url():
+    ctl = OllamaCtl(installer_url=lambda: "https://evil.example.com/x.exe",
+                    downloader=lambda url: b"X", runner=lambda p: None)
+    ok, detail = ctl.install(consent=True)
+    assert ok is False and "official" in detail.lower()
+
+
+def test_install_runs_official_with_consent():
+    ran = {}
+    ctl = OllamaCtl(
+        installer_url=lambda: "https://ollama.com/download/OllamaSetup.exe",
+        downloader=lambda url: b"INSTALLER-BYTES",
+        runner=lambda path: ran.setdefault("path", path),
+        which=lambda n: "ollama",  # re-detect succeeds after install
+    )
+    ok, detail = ctl.install(consent=True)
+    assert ok is True and ran["path"].endswith(".exe")

--- a/tests/test_multi_runner.py
+++ b/tests/test_multi_runner.py
@@ -46,3 +46,19 @@ def test_shared_write_lock_passed_to_each_runner(monkeypatch):
     jobs = [(Agent.from_dict({"name": "a"}), "t"), (Agent.from_dict({"name": "b"}), "t")]
     multi_runner.run_many(jobs, emit=lambda label, ev: None)
     assert locks_seen[0] is locks_seen[1] is not None  # same shared lock for all jobs
+
+
+def test_duplicate_agent_runs_once(monkeypatch):
+    # The same agent twice in one batch must run ONCE (no concurrent Sessions on
+    # its shared pool dir, no summary collision).
+    runs = []
+
+    def fake_run(agent, task, **kw):
+        runs.append((agent.name, task))
+        yield {"type": "done", "text": "x", "ok": True}
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    jobs = [(Agent.from_dict({"name": "jane"}), "a"), (Agent.from_dict({"name": "jane"}), "b")]
+    summaries = multi_runner.run_many(jobs, emit=lambda label, ev: None)
+    assert len(runs) == 1 and runs[0] == ("jane", "a")   # first kept, dup dropped
+    assert len(summaries) == 1 and summaries[0]["name"] == "jane"

--- a/tests/test_multi_runner.py
+++ b/tests/test_multi_runner.py
@@ -1,0 +1,48 @@
+# tests/test_multi_runner.py
+from aether_agent import multi_runner
+from aether_agent.agent_profile import Agent
+
+
+def test_run_many_streams_labeled_events_and_summaries(monkeypatch):
+    scripts = {
+        "jane": [{"type": "monologue", "text": "j1"}, {"type": "tool_call", "name": "read_file", "args": {}},
+                 {"type": "done", "text": "jane done", "ok": True}],
+        "neo": [{"type": "monologue", "text": "n1"}, {"type": "done", "text": "neo done", "ok": True}],
+    }
+
+    def fake_run(agent, task, **kw):
+        for ev in scripts[agent.name]:
+            yield ev
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    seen = []
+    jobs = [(Agent.from_dict({"name": "jane"}), "t1"), (Agent.from_dict({"name": "neo"}), "t2")]
+    summaries = multi_runner.run_many(jobs, emit=lambda label, ev: seen.append((label, ev.get("type"))))
+    labels = {label for label, _ in seen}
+    assert labels == {"jane", "neo"}
+    assert ("jane", "monologue") in seen and ("neo", "done") in seen
+    by_name = {s["name"]: s for s in summaries}
+    assert by_name["jane"]["tool_calls"] == 1 and by_name["jane"]["ok"] is True
+    assert by_name["neo"]["summary"] == "neo done"
+
+
+def test_cap_at_8(monkeypatch):
+    def fake_run(agent, task, **kw):
+        yield {"type": "done", "text": "x", "ok": True}
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    jobs = [(Agent.from_dict({"name": f"a{i}"}), "t") for i in range(12)]
+    summaries = multi_runner.run_many(jobs, emit=lambda label, ev: None)
+    assert len(summaries) == 8  # capped
+
+
+def test_shared_write_lock_passed_to_each_runner(monkeypatch):
+    locks_seen = []
+
+    def fake_run(agent, task, *, write_lock=None, **kw):
+        locks_seen.append(write_lock)
+        yield {"type": "done", "text": "x", "ok": True}
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    jobs = [(Agent.from_dict({"name": "a"}), "t"), (Agent.from_dict({"name": "b"}), "t")]
+    multi_runner.run_many(jobs, emit=lambda label, ev: None)
+    assert locks_seen[0] is locks_seen[1] is not None  # same shared lock for all jobs

--- a/tests/test_ollama_ctl.py
+++ b/tests/test_ollama_ctl.py
@@ -1,0 +1,95 @@
+# tests/test_ollama_ctl.py
+from aether_agent.ollama_ctl import OllamaCtl
+
+
+class _FakeProc:
+    def __init__(self):
+        self.terminated = False
+    def terminate(self):
+        self.terminated = True
+    def poll(self):
+        return None
+
+
+def _ctl(*, tags_up=True, which="ollama", pull_lines=None, proc=None):
+    state = {"serves": 0}
+
+    def http_get(path):
+        if path == "/api/tags":
+            if tags_up:
+                return {"models": [{"name": "qwen2.5-coder:7b", "size": 5_000_000_000}]}
+            raise OSError("connection refused")
+        if path == "/api/ps":
+            return {"models": []}
+        raise AssertionError(path)
+
+    def http_post_stream(path, body):
+        assert path == "/api/pull"
+        for ln in (pull_lines or []):
+            yield ln
+
+    def popen(args):
+        state["serves"] += 1
+        return proc or _FakeProc()
+
+    ctl = OllamaCtl(
+        http_get=http_get,
+        http_post_stream=http_post_stream,
+        popen=popen,
+        which=lambda name: which,
+        sleep=lambda s: None,
+    )
+    ctl._serve_calls = state
+    return ctl
+
+
+def test_detect_reports_install_and_daemon():
+    d = _ctl(tags_up=True).detect()
+    assert d["installed"] is True and d["daemon_up"] is True
+    d2 = _ctl(tags_up=False, which=None).detect()
+    assert d2["installed"] is False and d2["daemon_up"] is False
+
+
+def test_ensure_serve_starts_only_when_down_and_owns_it():
+    up = _ctl(tags_up=True)
+    assert up.ensure_serve() is True
+    assert up._owned is False and up._serve_calls["serves"] == 0  # already up -> not owned
+
+    proc = _FakeProc()
+    down = _ctl(tags_up=False, proc=proc)
+    # daemon is down at first probe; mark it up after the spawn so the poll succeeds
+    down._daemon_up = lambda: down._serve_calls["serves"] > 0
+    assert down.ensure_serve() is True
+    assert down._owned is True and down._serve_calls["serves"] == 1
+
+
+def test_stop_owned_only_kills_what_we_started():
+    proc = _FakeProc()
+    down = _ctl(tags_up=False, proc=proc)
+    down._daemon_up = lambda: down._serve_calls["serves"] > 0
+    down.ensure_serve()
+    down.stop_owned()
+    assert proc.terminated is True
+
+    up = _ctl(tags_up=True)
+    up.ensure_serve()
+    up.stop_owned()  # nothing owned -> no-op, must not raise
+
+
+def test_pull_streams_progress_callbacks():
+    lines = [
+        {"status": "pulling", "completed": 1, "total": 4},
+        {"status": "pulling", "completed": 4, "total": 4},
+        {"status": "success"},
+    ]
+    ctl = _ctl(pull_lines=lines)
+    seen = []
+    ok, detail = ctl.pull("qwen2.5-coder:7b", on_progress=lambda s, c, t: seen.append((s, c, t)))
+    assert ok is True
+    assert seen[0] == ("pulling", 1, 4) and seen[-1][0] == "success"
+
+
+def test_list_models_returns_installed_tags():
+    ctl = _ctl(tags_up=True)
+    models = ctl.list_models()
+    assert {"tag": "qwen2.5-coder:7b", "size_bytes": 5_000_000_000} in models

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,6 +1,5 @@
 # tests/test_onboarding.py
 from aether_agent import onboarding
-from aether_agent.onboarding import Preflight
 
 
 class _Ctl:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,63 @@
+# tests/test_onboarding.py
+from aether_agent import onboarding
+from aether_agent.onboarding import Preflight
+
+
+class _Ctl:
+    def __init__(self, installed=True, daemon=True, models=None, pull_ok=True):
+        self._installed, self._daemon = installed, daemon
+        self._models = models if models is not None else ["qwen2.5-coder:7b"]
+        self._pull_ok = pull_ok
+        self.installed_called = self.served = self.pulled = None
+    def detect(self):
+        return {"installed": self._installed, "daemon_up": self._daemon}
+    def install(self, *, consent):
+        self.installed_called = consent
+        self._installed = consent
+        return (consent, "ok" if consent else "declined")
+    def ensure_serve(self):
+        self.served = True
+        self._daemon = True
+        return True
+    def list_models(self):
+        return [{"tag": t, "size_bytes": 1} for t in self._models]
+    def pull(self, tag, on_progress=None):
+        self.pulled = tag
+        if self._pull_ok:
+            self._models.append(tag)
+        return (self._pull_ok, "success" if self._pull_ok else "boom")
+    def stop_owned(self):
+        pass
+
+
+def test_preflight_healthy_is_silent_noop():
+    ctl = _Ctl(installed=True, daemon=True, models=["qwen2.5-coder:7b"])
+    pf = onboarding.preflight(ctl, resources=lambda: ("qwen2.5-coder:7b", "ok"),
+                              prompt=lambda q: "")  # never prompted
+    assert pf.ok is True and pf.chosen_model == "qwen2.5-coder:7b"
+    assert ctl.served is None and ctl.pulled is None  # nothing to do
+
+
+def test_preflight_full_path_installs_serves_picks_pulls():
+    ctl = _Ctl(installed=False, daemon=False, models=[])
+    answers = iter(["y", ""])  # y to install, Enter to accept the pick
+    pf = onboarding.preflight(ctl, resources=lambda: ("qwen2.5-coder:7b", "16 GB -> 7b"),
+                              prompt=lambda q: next(answers))
+    assert ctl.installed_called is True
+    assert ctl.served is True
+    assert ctl.pulled == "qwen2.5-coder:7b"
+    assert pf.ok is True and pf.chosen_model == "qwen2.5-coder:7b"
+
+
+def test_preflight_declined_install_exits_clean():
+    ctl = _Ctl(installed=False, daemon=False, models=[])
+    pf = onboarding.preflight(ctl, resources=lambda: ("qwen2.5-coder:7b", "x"),
+                              prompt=lambda q: "n")
+    assert pf.ok is False and ctl.served is None
+    assert "manual" in pf.message.lower() or "install" in pf.message.lower()
+
+
+def test_doctor_reports_each_check():
+    ctl = _Ctl(installed=True, daemon=True, models=["qwen2.5-coder:7b"])
+    report = onboarding.doctor(ctl, resources=lambda: ("qwen2.5-coder:7b", "ok"))
+    assert "ollama" in report.lower() and "model" in report.lower()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,30 @@
+# tests/test_progress.py
+from aether_agent import progress
+
+
+def test_bar_empty_full_and_clamp():
+    assert progress.progress_bar(0.0, width=10) == "[----------] 0%"
+    assert progress.progress_bar(1.0, width=10) == "[##########] 100%"
+    assert progress.progress_bar(-5, width=10) == "[----------] 0%"
+    assert progress.progress_bar(2, width=10) == "[##########] 100%"
+    assert progress.progress_bar(0.5, width=10) == "[#####-----] 50%"
+
+
+def test_fmt_bytes():
+    assert progress.fmt_bytes(0) == "0 B"
+    assert progress.fmt_bytes(1536) == "1.5 KB"
+    assert progress.fmt_bytes(5 * 1024**3) == "5.0 GB"
+
+
+def test_pull_line_and_step_and_spinner():
+    line = progress.pull_line("qwen2.5-coder:7b", 2 * 1024**3, 4 * 1024**3)
+    assert "qwen2.5-coder:7b" in line and "50%" in line
+    assert progress.step("serve", ok=True) == "  [ok] serve"
+    assert progress.step("serve", ok=False) == "  [x] serve"
+    assert progress.step("serve") == "  ... serve"
+    assert progress.spinner_frame(0) in "|/-\\"
+
+
+def test_output_is_cp1252_safe():
+    s = progress.progress_bar(0.5) + progress.step("x", True) + progress.pull_line("m", 1, 2)
+    s.encode("cp1252")  # must not raise

--- a/tests/test_repl_agents.py
+++ b/tests/test_repl_agents.py
@@ -1,0 +1,36 @@
+import io
+
+import pytest
+
+from aether_agent import repl
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_apply_agent_sets_prompt_accent_persona():
+    a = Agent.from_dict({"name": "jane", "accent": "green", "prompt": "jane > ", "banner": "~J~"})
+    state = repl._apply_agent(a)
+    assert state["prompt"] == "jane > "
+    assert "32" in state["accent_ansi"]  # green = 32
+    assert state["banner"] == "~J~"
+
+
+def test_run_agent_flag_streams_via_runner(monkeypatch):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    seen = {}
+
+    def fake_run(agent, task, **kw):
+        seen["name"] = agent.name
+        seen["task"] = task
+        yield {"type": "done", "text": "ran"}
+
+    monkeypatch.setattr("aether_agent.agent_runner.run", fake_run)
+    out = io.StringIO()
+    repl._handle_agent_action({"run_agent": {"name": "jane", "task": "do x"}}, out)
+    assert seen == {"name": "jane", "task": "do x"}
+    assert "ran" in out.getvalue()

--- a/tests/test_repl_multi.py
+++ b/tests/test_repl_multi.py
@@ -1,0 +1,46 @@
+# tests/test_repl_multi.py
+import io
+
+import pytest
+
+from aether_agent import repl
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_parse_multi_two_runs():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    agent_store.create(Agent.from_dict({"name": "neo"}))
+    jobs = repl._parse_multi("/agent jane fix tests \\ /agent neo write docs")
+    assert jobs is not None
+    assert [(a.name, t) for a, t in jobs] == [("jane", "fix tests"), ("neo", "write docs")]
+
+
+def test_parse_multi_single_returns_none():
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    assert repl._parse_multi("/agent jane fix tests") is None  # no ' \\ ' -> not multi
+
+
+def test_handle_multi_streams_labeled(monkeypatch):
+    from aether_agent import agent_store
+    agent_store.create(Agent.from_dict({"name": "jane"}))
+    agent_store.create(Agent.from_dict({"name": "neo"}))
+
+    def fake_run_many(jobs, *, emit, **kw):
+        for a, _ in jobs:
+            emit(a.name, {"type": "done", "text": f"{a.name} ok"})
+        return [{"name": a.name, "ok": True, "summary": f"{a.name} ok", "tool_calls": 0} for a, _ in jobs]
+
+    monkeypatch.setattr("aether_agent.multi_runner.run_many", fake_run_many)
+    out = io.StringIO()
+    jobs = repl._parse_multi("/agent jane t \\ /agent neo t")
+    repl._handle_multi(jobs, out)
+    text = out.getvalue()
+    assert "[jane]" in text and "[neo]" in text
+    assert "done" in text.lower()

--- a/tests/test_repl_preflight.py
+++ b/tests/test_repl_preflight.py
@@ -1,0 +1,32 @@
+# tests/test_repl_preflight.py
+import io
+
+from aether_agent import repl
+
+
+def test_make_ctx_carries_ollama():
+    ctx = repl._make_ctx(authed=False, api=None, model="m", ollama="OLLAMA_SENTINEL")
+    assert ctx.ollama == "OLLAMA_SENTINEL"
+
+
+def test_main_runs_preflight_then_stops_owned(monkeypatch):
+    calls = {"preflight": 0, "stopped": 0}
+
+    class _Ctl:
+        def stop_owned(self):
+            calls["stopped"] += 1
+
+    monkeypatch.setattr(repl, "_build_ollama", lambda backend, authed: _Ctl())
+
+    def fake_preflight(c, **kw):
+        calls["preflight"] += 1
+        from aether_agent.onboarding import Preflight
+        return Preflight(True, "qwen2.5-coder:7b", "", [])
+
+    monkeypatch.setattr(repl, "_preflight", fake_preflight)
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))  # immediate EOF -> loop exits
+
+    rc = repl.main([])
+    assert rc == 0
+    assert calls["preflight"] == 1
+    assert calls["stopped"] == 1  # teardown ran in finally

--- a/tests/test_repl_preflight.py
+++ b/tests/test_repl_preflight.py
@@ -30,3 +30,31 @@ def test_main_runs_preflight_then_stops_owned(monkeypatch):
     assert rc == 0
     assert calls["preflight"] == 1
     assert calls["stopped"] == 1  # teardown ran in finally
+
+
+def test_setup_rerun_surfaces_failure_message(monkeypatch, capsys):
+    # A failed `/setup` re-run must print its reason (parity with the launch + CLI
+    # paths), not silently keep the REPL in a broken state.
+    from aether_agent.onboarding import Preflight
+
+    class _Ctl:
+        def stop_owned(self):
+            pass
+
+    monkeypatch.setattr(repl, "_build_ollama", lambda backend, authed: _Ctl())
+
+    calls = {"n": 0}
+
+    def fake_preflight(c, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:  # launch: healthy
+            return Preflight(True, "qwen2.5-coder:7b", "", [])
+        return Preflight(False, None, "could not start ollama serve", [])  # /setup: fails
+
+    monkeypatch.setattr(repl, "_preflight", fake_preflight)
+    monkeypatch.setattr("sys.stdin", io.StringIO("/setup\n"))  # one /setup, then EOF
+
+    rc = repl.main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "could not start ollama serve" in out

--- a/tests/test_run_agent_events_system.py
+++ b/tests/test_run_agent_events_system.py
@@ -1,0 +1,29 @@
+from aether_agent import agent as agent_mod
+from aether_agent.tools import Tools
+
+
+class _FakeLLM:
+    def __init__(self):
+        self.seen_system = None
+
+    def chat(self, messages, tools=None):
+        self.seen_system = messages[0]["content"]
+        return {"role": "assistant", "content": "ok", "tool_calls": []}
+
+
+def test_system_param_overrides_default_persona(tmp_path):
+    llm = _FakeLLM()
+    tools = Tools(str(tmp_path), test_cmd="")  # empty test_cmd -> verify gate is a no-op
+    events = list(agent_mod.run_agent_events(
+        "hi", llm=llm, tools=tools, system="You are Jane.", verify_finish=False,
+    ))
+    assert llm.seen_system == "You are Jane."
+    assert any(e["type"] == "done" for e in events)
+
+
+def test_system_defaults_to_builtin_when_omitted(tmp_path):
+    from aether_agent.persona import SYSTEM_PROMPT
+    llm = _FakeLLM()
+    tools = Tools(str(tmp_path), test_cmd="")
+    list(agent_mod.run_agent_events("hi", llm=llm, tools=tools, verify_finish=False))
+    assert llm.seen_system == SYSTEM_PROMPT

--- a/tests/test_slash.py
+++ b/tests/test_slash.py
@@ -109,20 +109,20 @@ def test_models_when_local_shows_ollama_hint_and_does_not_call_api() -> None:
     assert "/model" in res["text"]
 
 
-# --- /agents, /agent -------------------------------------------------------
+# --- /orchestrators, /orchestrator -----------------------------------------
 def test_agents_when_authed_lists_orchestrators() -> None:
     api = FakeApiClient(
         {"/agents": {"agents": [{"id": "neo", "label": "Neo"}, {"id": "kronus", "label": "Kronus"}]}}
     )
     ctx = _ctx(authed=True, api=api)
-    res = slash.dispatch(ctx, "/agents")
+    res = slash.dispatch(ctx, "/orchestrators")
     assert any(p.startswith("/agents") for p in api.get_paths)
     assert "neo" in res["text"] and "kronus" in res["text"]
 
 
 def test_agent_sets_id_and_returns_restart() -> None:
     ctx = _ctx(authed=True, model="m")
-    res = slash.dispatch(ctx, "/agent kronus")
+    res = slash.dispatch(ctx, "/orchestrator kronus")
     assert res.get("restart") == {"agent": "kronus"}
 
 

--- a/tests/test_slash_agents.py
+++ b/tests/test_slash_agents.py
@@ -1,0 +1,23 @@
+# tests/test_slash_agents.py
+import pytest
+
+from aether_agent.slash import SlashContext, dispatch
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def test_slash_routes_agent_commands():
+    res = dispatch(SlashContext(api=None), "/new-agent jane")
+    assert "jane" in res["text"]
+    res2 = dispatch(SlashContext(api=None, active_agent=""), "/agent jane")
+    assert res2.get("switch_agent") == "jane"
+    res3 = dispatch(SlashContext(api=None), "/agents")
+    assert "jane" in res3["text"]
+
+
+def test_help_lists_agent_commands():
+    res = dispatch(SlashContext(api=None), "/help")
+    assert "/agent" in res["text"] and "/new-agent" in res["text"]

--- a/tests/test_slash_custom_invoke.py
+++ b/tests/test_slash_custom_invoke.py
@@ -1,0 +1,39 @@
+# tests/test_slash_custom_invoke.py
+import pytest
+
+from aether_agent.slash import SlashContext, dispatch
+from aether_agent.agent_profile import Agent
+
+
+@pytest.fixture(autouse=True)
+def _tmp_cfg(tmp_path, monkeypatch):
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+
+
+def _mk_with_cmd():
+    from aether_agent import agent_store, agent_commands
+    a = agent_commands.add(Agent.from_dict({"name": "jane"}), "review", "Review $1 for bugs")
+    agent_store.create(a)
+
+
+def test_builtin_wins_over_custom_same_name():
+    res = dispatch(SlashContext(api=None, active_agent="jane"), "/help")
+    assert "/exit" in res["text"]  # the built-in help text resolves, not a custom
+
+
+def test_active_agent_custom_resolves():
+    _mk_with_cmd()
+    res = dispatch(SlashContext(api=None, active_agent="jane"), "/review src/api.py")
+    assert res.get("run_agent") == {"name": "jane", "task": "Review src/api.py for bugs"}
+
+
+def test_no_active_agent_unknown():
+    _mk_with_cmd()
+    res = dispatch(SlashContext(api=None, active_agent=""), "/review x")
+    assert "unknown" in res["text"].lower()
+
+
+def test_unknown_name_with_active_agent_is_unknown():
+    _mk_with_cmd()
+    res = dispatch(SlashContext(api=None, active_agent="jane"), "/ghost x")
+    assert "unknown" in res["text"].lower()

--- a/tests/test_slash_ollama.py
+++ b/tests/test_slash_ollama.py
@@ -1,0 +1,40 @@
+# tests/test_slash_ollama.py
+from aether_agent.slash import SlashContext, dispatch
+
+
+class _Ctl:
+    def detect(self):
+        return {"installed": True, "daemon_up": True}
+    def list_models(self):
+        return [{"tag": "qwen2.5-coder:7b", "size_bytes": 5_000_000_000}]
+    def ps(self):
+        return []
+    def pull(self, tag, on_progress=None):
+        return (True, "success")
+
+
+def _ctx():
+    return SlashContext(api=None, authed=False, model="qwen2.5-coder:7b", ollama=_Ctl())
+
+
+def test_models_local_lists_installed_with_marker():
+    out = dispatch(_ctx(), "/models")["text"]
+    assert "qwen2.5-coder:7b" in out and "›" in out
+
+
+def test_doctor_dispatch():
+    assert "ollama" in dispatch(_ctx(), "/doctor")["text"].lower()
+
+
+def test_pull_dispatch_reports_result():
+    assert "qwen2.5-coder:7b" in dispatch(_ctx(), "/pull qwen2.5-coder:7b")["text"]
+
+
+def test_serve_dispatch_shows_daemon_state():
+    out = dispatch(_ctx(), "/serve")["text"].lower()
+    assert "up" in out or "running" in out
+
+
+def test_setup_dispatch_recognized_not_unknown():
+    res = dispatch(_ctx(), "/setup")
+    assert "text" in res and "unknown" not in res["text"].lower()


### PR DESCRIPTION
The complete **"Claude Code for local"** build — four stacked sub-projects that turn `unlimited-context-llm` into a local, Ollama-native, multi-agent coding terminal on the Unlimited-Context engine.

## The four sub-projects

**A — Ollama-wrapped terminal** (`ollama_ctl`, `hardware`, `onboarding`, `progress`)
The terminal owns the whole Ollama lifecycle: detect → consent-gated + official-host-pinned install → supervise `serve` (stop only what it started) → hardware-aware model pick → pull with live progress. `aether doctor` / `aether setup`; `/pull /doctor /serve /setup`.

**B — Custom local agents** (`agent_profile`, `agent_store`, `agent_runner`, `agent_slash`)
Named, shareable agents — each with its own model, its own **persistent Unlimited-Context memory pool** (`Session(pool_dir, separate)`), persona, visual identity (accent/prompt/banner), and tool/permission policy. `/new-agent`, `/agent <name> <verb>`, `from aether_agent import Agent` library API. `_PolicyTools` enforces a per-agent tool allowlist + permission gate.

**C — Custom commands** (`agent_commands`)
Per-agent prompt-macros (`/agent jane cmd add review = Review $1 for bugs` → `/review src/api.py`). Authored manually or by the agent via a gated, macro-only `define_command` tool (kept out of the 8-tool bridge protocol). Bare `/cmd` resolves only when an agent is active, and **built-ins always win** (reserved names can't be shadowed).

**D — Multi-agent** (`agents_view`, `multi_runner`)
`/agents` column dashboard + concurrent runs: `/agent jane fix tests \ /agent neo write docs` runs them at once in daemon threads with live per-agent labeled output. Shared cwd is **write-gated** (destructive tools serialized through one lock); each agent keeps its own isolated memory pool; capped at 8; one run per agent per batch (no same-pool race).



## Bugs the reviews caught + fixed
- A: SSRF redirect TOCTOU + async-tool wiring on the `code` path; `/setup` silent-fail.
- D: **duplicate-agent same-pool-dir race** (two `Session`s on one memory pool) → `run_many` now dedupes by agent name.

