### PR TITLE
Remove 'aether' coding terminal section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,32 +263,6 @@ aether-context run "..." --no-mpo-chain                      # disable for one r
 
 > **Tip:** run `aether-context doctor` first — it catches the three things that ever go wrong (Ollama down, model not pulled, not enough disk) and prints the exact fix.
 
-## The `aether` coding terminal
-
-The same install ships a second command — **`aether`** — an open-source agentic **coding terminal**
-running on the Unlimited Context engine. It's **local-first**: turns run on your local **[Ollama](https://ollama.com)**
-by default (no account, no network); sign in and they switch to the **Aether cloud API**. It's the
-Python-native twin of [`aether-code`](https://github.com/DBarr3/aether-agent) (the TypeScript terminal)
-— same commands, same backend, same tools.
-
-| Command | What it does |
-|---|---|
-| `aether` | Open the interactive REPL (local Ollama by default). |
-| `aether "<prompt>"` | One-shot turn, streamed. |
-| `aether code "<task>"` | Autonomous coding run on the Unlimited Context brain (test-gated, git-checkpointed). |
-| `aether auth login` | Sign in (`--token <t>` or `--username/--password`) → turns switch to the Aether cloud API. |
-| `aether auth status \| logout \| token` | Show / clear / print the stored credential. |
-| `aether models` | List models available to your tier. |
-| `aether config [show\|get <k>\|set <k> <v>]` | Local settings, incl. `backend = auto\|local\|cloud`. |
-
-**Slash commands** (inside the REPL): `/help` · `/models` · `/model <tag>` · `/agents` · `/agent <id>` · `/tier` · `/audit [n]` · `/web <query>` · `/clear` · `/exit`.
-
-**Web tools** — the agent can reach the web on any backend: `web_search` (DuckDuckGo, no key) and `web_fetch` (URL → readable text, SSRF-guarded).
-
-**Backend** — `auto` (the default) uses your local Ollama until you `aether auth login`, then the Aether cloud API. Force it with `aether config set backend local|cloud` or `AETHER_BACKEND=local`.
-
-**Smoke test** — with Ollama up, `python -m aether_agent.smoke` (or `aether-smoke`) runs the SSRF guard, a real local turn, a web search + fetch, and the cloud path (when signed in), printing `PASS`/`SKIP`/`FAIL` (exit non-zero only on a real failure — missing Ollama/network/sign-in are skips).
-
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
Removed section about the 'aether' coding terminal and its commands.

<!-- Keep it short: why this matters, then what changed. -->

## Why

<!-- The problem or motivation in one or two sentences. -->

## What changed

<!-- Bullet the key changes. -->
-

## Checklist

- [ ] `pytest` is green locally (`pip install -e ".[dev]" && pytest -q`)
- [ ] `ruff check aether_context tests` and `mypy aether_context` are clean
- [ ] New behavior has a test (hermetic — numpy-only, `MockLLM`, no network)
- [ ] Stayed local-first: no new heavy required dependency (extras are fine)
- [ ] Stays local-first — no required network service or hosted coupling
- [ ] Updated docs / `CHANGELOG.md` if user-facing
