### PR TITLE
Default to local-first; one-step cloud sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,16 +280,16 @@ Python-native twin of [`aether-code`](https://github.com/DBarr3/aether-agent) (t
 | `aether` | Open the interactive REPL (local Ollama by default). |
 | `aether "<prompt>"` | One-shot turn, streamed. |
 | `aether code "<task>"` | Autonomous coding run on the Unlimited Context brain (test-gated, git-checkpointed). |
-| `aether auth login` | Sign in (`--token <t>` or `--username/--password`) → turns switch to the Aether cloud API. |
+| `aether auth login` | Sign in (`--token <t>` or `--username/--password`) for the hosted API (then set `backend auto\|cloud`). |
 | `aether auth status \| logout \| token` | Show / clear / print the stored credential. |
 | `aether models` | List models available to your tier. |
-| `aether config [show\|get <k>\|set <k> <v>]` | Local settings, incl. `backend = auto\|local\|cloud`. |
+| `aether config [show\|get <k>\|set <k> <v>]` | Local settings, incl. `backend = local (default)\|auto\|cloud`. |
 
 **Slash commands** (inside the REPL): `/help` · `/models` · `/model <tag>` · `/agents` · `/agent <id>` · `/tier` · `/audit [n]` · `/web <query>` · `/clear` · `/exit`.
 
 **Web tools** — the agent can reach the web on any backend: `web_search` (DuckDuckGo, no key) and `web_fetch` (URL → readable text, SSRF-guarded).
 
-**Backend** — `auto` (the default) uses your local Ollama until you `aether auth login`, then the Aether cloud API. Force it with `aether config set backend local|cloud` or `AETHER_BACKEND=local`.
+**Backend** — `local` (the default) runs every turn on your own Ollama; nothing leaves your machine and no account is needed. Opt into the hosted Aether API with `aether config set backend auto|cloud` (or `AETHER_BACKEND=auto`) plus `aether auth login` — `auto` uses the cloud only when you're signed in and falls back to local otherwise. The hosted API is the maintainer's own instance, so a fresh clone never calls it.
 
 **Smoke test** — with Ollama up, `python -m aether_agent.smoke` (or `aether-smoke`) runs the SSRF guard, a real local turn, a web search + fetch, and the cloud path (when signed in), printing `PASS`/`SKIP`/`FAIL` (exit non-zero only on a real failure — missing Ollama/network/sign-in are skips).
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,18 @@
 
 # ⚡ Unlimited Context LLM
 
-Give your Ai superpowers with **Unlimited context for [Ollama](https://ollama.com)** — give any LLM a **billion+ token memory**. Local-first, on your own machine, free.
+**Give your AI superpowers with unlimited context for [Ollama](https://ollama.com)** — a **billion+ token memory** for any LLM. Local-first, on your own machine, free.
 
 <img width="537" height="405" alt="Unlimited Context" src="https://github.com/user-attachments/assets/79758729-ead7-42ca-9784-831cae68ef06" />
 
-[![License](https://img.shields.io/badge/license-Apache--2.0-06b6d4)](LICENSE) [![Python](https://img.shields.io/badge/python-3.10%2B-14b8a6)](https://www.python.org) [![Built by Aether](https://img.shields.io/badge/built%20by-Aether-7c3aed)](https://aethersystems.net)
+[![License](https://img.shields.io/badge/License-Apache_2.0-06b6d4?style=flat-square)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-14b8a6?style=flat-square&logo=python&logoColor=white)](https://www.python.org)
+[![Built by Aether](https://img.shields.io/badge/Built_by-Aether-7c3aed?style=flat-square)](https://aethersystems.net)
+[![Local-first](https://img.shields.io/badge/Local--first-100%25_offline-0ea5e9?style=flat-square)](#what-you-get)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square)](CONTRIBUTING.md)
+[![Stars](https://img.shields.io/github/stars/DBarr3/Unlimited-Context-LLM?style=flat-square&logo=github&color=eab308)](https://github.com/DBarr3/Unlimited-Context-LLM/stargazers)
 
 **An open project from [Aether](https://aethersystems.net)** · Apache-2.0 · [Install](#quickstart)
-
-</div>
-
----
-
-<div align="center">
-
-> **Your context window didn't get bigger. Its *reach* did.**
-> Unlimited Context is virtual memory for an LLM. The model keeps its small window; the engine keeps a vast store on your disk and pulls the *right slice* back in while the model reasons. A small local model stays coherent across runs that would blow past any context window.
-
-> ⚠️ **Giving a model durable memory is powerful — read the safety measures first.** Real
-> concerns (runaway agents, grounding drift, an agent's own notes becoming its rules) and what
-> we do about them: **[Aether AI — Ethical & Safety Measures](SAFETY.md)**. The project is open
-> under Apache-2.0 and governed by the **[Acceptable Use Policy](USE_POLICY.md)** — these are not
-> recommendations. Anyone using the project must comply with its terms, and by using the project you
-> already agree to and are bound by them.
 
 <p align="center">
   <a href="#the-shape-of-it">The shape of it</a> ·
@@ -47,7 +36,17 @@ Give your Ai superpowers with **Unlimited context for [Ollama](https://ollama.co
 
 ---
 
-<div align="center">
+> **Your context window didn't get bigger. Its *reach* did.**
+> Unlimited Context is virtual memory for an LLM. The model keeps its small window; the engine keeps a vast store on your disk and pulls the *right slice* back in while the model reasons. A small local model stays coherent across runs that would blow past any context window.
+
+> ⚠️ **Giving a model durable memory is powerful — read the safety measures first.** Real
+> concerns (runaway agents, grounding drift, an agent's own notes becoming its rules) and what
+> we do about them: **[Aether AI — Ethical & Safety Measures](SAFETY.md)**. The project is open
+> under Apache-2.0 and governed by the **[Acceptable Use Policy](USE_POLICY.md)** — these are not
+> recommendations. Anyone using the project must comply with its terms, and by using the project you
+> already agree to and are bound by them.
+
+---
 
 ## The shape of it
 
@@ -60,10 +59,7 @@ Four steps, start to reach:
 
 That's it. A 5 GB pool gives a small model ~1.16B tokens of reach — about **9,000×** a 128K window — on your own machine, offline.
 
-
 ---
-
-<div align="center">
 
 ## The problem
 
@@ -172,7 +168,6 @@ How those numbers come out: ~2.2 KB per slice (a 256-dim vector + compressed tex
 > **Honest:** that's encoded **reach**, retrieved in slices — not a bigger attention window, and it rides on retrieval hit rate. A bigger pool buys more reachable codebase/corpus *per session* — not more concurrent sessions (those are RAM-bound, ~30 on 8 GB either way).
 
 ---
-
 
 ## The proof
 
@@ -323,21 +318,6 @@ That's the whole thing. One small model, one command, a billion tokens of reach 
 
 "Unlimited" means **reach, not attention.** Your model keeps its native window — we make it *reach* a billion-token pool in slices, via fast retrieval. The whole thing rides on retrieval **hit rate**; when it's high (and the loader is built to keep it high), the pool feels like one seamless context. The measured proof of all this is up top — see [The proof](#the-proof).
 
-## Benchmark — measured, on a real model
-
-A live run on **`deepseek/deepseek-v4-pro`** (via OpenRouter), driving an agent through **60 real GitHub issues** over a **40-turn session that overflows the model's window** — engine **on** vs **off** (off = no engine, same model, transcript truncated to the window). Full write-up: [`docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md`](docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md).
-
-| Metric | Off (baseline) | On (engine) | Change |
-|---|:---:|:---:|:---:|
-| **Recall coherence** (early facts still correct) | 0.15 | **1.00** | **6.7×** |
-| **Work outcome** (tasks done right) | 3 / 20 | **20 / 20** | **3 → 20** |
-| **Cost — full session** | $0.0711 | **$0.0542** | **−24%** |
-| **Cost — back half (recall phase)** | $0.00117/turn | **$0.00053/turn** | **−54%** |
-
-What the engine provided, in one session: it **held coherence flat at 1.00 while the baseline drifted to 0.15** (early issues fell out of the window and were lost), turned a **3/20 failing run into 20/20**, and did it for **~25% less money overall — over half off in the back half**, where the baseline drags a bloated transcript into every call and the engine sends a compact recalled window. Total spend for the whole benchmark: **$0.19**. Committed raw artifacts: [`docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/`](docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/) (`api_eval_results.json`, `api_eval_series.csv`, `api_eval_plot.png`, `RESULTS.md`).
-
-<sub>**Scope, honestly:** this measures the **engine** (retrieve-on-overflow memory), not the MPO chain — on this single-fact recall task the MPO chain **ties** plain recall (both 1.00). The MPO's multi-slice edge is **synthetic-only so far** (`bench/chain_recall.py`: connected-context recall 0.15 → 0.78); the live `thread` run that would confirm it is **pending** — not yet claimed. Magnitude scales with the overflow ratio: the 2000-token window is deliberately tiny to force overflow, so a realistic window shows a smaller (still real) gain. N=20 recall turns, single run. Reproduce: `python -m bench.api_eval --model deepseek/deepseek-v4-pro --repo microsoft/vscode --arms off,on,on_chain --plot`.</sub>
-
 ## Citation
 
 If Unlimited Context helps your work, please cite it. Built and maintained by **Aether AI**.
@@ -362,8 +342,6 @@ If this gave your local model superpowers, **drop a star** — it's how other pe
 ## License
 
 **Apache-2.0.** Use it, fork it, ship it in your product.
-
-</div>
 
 ---
 

--- a/aether_agent/cli.py
+++ b/aether_agent/cli.py
@@ -111,7 +111,7 @@ def _one_shot(prompt: str) -> int:
     api = ApiClient(cfg.get("baseUrl", ""), store)
     brain = select_brain(
         authed=store.get() is not None,
-        backend=str(cfg.get("backend", "auto")),
+        backend=str(cfg.get("backend", "local")),
         api=api,
         model=str(cfg.get("defaultModel", "") or ""),
     )

--- a/aether_agent/cli.py
+++ b/aether_agent/cli.py
@@ -156,7 +156,7 @@ def _cmd_auth(rest: list[str]) -> int:
     action = ns.action or "status"
 
     if action == "login":
-        return _auth_login(ns, base_url, store)
+        return _auth_login(ns, cfg, store)
     if action == "logout":
         store.clear()
         print("logged out.")
@@ -174,13 +174,15 @@ def _cmd_auth(rest: list[str]) -> int:
     return 0
 
 
-def _auth_login(ns: argparse.Namespace, base_url: str, store: FileTokenStore) -> int:
+def _auth_login(ns: argparse.Namespace, cfg: dict[str, Any], store: FileTokenStore) -> int:
+    base_url = cfg.get("baseUrl", "")
     token = ns.token
     if ns.with_token and not token:
         token = sys.stdin.readline().strip()
     if token:
         store.set(token)
         print("token saved.")
+        _enable_cloud_after_login(cfg)
         return 0
     if ns.username and ns.password:
         try:
@@ -190,9 +192,26 @@ def _auth_login(ns: argparse.Namespace, base_url: str, store: FileTokenStore) ->
             return 1
         plan = res.get("plan")
         print(f"logged in{f' (plan {plan})' if plan else ''}.")
+        _enable_cloud_after_login(cfg)
         return 0
     print("usage: aether auth login [--token T | --username U --password P | --with-token]", file=sys.stderr)
     return 1
+
+
+def _enable_cloud_after_login(cfg: dict[str, Any]) -> None:
+    """Signing in is an explicit "use the hosted API" signal, so move a
+    local-default install onto ``auto`` (cloud while signed in, local otherwise)
+    — turns then reach the Aether API without a second command. An explicit
+    ``cloud`` / ``auto`` choice is left untouched, and we never silently
+    downgrade: local-first is only the *unconfigured* default, not a lock, and
+    sign-in is fully reversible with ``aether config set backend local``.
+    """
+    if str(cfg.get("backend", "local")).strip().lower() != "local":
+        return
+    cfg["backend"] = "auto"
+    save_config(cfg)
+    print("cloud enabled (backend=auto); turns use the Aether API while you're signed in.")
+    print("  stay local instead with: aether config set backend local")
 
 
 # --- models ----------------------------------------------------------------

--- a/aether_agent/config.py
+++ b/aether_agent/config.py
@@ -5,15 +5,21 @@
 
 This is the AGENT (CLI host) config and is deliberately distinct from
 ``aether_context.config`` (the engine's on-disk *pool* config). Mirror of
-aether-code ``src/core/config.ts``: a single env var (AETHER_BASE_URL) re-points
-every API call at a staging/self-hosted backend, and AETHER_CONFIG_DIR relocates
-the whole config directory (used by tests). A corrupt config.json must NEVER
-crash the CLI — it falls back to the defaults.
+aether-code ``src/core/config.ts``: AETHER_BASE_URL re-points every API call at a
+staging/self-hosted backend, AETHER_BACKEND forces the routing knob
+(``local`` / ``auto`` / ``cloud``), and AETHER_CONFIG_DIR relocates the whole
+config directory (used by tests). A corrupt config.json must NEVER crash the
+CLI — it falls back to the defaults.
+
+This project is local-first: ``backend`` defaults to ``local`` so a fresh clone
+runs every turn on the user's own Ollama and never calls the hosted API. ``auto``
+and ``cloud`` are opt-in — the hosted API is the maintainer's own instance.
 
 On-disk contract (lockstep with the TS mirror):
   - dir:  ~/.config/aether            (env AETHER_CONFIG_DIR override)
   - file: <dir>/config.json
   - default baseUrl: https://api.aethersystems.net/cloud
+  - default backend: local            (env AETHER_BACKEND override)
 """
 from __future__ import annotations
 
@@ -32,7 +38,7 @@ DEFAULT_BASE_URL = "https://api.aethersystems.net/cloud"
 DEFAULT_CONFIG: dict[str, Any] = {
     "baseUrl": DEFAULT_BASE_URL,
     "defaultModel": "",
-    "backend": "auto",
+    "backend": "local",  # local-first default; auto/cloud are opt-in (env AETHER_BACKEND)
     "permissionMode": "ask",
     "autoApply": False,
     "telemetry": True,
@@ -59,7 +65,8 @@ def load_config() -> dict[str, Any]:
 
     Missing file -> a copy of the defaults. Corrupt/partial JSON -> defaults with
     any readable keys merged in (a bad config can't brick the CLI). The
-    AETHER_BASE_URL env var ALWAYS wins for ``baseUrl`` (env > file > default).
+    AETHER_BASE_URL env var ALWAYS wins for ``baseUrl`` and AETHER_BACKEND for
+    ``backend`` (env > file > default).
     """
     cfg = dict(DEFAULT_CONFIG)
     path = config_path()
@@ -74,6 +81,9 @@ def load_config() -> dict[str, Any]:
     env_base = os.environ.get("AETHER_BASE_URL")
     if env_base:
         cfg["baseUrl"] = env_base
+    env_backend = os.environ.get("AETHER_BACKEND")
+    if env_backend and env_backend.strip():
+        cfg["backend"] = env_backend.strip()
     return cfg
 
 

--- a/aether_agent/repl.py
+++ b/aether_agent/repl.py
@@ -9,9 +9,11 @@ then loops on ``input()``: a line starting with ``/`` goes to
 whose events are rendered with the shared vocabulary (monologue / tool_call /
 tool_result / done / error).
 
-Policy: ``FileTokenStore`` has a token -> cloud brain; else local Ollama. The
-``backend`` config knob (``auto`` / ``local`` / ``cloud``) is honored by
-``select_brain``. Ctrl-C aborts the current turn (prints ``(interrupted)``);
+Policy: the ``backend`` config knob is honored by ``select_brain`` and defaults
+to ``local`` — this is a local-first project, so turns run on the user's own
+Ollama and nothing leaves the machine. Opt into the hosted API with ``auto``
+(cloud when a token is present, else local) or ``cloud``. Ctrl-C aborts the
+current turn (prints ``(interrupted)``);
 Ctrl-C at an empty prompt (or EOF) exits. A non-TTY stdin uses the same plain
 ``input()`` loop (no raw-mode key handling — that lives in the TS host).
 
@@ -46,7 +48,7 @@ _PROMPT = "aether › "
 
 def _backend_label(backend: str, authed: bool) -> str:
     """Human label for the brain that will serve turns this session."""
-    b = (backend or "auto").strip().lower()
+    b = (backend or "local").strip().lower()
     if b == "cloud" or (b == "auto" and authed):
         return "cloud (Aether API)"
     return "local Ollama (offline)"
@@ -98,7 +100,7 @@ def _run_turn(brain: Any, line: str, out: Any) -> None:
 
 def _build_ollama(backend: str, authed: bool) -> Any:
     """The local Ollama controller, only when this session will serve locally."""
-    b = (backend or "auto").strip().lower()
+    b = (backend or "local").strip().lower()
     if b == "cloud" or (b == "auto" and authed):
         return None  # cloud session — no local daemon to manage
     return OllamaCtl()
@@ -203,7 +205,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     out = sys.stdout
     cfg = load_config()
     base_url = cfg.get("baseUrl", "")
-    backend = str(cfg.get("backend", "auto"))
+    backend = str(cfg.get("backend", "local"))
     model = str(cfg.get("defaultModel", "") or "")
 
     store = FileTokenStore()

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -21,10 +21,11 @@ from aether_agent import config as agent_config
 def test_defaults_when_no_file(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
     monkeypatch.delenv("AETHER_BASE_URL", raising=False)
+    monkeypatch.delenv("AETHER_BACKEND", raising=False)
     cfg = agent_config.load_config()
     assert cfg["baseUrl"] == "https://api.aethersystems.net/cloud"
     assert cfg["defaultModel"] == ""
-    assert cfg["backend"] == "auto"
+    assert cfg["backend"] == "local"  # local-first: a fresh clone never phones home
     assert cfg["permissionMode"] == "ask"
     assert cfg["autoApply"] is False
     assert cfg["telemetry"] is True
@@ -59,6 +60,15 @@ def test_base_url_env_overrides_saved_file(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("AETHER_BASE_URL", "https://env.example.net/cloud")
     cfg = agent_config.load_config()
     assert cfg["baseUrl"] == "https://env.example.net/cloud"
+
+
+def test_backend_env_overrides_default(tmp_path: Path, monkeypatch):
+    # AETHER_BACKEND opts a clone into the hosted API without editing config.json.
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("AETHER_BASE_URL", raising=False)
+    monkeypatch.setenv("AETHER_BACKEND", "cloud")
+    cfg = agent_config.load_config()
+    assert cfg["backend"] == "cloud"
 
 
 # --- corrupt json fallback ------------------------------------------------

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -150,6 +150,35 @@ def test_auth_login_with_token_stores_it(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert FileTokenStore().get() == "aek_testtoken123"
 
 
+def test_auth_login_enables_cloud_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Local is the default, but signing in opts you into the hosted API (auto)
+    # in one step — the cloud is never disabled, only off by default.
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("AETHER_TOKEN", raising=False)
+    monkeypatch.delenv("AETHER_BACKEND", raising=False)
+    from aether_agent.config import load_config
+
+    assert load_config()["backend"] == "local"  # fresh install: local-first
+    code = cli.main(["auth", "login", "--token", "aek_testtoken123"])
+    assert code == 0
+    assert load_config()["backend"] == "auto"  # sign-in moved it onto the cloud
+
+
+def test_auth_login_keeps_explicit_backend_choice(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A deliberate backend choice is never overwritten by login.
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("AETHER_TOKEN", raising=False)
+    monkeypatch.delenv("AETHER_BACKEND", raising=False)
+    from aether_agent.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["backend"] = "cloud"
+    save_config(cfg)
+    code = cli.main(["auth", "login", "--token", "tok"])
+    assert code == 0
+    assert load_config()["backend"] == "cloud"  # unchanged
+
+
 def test_auth_logout_clears_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
     monkeypatch.delenv("AETHER_TOKEN", raising=False)


### PR DESCRIPTION
## Summary

Make the agent **local-first by default** so a fresh clone runs entirely on the user's own machine and never calls the hosted API unless asked. The Aether cloud stays fully available — it's now opt-in via sign-in rather than the implicit default.

## What changed

- **Default backend `auto` → `local`** (`config.py`). A fresh clone (no token, no config) runs every turn on local Ollama; nothing leaves the machine and no account is needed.
- **One-step cloud sign-in** (`cli.py`). `aether auth login` now moves a local-default install onto `auto` (cloud while signed in, local otherwise), so the hosted API still "just works" after login without a second command. An explicit `cloud`/`auto` choice is never overwritten, and it's reversible with `aether config set backend local`.
- **`AETHER_BACKEND` env override** implemented (was documented in the README but never wired in) — force `local|auto|cloud` for a run without editing `config.json`.
- **Docs**: README backend section updated to reflect the local-first default and the opt-in cloud path.
- Also includes an earlier README professional-cleanup commit already on this branch.

## Behavior

| Situation | Backend |
|---|---|
| Fresh clone, never logged in | local (own Ollama) |
| `aether auth login` | cloud (login flips `local`→`auto` in one step) |
| `aether auth logout` | falls back to local (under `auto`) |
| `aether config set backend local` | local (reversible anytime) |
| Explicit `backend cloud`/`auto` already set | unchanged |

## Test plan

- `pytest -q` — **543 passed, 5 skipped** (skips are the Ollama/network integration tests).
- New tests: default backend is `local`; `AETHER_BACKEND` override; sign-in upgrades `local`→`auto`; explicit backend choice preserved across login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
