### PR TITLE
feat(bench): SWE-bench codepro eval — dsv4-pro off vs engine-MAX (turbovec+overpool+chain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,16 +280,16 @@ Python-native twin of [`aether-code`](https://github.com/DBarr3/aether-agent) (t
 | `aether` | Open the interactive REPL (local Ollama by default). |
 | `aether "<prompt>"` | One-shot turn, streamed. |
 | `aether code "<task>"` | Autonomous coding run on the Unlimited Context brain (test-gated, git-checkpointed). |
-| `aether auth login` | Sign in (`--token <t>` or `--username/--password`) → turns switch to the Aether cloud API. |
+| `aether auth login` | Sign in (`--token <t>` or `--username/--password`) for the hosted API (then set `backend auto\|cloud`). |
 | `aether auth status \| logout \| token` | Show / clear / print the stored credential. |
 | `aether models` | List models available to your tier. |
-| `aether config [show\|get <k>\|set <k> <v>]` | Local settings, incl. `backend = auto\|local\|cloud`. |
+| `aether config [show\|get <k>\|set <k> <v>]` | Local settings, incl. `backend = local (default)\|auto\|cloud`. |
 
 **Slash commands** (inside the REPL): `/help` · `/models` · `/model <tag>` · `/agents` · `/agent <id>` · `/tier` · `/audit [n]` · `/web <query>` · `/clear` · `/exit`.
 
 **Web tools** — the agent can reach the web on any backend: `web_search` (DuckDuckGo, no key) and `web_fetch` (URL → readable text, SSRF-guarded).
 
-**Backend** — `auto` (the default) uses your local Ollama until you `aether auth login`, then the Aether cloud API. Force it with `aether config set backend local|cloud` or `AETHER_BACKEND=local`.
+**Backend** — `local` (the default) runs every turn on your own Ollama; nothing leaves your machine and no account is needed. Opt into the hosted Aether API with `aether config set backend auto|cloud` (or `AETHER_BACKEND=auto`) plus `aether auth login` — `auto` uses the cloud only when you're signed in and falls back to local otherwise. The hosted API is the maintainer's own instance, so a fresh clone never calls it.
 
 **Smoke test** — with Ollama up, `python -m aether_agent.smoke` (or `aether-smoke`) runs the SSRF guard, a real local turn, a web search + fetch, and the cloud path (when signed in), printing `PASS`/`SKIP`/`FAIL` (exit non-zero only on a real failure — missing Ollama/network/sign-in are skips).
 

--- a/README.md
+++ b/README.md
@@ -2,29 +2,18 @@
 
 # ⚡ Unlimited Context LLM
 
-Give your Ai superpowers with **Unlimited context for [Ollama](https://ollama.com)** — give any LLM a **billion+ token memory**. Local-first, on your own machine, free.
+**Give your AI superpowers with unlimited context for [Ollama](https://ollama.com)** — a **billion+ token memory** for any LLM. Local-first, on your own machine, free.
 
 <img width="537" height="405" alt="Unlimited Context" src="https://github.com/user-attachments/assets/79758729-ead7-42ca-9784-831cae68ef06" />
 
-[![License](https://img.shields.io/badge/license-Apache--2.0-06b6d4)](LICENSE) [![Python](https://img.shields.io/badge/python-3.10%2B-14b8a6)](https://www.python.org) [![Built by Aether](https://img.shields.io/badge/built%20by-Aether-7c3aed)](https://aethersystems.net)
+[![License](https://img.shields.io/badge/License-Apache_2.0-06b6d4?style=flat-square)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-14b8a6?style=flat-square&logo=python&logoColor=white)](https://www.python.org)
+[![Built by Aether](https://img.shields.io/badge/Built_by-Aether-7c3aed?style=flat-square)](https://aethersystems.net)
+[![Local-first](https://img.shields.io/badge/Local--first-100%25_offline-0ea5e9?style=flat-square)](#what-you-get)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square)](CONTRIBUTING.md)
+[![Stars](https://img.shields.io/github/stars/DBarr3/Unlimited-Context-LLM?style=flat-square&logo=github&color=eab308)](https://github.com/DBarr3/Unlimited-Context-LLM/stargazers)
 
 **An open project from [Aether](https://aethersystems.net)** · Apache-2.0 · [Install](#quickstart)
-
-</div>
-
----
-
-<div align="center">
-
-> **Your context window didn't get bigger. Its *reach* did.**
-> Unlimited Context is virtual memory for an LLM. The model keeps its small window; the engine keeps a vast store on your disk and pulls the *right slice* back in while the model reasons. A small local model stays coherent across runs that would blow past any context window.
-
-> ⚠️ **Giving a model durable memory is powerful — read the safety measures first.** Real
-> concerns (runaway agents, grounding drift, an agent's own notes becoming its rules) and what
-> we do about them: **[Aether AI — Ethical & Safety Measures](SAFETY.md)**. The project is open
-> under Apache-2.0 and governed by the **[Acceptable Use Policy](USE_POLICY.md)** — these are not
-> recommendations. Anyone using the project must comply with its terms, and by using the project you
-> already agree to and are bound by them.
 
 <p align="center">
   <a href="#the-shape-of-it">The shape of it</a> ·
@@ -47,7 +36,17 @@ Give your Ai superpowers with **Unlimited context for [Ollama](https://ollama.co
 
 ---
 
-<div align="center">
+> **Your context window didn't get bigger. Its *reach* did.**
+> Unlimited Context is virtual memory for an LLM. The model keeps its small window; the engine keeps a vast store on your disk and pulls the *right slice* back in while the model reasons. A small local model stays coherent across runs that would blow past any context window.
+
+> ⚠️ **Giving a model durable memory is powerful — read the safety measures first.** Real
+> concerns (runaway agents, grounding drift, an agent's own notes becoming its rules) and what
+> we do about them: **[Aether AI — Ethical & Safety Measures](SAFETY.md)**. The project is open
+> under Apache-2.0 and governed by the **[Acceptable Use Policy](USE_POLICY.md)** — these are not
+> recommendations. Anyone using the project must comply with its terms, and by using the project you
+> already agree to and are bound by them.
+
+---
 
 ## The shape of it
 
@@ -60,10 +59,7 @@ Four steps, start to reach:
 
 That's it. A 5 GB pool gives a small model ~1.16B tokens of reach — about **9,000×** a 128K window — on your own machine, offline.
 
-
 ---
-
-<div align="center">
 
 ## The problem
 
@@ -172,7 +168,6 @@ How those numbers come out: ~2.2 KB per slice (a 256-dim vector + compressed tex
 > **Honest:** that's encoded **reach**, retrieved in slices — not a bigger attention window, and it rides on retrieval hit rate. A bigger pool buys more reachable codebase/corpus *per session* — not more concurrent sessions (those are RAM-bound, ~30 on 8 GB either way).
 
 ---
-
 
 ## The proof
 
@@ -323,21 +318,6 @@ That's the whole thing. One small model, one command, a billion tokens of reach 
 
 "Unlimited" means **reach, not attention.** Your model keeps its native window — we make it *reach* a billion-token pool in slices, via fast retrieval. The whole thing rides on retrieval **hit rate**; when it's high (and the loader is built to keep it high), the pool feels like one seamless context. The measured proof of all this is up top — see [The proof](#the-proof).
 
-## Benchmark — measured, on a real model
-
-A live run on **`deepseek/deepseek-v4-pro`** (via OpenRouter), driving an agent through **60 real GitHub issues** over a **40-turn session that overflows the model's window** — engine **on** vs **off** (off = no engine, same model, transcript truncated to the window). Full write-up: [`docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md`](docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md).
-
-| Metric | Off (baseline) | On (engine) | Change |
-|---|:---:|:---:|:---:|
-| **Recall coherence** (early facts still correct) | 0.15 | **1.00** | **6.7×** |
-| **Work outcome** (tasks done right) | 3 / 20 | **20 / 20** | **3 → 20** |
-| **Cost — full session** | $0.0711 | **$0.0542** | **−24%** |
-| **Cost — back half (recall phase)** | $0.00117/turn | **$0.00053/turn** | **−54%** |
-
-What the engine provided, in one session: it **held coherence flat at 1.00 while the baseline drifted to 0.15** (early issues fell out of the window and were lost), turned a **3/20 failing run into 20/20**, and did it for **~25% less money overall — over half off in the back half**, where the baseline drags a bloated transcript into every call and the engine sends a compact recalled window. Total spend for the whole benchmark: **$0.19**. Committed raw artifacts: [`docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/`](docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/) (`api_eval_results.json`, `api_eval_series.csv`, `api_eval_plot.png`, `RESULTS.md`).
-
-<sub>**Scope, honestly:** this measures the **engine** (retrieve-on-overflow memory), not the MPO chain — on this single-fact recall task the MPO chain **ties** plain recall (both 1.00). The MPO's multi-slice edge is **synthetic-only so far** (`bench/chain_recall.py`: connected-context recall 0.15 → 0.78); the live `thread` run that would confirm it is **pending** — not yet claimed. Magnitude scales with the overflow ratio: the 2000-token window is deliberately tiny to force overflow, so a realistic window shows a smaller (still real) gain. N=20 recall turns, single run. Reproduce: `python -m bench.api_eval --model deepseek/deepseek-v4-pro --repo microsoft/vscode --arms off,on,on_chain --plot`.</sub>
-
 ## Citation
 
 If Unlimited Context helps your work, please cite it. Built and maintained by **Aether AI**.
@@ -362,8 +342,6 @@ If this gave your local model superpowers, **drop a star** — it's how other pe
 ## License
 
 **Apache-2.0.** Use it, fork it, ship it in your product.
-
-</div>
 
 ---
 

--- a/aether_agent/cli.py
+++ b/aether_agent/cli.py
@@ -111,7 +111,7 @@ def _one_shot(prompt: str) -> int:
     api = ApiClient(cfg.get("baseUrl", ""), store)
     brain = select_brain(
         authed=store.get() is not None,
-        backend=str(cfg.get("backend", "auto")),
+        backend=str(cfg.get("backend", "local")),
         api=api,
         model=str(cfg.get("defaultModel", "") or ""),
     )

--- a/aether_agent/cli.py
+++ b/aether_agent/cli.py
@@ -156,7 +156,7 @@ def _cmd_auth(rest: list[str]) -> int:
     action = ns.action or "status"
 
     if action == "login":
-        return _auth_login(ns, base_url, store)
+        return _auth_login(ns, cfg, store)
     if action == "logout":
         store.clear()
         print("logged out.")
@@ -174,13 +174,15 @@ def _cmd_auth(rest: list[str]) -> int:
     return 0
 
 
-def _auth_login(ns: argparse.Namespace, base_url: str, store: FileTokenStore) -> int:
+def _auth_login(ns: argparse.Namespace, cfg: dict[str, Any], store: FileTokenStore) -> int:
+    base_url = cfg.get("baseUrl", "")
     token = ns.token
     if ns.with_token and not token:
         token = sys.stdin.readline().strip()
     if token:
         store.set(token)
         print("token saved.")
+        _enable_cloud_after_login(cfg)
         return 0
     if ns.username and ns.password:
         try:
@@ -190,9 +192,26 @@ def _auth_login(ns: argparse.Namespace, base_url: str, store: FileTokenStore) ->
             return 1
         plan = res.get("plan")
         print(f"logged in{f' (plan {plan})' if plan else ''}.")
+        _enable_cloud_after_login(cfg)
         return 0
     print("usage: aether auth login [--token T | --username U --password P | --with-token]", file=sys.stderr)
     return 1
+
+
+def _enable_cloud_after_login(cfg: dict[str, Any]) -> None:
+    """Signing in is an explicit "use the hosted API" signal, so move a
+    local-default install onto ``auto`` (cloud while signed in, local otherwise)
+    — turns then reach the Aether API without a second command. An explicit
+    ``cloud`` / ``auto`` choice is left untouched, and we never silently
+    downgrade: local-first is only the *unconfigured* default, not a lock, and
+    sign-in is fully reversible with ``aether config set backend local``.
+    """
+    if str(cfg.get("backend", "local")).strip().lower() != "local":
+        return
+    cfg["backend"] = "auto"
+    save_config(cfg)
+    print("cloud enabled (backend=auto); turns use the Aether API while you're signed in.")
+    print("  stay local instead with: aether config set backend local")
 
 
 # --- models ----------------------------------------------------------------

--- a/aether_agent/config.py
+++ b/aether_agent/config.py
@@ -5,15 +5,21 @@
 
 This is the AGENT (CLI host) config and is deliberately distinct from
 ``aether_context.config`` (the engine's on-disk *pool* config). Mirror of
-aether-code ``src/core/config.ts``: a single env var (AETHER_BASE_URL) re-points
-every API call at a staging/self-hosted backend, and AETHER_CONFIG_DIR relocates
-the whole config directory (used by tests). A corrupt config.json must NEVER
-crash the CLI — it falls back to the defaults.
+aether-code ``src/core/config.ts``: AETHER_BASE_URL re-points every API call at a
+staging/self-hosted backend, AETHER_BACKEND forces the routing knob
+(``local`` / ``auto`` / ``cloud``), and AETHER_CONFIG_DIR relocates the whole
+config directory (used by tests). A corrupt config.json must NEVER crash the
+CLI — it falls back to the defaults.
+
+This project is local-first: ``backend`` defaults to ``local`` so a fresh clone
+runs every turn on the user's own Ollama and never calls the hosted API. ``auto``
+and ``cloud`` are opt-in — the hosted API is the maintainer's own instance.
 
 On-disk contract (lockstep with the TS mirror):
   - dir:  ~/.config/aether            (env AETHER_CONFIG_DIR override)
   - file: <dir>/config.json
   - default baseUrl: https://api.aethersystems.net/cloud
+  - default backend: local            (env AETHER_BACKEND override)
 """
 from __future__ import annotations
 
@@ -32,7 +38,7 @@ DEFAULT_BASE_URL = "https://api.aethersystems.net/cloud"
 DEFAULT_CONFIG: dict[str, Any] = {
     "baseUrl": DEFAULT_BASE_URL,
     "defaultModel": "",
-    "backend": "auto",
+    "backend": "local",  # local-first default; auto/cloud are opt-in (env AETHER_BACKEND)
     "permissionMode": "ask",
     "autoApply": False,
     "telemetry": True,
@@ -59,7 +65,8 @@ def load_config() -> dict[str, Any]:
 
     Missing file -> a copy of the defaults. Corrupt/partial JSON -> defaults with
     any readable keys merged in (a bad config can't brick the CLI). The
-    AETHER_BASE_URL env var ALWAYS wins for ``baseUrl`` (env > file > default).
+    AETHER_BASE_URL env var ALWAYS wins for ``baseUrl`` and AETHER_BACKEND for
+    ``backend`` (env > file > default).
     """
     cfg = dict(DEFAULT_CONFIG)
     path = config_path()
@@ -74,6 +81,9 @@ def load_config() -> dict[str, Any]:
     env_base = os.environ.get("AETHER_BASE_URL")
     if env_base:
         cfg["baseUrl"] = env_base
+    env_backend = os.environ.get("AETHER_BACKEND")
+    if env_backend and env_backend.strip():
+        cfg["backend"] = env_backend.strip()
     return cfg
 
 

--- a/aether_agent/repl.py
+++ b/aether_agent/repl.py
@@ -9,9 +9,11 @@ then loops on ``input()``: a line starting with ``/`` goes to
 whose events are rendered with the shared vocabulary (monologue / tool_call /
 tool_result / done / error).
 
-Policy: ``FileTokenStore`` has a token -> cloud brain; else local Ollama. The
-``backend`` config knob (``auto`` / ``local`` / ``cloud``) is honored by
-``select_brain``. Ctrl-C aborts the current turn (prints ``(interrupted)``);
+Policy: the ``backend`` config knob is honored by ``select_brain`` and defaults
+to ``local`` — this is a local-first project, so turns run on the user's own
+Ollama and nothing leaves the machine. Opt into the hosted API with ``auto``
+(cloud when a token is present, else local) or ``cloud``. Ctrl-C aborts the
+current turn (prints ``(interrupted)``);
 Ctrl-C at an empty prompt (or EOF) exits. A non-TTY stdin uses the same plain
 ``input()`` loop (no raw-mode key handling — that lives in the TS host).
 
@@ -46,7 +48,7 @@ _PROMPT = "aether › "
 
 def _backend_label(backend: str, authed: bool) -> str:
     """Human label for the brain that will serve turns this session."""
-    b = (backend or "auto").strip().lower()
+    b = (backend or "local").strip().lower()
     if b == "cloud" or (b == "auto" and authed):
         return "cloud (Aether API)"
     return "local Ollama (offline)"
@@ -98,7 +100,7 @@ def _run_turn(brain: Any, line: str, out: Any) -> None:
 
 def _build_ollama(backend: str, authed: bool) -> Any:
     """The local Ollama controller, only when this session will serve locally."""
-    b = (backend or "auto").strip().lower()
+    b = (backend or "local").strip().lower()
     if b == "cloud" or (b == "auto" and authed):
         return None  # cloud session — no local daemon to manage
     return OllamaCtl()
@@ -203,7 +205,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     out = sys.stdout
     cfg = load_config()
     base_url = cfg.get("baseUrl", "")
-    backend = str(cfg.get("backend", "auto"))
+    backend = str(cfg.get("backend", "local"))
     model = str(cfg.get("defaultModel", "") or "")
 
     store = FileTokenStore()

--- a/aether_context/config.py
+++ b/aether_context/config.py
@@ -91,11 +91,17 @@ class PoolConfig:
     dim: int = DEFAULT_DIM
     slice_tokens: int = DEFAULT_SLICE_TOKENS
     dir: Path = field(default_factory=default_pool_dir)
+    quantize_bits: int = 0   # TurboVec: 0 = float32 (default); 8 = recall-safe (~4x); 4 = lossy/flagged
 
     def __post_init__(self) -> None:
         # Path coercion (callers may pass a str).
         if not isinstance(self.dir, Path):
             self.dir = Path(self.dir)
+        if self.quantize_bits not in (0, 4, 8):
+            raise PoolBudgetError(
+                f"quantize_bits={self.quantize_bits} is not one of (0, 4, 8)",
+                hint="0=float32, 8=recall-safe TurboVec (~4x), 4=lossy (flag-only).",
+            )
         if self.pool_gb < POOL_GB_FLOOR:
             raise PoolBudgetError(
                 f"pool_gb={self.pool_gb} is below the {POOL_GB_FLOOR} GB pool floor "

--- a/aether_context/context_pool.py
+++ b/aether_context/context_pool.py
@@ -47,6 +47,7 @@ import numpy as np
 from aether_context._log import get_logger
 from aether_context.config import PoolConfig, TOKENS_PER_GB
 from aether_context.errors import PoolBudgetError, PoolCorrupt
+from aether_context.quantize import dequantize, packed_bytes_per_row, quantize
 from aether_context.witness import Witness
 
 logger = get_logger(__name__)
@@ -249,6 +250,14 @@ class ContextPool:
     def __init__(self, config: PoolConfig, *, ceiling_bytes: int | None = None) -> None:
         self._config = config
         self._dim = config.dim
+        # TurboVec: 0 = float32 (default; this whole class is byte-identical to before). >0 stores
+        # quantized CODES on disk (8-bit recall-safe) while keeping the float32 unit vector in RAM for
+        # exact search — so disk footprint drops ~4x with no recall loss; reload dequantizes.
+        self._qbits = int(getattr(config, "quantize_bits", 0) or 0)
+        self._mdtype = np.uint8 if self._qbits else np.float32
+        self._mcols = packed_bytes_per_row(self._dim, self._qbits) if self._qbits else self._dim
+        self._vname = f"vectors.q{self._qbits}" if self._qbits else VECTORS_FILENAME
+        self._scale_of: dict[str, float] = {}   # per-slice quant scale (qbits>0 only)
         self._dir = Path(config.dir)
         # Resolve the index kind: honor 'hnsw' only when the lib is importable. 'tiered' is
         # accepted by config but not yet built — rather than silently masquerade as a paged
@@ -304,7 +313,17 @@ class ContextPool:
 
     # -- paths -----------------------------------------------------------------
     def _vectors_file(self) -> Path:
-        return self._dir / VECTORS_FILENAME
+        return self._dir / self._vname
+
+    def _write_row(self, row: int, sid: str, unit_vec: np.ndarray) -> None:
+        """Write a unit vector into mmap row ``row`` — quantized to codes when TurboVec is on."""
+        assert self._mmap is not None
+        if self._qbits:
+            codes, scale = quantize(unit_vec[None], self._qbits)
+            self._mmap[row] = codes[0]
+            self._scale_of[sid] = float(scale[0])
+        else:
+            self._mmap[row] = unit_vec
 
     def _metadata_file(self) -> Path:
         return self._dir / METADATA_FILENAME
@@ -358,7 +377,7 @@ class ContextPool:
             self._row_of[sl.id] = row
         stored_vec = self._unit(vec)
         assert self._mmap is not None
-        self._mmap[row] = stored_vec
+        self._write_row(row, sl.id, stored_vec)
         self._slices[sl.id] = Slice(
             id=sl.id,
             session=sl.session,
@@ -507,6 +526,7 @@ class ContextPool:
         """Drop a single slice id from the in-RAM structures (mmap row reclaimed on compact)."""
         self._slices.pop(sid, None)
         self._row_of.pop(sid, None)
+        self._scale_of.pop(sid, None)
         self._witness.forget(sid)
         try:
             self._order.remove(sid)
@@ -526,9 +546,15 @@ class ContextPool:
         if n == 0:
             self._row_of = {}
             return
-        packed = np.empty((n, self._dim), dtype=np.float32)
+        packed = np.empty((n, self._mcols), dtype=self._mdtype)
         for new_row, sid in enumerate(self._order):
-            packed[new_row] = self._slices[sid].vector
+            v = self._slices[sid].vector
+            if self._qbits:
+                codes, scale = quantize(v[None], self._qbits)
+                packed[new_row] = codes[0]
+                self._scale_of[sid] = float(scale[0])
+            else:
+                packed[new_row] = v
             self._row_of[sid] = new_row
         self._mmap[:n] = packed
 
@@ -546,6 +572,8 @@ class ContextPool:
             "dim": self._dim,
             "index": self.index_kind,
             "sessions": sorted({s.session for s in self._slices.values()}),
+            "quantized": self._qbits > 0,
+            "quantize_bits": self._qbits,
         }
 
     # -- persistence -----------------------------------------------------------
@@ -582,12 +610,14 @@ class ContextPool:
                 "tokens": self._slices[sid].tokens,
                 "meta": self._slices[sid].meta,
                 "score": self._slices[sid].score,
+                "scale": self._scale_of.get(sid, 1.0),
             }
             for sid in self._order
         ]
         header = {
             "version": POOL_FORMAT_VERSION,
             "dim": self._dim,
+            "quantize_bits": self._qbits,
             "count": len(self._order),
             "capacity": self._capacity,
             "index": self._config.index,
@@ -619,6 +649,12 @@ class ContextPool:
                 f"pool at {self._dir} was written with dim={disk_dim}, "
                 f"but this pool expects dim={self._dim}",
             )
+        disk_qbits = int(header.get("quantize_bits", 0))
+        if disk_qbits != self._qbits:
+            raise PoolCorrupt(
+                f"pool at {self._dir} was written with quantize_bits={disk_qbits}, "
+                f"but this pool expects quantize_bits={self._qbits} (codes can't be reinterpreted)",
+            )
         vfile = self._vectors_file()
         if not vfile.exists():
             raise PoolCorrupt(
@@ -631,7 +667,14 @@ class ContextPool:
             for rec in records:
                 sid = rec["id"]
                 row = int(rec["row"])
-                vec = np.asarray(self._mmap[row], dtype=np.float32).copy()
+                if self._qbits:
+                    scale = float(rec.get("scale", 1.0))
+                    self._scale_of[sid] = scale
+                    vec = dequantize(np.asarray(self._mmap[row])[None],
+                                     np.array([scale], dtype=np.float32),
+                                     self._dim, self._qbits)[0]
+                else:
+                    vec = np.asarray(self._mmap[row], dtype=np.float32).copy()
                 sl = Slice(
                     id=sid,
                     session=rec["session"],
@@ -670,7 +713,7 @@ class ContextPool:
         if self._mmap is not None:
             keep = min(self._capacity, len(self._order))
             if keep > 0:
-                carry = np.asarray(self._mmap[:keep], dtype=np.float32).copy()
+                carry = np.asarray(self._mmap[:keep], dtype=self._mdtype).copy()
         self._release_mmap()
         self._dir.mkdir(parents=True, exist_ok=True)
         self._open_mmap(new_cap, carry=carry)
@@ -695,7 +738,7 @@ class ContextPool:
         seed = carry
         if seed is None and vfile.exists() and capacity > 0:
             seed = self._read_existing_rows(vfile, capacity)
-        mm = np.memmap(vfile, dtype=np.float32, mode="w+", shape=(capacity, self._dim))
+        mm = np.memmap(vfile, dtype=self._mdtype, mode="w+", shape=(capacity, self._mcols))
         if seed is not None and seed.shape[0] > 0:
             rows = min(seed.shape[0], capacity)
             mm[:rows] = seed[:rows]
@@ -709,17 +752,17 @@ class ContextPool:
         call — required so the subsequent ``w+`` mmap open succeeds on Windows.
         """
         size = vfile.stat().st_size
-        row_bytes = self._dim * 4
+        row_bytes = self._mcols * np.dtype(self._mdtype).itemsize
         if row_bytes == 0:
             return None
         n_rows = size // row_bytes
         if n_rows == 0:
             return None
         take = min(n_rows, capacity)
-        flat = np.fromfile(vfile, dtype=np.float32, count=take * self._dim)
-        if flat.size < take * self._dim:
+        flat = np.fromfile(vfile, dtype=self._mdtype, count=take * self._mcols)
+        if flat.size < take * self._mcols:
             return None
-        return flat.reshape(take, self._dim)
+        return flat.reshape(take, self._mcols)
 
     # -- helpers ---------------------------------------------------------------
     def _live_matrix(self) -> np.ndarray:
@@ -727,6 +770,9 @@ class ContextPool:
         n = len(self._order)
         if n == 0 or self._mmap is None:
             return np.empty((0, self._dim), dtype=np.float32)
+        if self._qbits:
+            # mmap holds quantized codes; search on the exact float32 RAM copies (recall parity).
+            return np.array([self._slices[sid].vector for sid in self._order], dtype=np.float32)
         return np.asarray(self._mmap[:n])
 
     def _refresh_index(self, matrix: np.ndarray) -> None:

--- a/aether_context/quantize.py
+++ b/aether_context/quantize.py
@@ -1,0 +1,86 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""TurboVec — scalar quantization of unit retrieval vectors (the context pool's compression codec).
+
+The context pool stores L2-normalized 256-dim float32 vectors (1024 B/row). TurboVec quantizes each
+row to ``bits``-bit codes + a per-row float32 scale, so the footprint drops to ``dim*bits/8 + 4`` bytes
+— ~8x at 4-bit, ~4x at 8-bit. The same byte ceiling then holds that many more slices in the hot set,
+which is the coherence-at-scale win (more of the run stays resident, fewer cold reads).
+
+Per-row SYMMETRIC quantization: ``code = round(v/scale) + half`` over ``scale = max|v| / half``, so the
+row's dynamic range maps onto the integer grid. Dequantization recovers ``(code-half)*scale`` and
+RE-NORMALIZES to unit length (cosine only cares about direction). Recall@k parity vs float32 is the gate
+the tests enforce (>=0.98). ``bits=0`` is the identity (the float32 path) — TurboVec is fully reversible.
+
+Pure numpy, no dependencies. Only 4- and 8-bit are supported (the codes pack to whole bytes cleanly).
+"""
+from __future__ import annotations
+
+import numpy as np
+
+SUPPORTED_BITS = (0, 4, 8)
+
+
+def packed_bytes_per_row(dim: int, bits: int) -> int:
+    """On-disk/in-RAM code bytes for one row at ``bits`` (excludes the 4-byte per-row scale)."""
+    if bits == 0:
+        return dim * 4
+    if bits == 8:
+        return dim
+    if bits == 4:
+        return (dim + 1) // 2
+    raise ValueError(f"unsupported bits={bits}; use one of {SUPPORTED_BITS}")
+
+
+def quantize(matrix: np.ndarray, bits: int = 4) -> tuple[np.ndarray, np.ndarray]:
+    """``(n, dim)`` float32 rows -> ``(codes uint8 (n, packed), scales float32 (n,))``.
+
+    Rows are assumed ~unit (the pool stores unit vectors). ``bits=0`` returns the raw float32 bytes as
+    uint8 with unit scales (identity passthrough), so callers can treat both paths uniformly.
+    """
+    m = np.ascontiguousarray(matrix, dtype=np.float32)
+    n, dim = m.shape
+    if bits == 0:
+        return m.view(np.uint8).reshape(n, dim * 4), np.ones(n, dtype=np.float32)
+    levels = (1 << bits) - 1
+    half = levels >> 1
+    maxabs = np.max(np.abs(m), axis=1)
+    scales = np.where(maxabs > 1e-12, maxabs / half, 1.0).astype(np.float32)
+    q = np.rint(m / scales[:, None]) + half
+    q = np.clip(q, 0, levels).astype(np.uint8)               # (n, dim) integer codes
+    if bits == 8:
+        return np.ascontiguousarray(q), scales
+    # 4-bit: pack two nibbles per byte (pad odd dim with a zero nibble).
+    if dim & 1:
+        q = np.pad(q, ((0, 0), (0, 1)))
+    codes = ((q[:, 0::2] << 4) | q[:, 1::2]).astype(np.uint8)
+    return np.ascontiguousarray(codes), scales
+
+
+def dequantize(codes: np.ndarray, scales: np.ndarray, dim: int, bits: int = 4) -> np.ndarray:
+    """Inverse of :func:`quantize` -> ``(n, dim)`` float32 UNIT rows (re-normalized for cosine)."""
+    if bits == 0:
+        return codes.reshape(codes.shape[0], dim * 4).view(np.float32).reshape(-1, dim).copy()
+    levels = (1 << bits) - 1
+    half = levels >> 1
+    if bits == 8:
+        q = codes.astype(np.float32)
+    else:  # 4-bit: unpack the nibbles
+        hi = (codes >> 4) & 0xF
+        lo = codes & 0xF
+        q = np.empty((codes.shape[0], hi.shape[1] * 2), dtype=np.float32)
+        q[:, 0::2] = hi
+        q[:, 1::2] = lo
+        q = q[:, :dim]
+    v = (q - half) * scales[:, None]
+    norms = np.linalg.norm(v, axis=1, keepdims=True)
+    norms[norms < 1e-12] = 1.0
+    return (v / norms).astype(np.float32)
+
+
+def compression_ratio(dim: int, bits: int) -> float:
+    """float32 row bytes / quantized row bytes (vector only) — the headline TurboVec multiple."""
+    if bits == 0:
+        return 1.0
+    return (dim * 4) / (packed_bytes_per_row(dim, bits) + 4)

--- a/aether_context/session.py
+++ b/aether_context/session.py
@@ -155,6 +155,7 @@ class Session:
         pool_dir: "str | Path | None" = None,
         pool_index: str = "flat",
         pool_mode: str = "separate",
+        pool_quantize: int = 0,   # TurboVec: 0=float32 (default), 8=recall-safe (~4x), 4=lossy/flagged
         context_window: int | None = None,
         output_tokens: int | None = None,
         resident_k: int = DEFAULT_RESIDENT_K,
@@ -201,6 +202,7 @@ class Session:
             mode=pool_mode,
             index=pool_index,
             dir=Path(pool_dir) if pool_dir is not None else PoolConfig().dir,
+            quantize_bits=pool_quantize,
         )
         self.pool: ContextPool = ContextPool(
             pool_config, ceiling_bytes=pool_ceiling_bytes

--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -1,0 +1,289 @@
+"""swe_eval — SWE-bench codepro eval (Phase A: generation). Drives dsv4-pro through an
+agentic file-tool loop over a per-instance checkout, off vs codepro-engine arms, and writes
+SWE-bench predictions JSONL. Phase B scoring is bench/swe_scoring.py (official swebench).
+
+Run (dry-run, no key): python -m bench.swe_eval --dry-run
+Run (live): OPENROUTER_API_KEY=... python -m bench.swe_eval --instances 1 --arms off,codepro
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from aether_context.encoder import StaticEncoder
+from aether_context.session import Session
+from bench.api_eval import cached_tokens, cost_usd
+from bench.swe_tools import RepoTools, prepare_checkout
+
+DEFAULT_MODEL = "deepseek/deepseek-v4-pro"
+DATASET = "princeton-nlp/SWE-bench_Lite"
+MODEL_NAME = "dsv4pro-codepro"   # stamped into predictions model_name_or_path
+
+
+@dataclass
+class SweConfig:
+    model: str = DEFAULT_MODEL
+    arms: tuple[str, ...] = ("off", "codepro")
+    instances: int = 0            # 0 = all of lite (300); N = first N (sorted)
+    window: int = 8192            # off-arm truncation window
+    max_steps: int = 30           # tool steps per instance ("max reasoning" budget)
+    pool_gb: int = 50             # codepro overpool reach
+    turbovec_bits: int = 8        # codepro TurboVec quant (0/4/8)
+    mpo_chain: bool = True        # codepro MPO chain
+    recall_k: int = 8             # slices recalled per turn (codepro)
+    price_in: float = 0.3
+    price_out: float = 1.2
+    max_usd: float = 25.0         # hard global spend cap (shared across arms+instances)
+    cost_spike_usd: float = 0.50
+    dry_run: bool = False
+    out_dir: Path = field(default_factory=lambda: Path("runs/swe_eval"))
+    work_dir: Path = field(default_factory=lambda: Path("runs/swe_eval/checkouts"))
+
+
+def select_instances(rows: list[dict], n: int) -> list[dict]:
+    """Deterministic instance set: sort by instance_id, take first n (n=0 -> all)."""
+    ordered = sorted(rows, key=lambda r: r["instance_id"])
+    return ordered if n <= 0 else ordered[:n]
+
+
+def load_lite(cfg: SweConfig) -> list[dict]:
+    """Load SWE-bench-lite test split. Dry-run -> a synthetic 2-instance stand-in."""
+    if cfg.dry_run:
+        return [
+            {"instance_id": "syn__repo-1", "repo": "syn/repo", "base_commit": "HEAD",
+             "problem_statement": "Fix add() to add instead of subtract."},
+            {"instance_id": "syn__repo-2", "repo": "syn/repo", "base_commit": "HEAD",
+             "problem_statement": "Fix VALUE to 2."},
+        ]
+    from datasets import load_dataset
+    ds = load_dataset(DATASET, split="test")
+    return [dict(r) for r in ds]
+
+
+def _truncate(messages: list[dict], window_tokens: int) -> list[dict]:
+    """OFF arm: keep system + a tail of messages fitting ~window (chars/4 estimate)."""
+    from aether_context.tokenizer import estimate
+    budget = window_tokens
+    head, tail = messages[:1], []
+    for m in reversed(messages[1:]):
+        c = estimate(m.get("content") or "")
+        if budget - c < 0:
+            break
+        budget -= c
+        tail.insert(0, m)
+    return head + tail
+
+
+_SYS = ("You are an expert software engineer fixing a real bug in a repository. Use read_file, "
+        "grep, and list_dir to investigate, then edit_file to apply a minimal fix. When the fix "
+        "is complete, reply with a one-line summary and STOP (no more tool calls). Make the repo's "
+        "own tests pass; change as little as possible.")
+
+
+def _empty_record(arm: str, inst: dict, halted: str) -> dict:
+    return {
+        "instance_id": inst["instance_id"],
+        "model_name_or_path": MODEL_NAME if arm == "codepro" else f"{MODEL_NAME}-off",
+        "model_patch": "", "arm": arm, "cost_usd": 0.0, "cached_tokens": 0,
+        "tool_calls": 0, "redundant_tool_calls": 0, "patch_nonempty": False,
+        "halted": halted,
+    }
+
+
+def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
+                 *, repo_url: Optional[str] = None) -> dict:
+    """Run ONE SWE instance under ONE arm. Returns a predictions record incl. model_patch.
+    OFF: window-truncated transcript. CODEPRO: Session(overpool+turbovec+chain) recall."""
+    url = repo_url or f"https://github.com/{inst['repo']}.git"
+    workdir = cfg.work_dir / arm / inst["instance_id"]
+    try:
+        checkout = prepare_checkout(url, inst["base_commit"], workdir)
+    except Exception as e:  # clone/checkout failed — record empty patch, keep the batch alive
+        return _empty_record(arm, inst, f"checkout_error: {type(e).__name__}")
+    tools = RepoTools(checkout)
+
+    session: Optional[Session] = None
+    encoder = StaticEncoder(dim=256)
+    if arm == "codepro":
+        session = Session("swe", pool_gb=cfg.pool_gb,
+                          pool_dir=cfg.out_dir / f"pool_{inst['instance_id']}_{arm}",
+                          context_window=cfg.window, mpo_chain=cfg.mpo_chain,
+                          pool_quantize=cfg.turbovec_bits)
+
+    user = (f"Repository: {inst['repo']} @ {inst['base_commit'][:10]}\n\n"
+            f"Problem:\n{inst['problem_statement']}\n\nInvestigate and fix it.")
+    transcript: list[dict] = [{"role": "system", "content": _SYS},
+                              {"role": "user", "content": user}]
+    cost = 0.0
+    cached = 0
+    halted: Optional[str] = None
+
+    for _step in range(cfg.max_steps):
+        if budget["spent"] >= cfg.max_usd:
+            halted = "budget_cap"
+            break
+        if session is not None:
+            qvec = encoder.encode(inst["problem_statement"])
+            recalled = session._cold_retrieve(session._key(), qvec, cfg.recall_k)
+            mem = "\n".join(f"[mem] {s.text}" for s in recalled) or "(empty)"
+            convo = _truncate([transcript[0],
+                               {"role": "system", "content": f"Working memory:\n{mem}"}]
+                              + transcript[1:], cfg.window)
+        else:
+            convo = _truncate(transcript, cfg.window)
+
+        out = chat.chat(convo, tools=RepoTools.TOOLS_SCHEMA)
+        usage = out.get("usage", {}) or {}
+        call_cost = cost_usd(usage, price_in=cfg.price_in, price_out=cfg.price_out)
+        cost += call_cost
+        budget["spent"] += call_cost
+        cached += cached_tokens(usage)
+        if call_cost > cfg.cost_spike_usd:
+            halted = "cost_spike"
+            break
+
+        tcs = out.get("tool_calls") or []
+        if tcs:
+            transcript.append({"role": "assistant", "content": out.get("content"),
+                               "tool_calls": tcs})
+            for tc in tcs:
+                fn = tc.get("function", {})
+                try:
+                    args = json.loads(fn.get("arguments") or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                result = tools.dispatch(fn.get("name", ""), args)
+                rjson = json.dumps(result)[:1500]
+                transcript.append({"role": "tool", "tool_call_id": tc.get("id", ""),
+                                   "content": rjson})
+                if session is not None:
+                    session.remember(f"{fn.get('name')}({args}): {rjson}")
+            continue
+        transcript.append({"role": "assistant", "content": out.get("content") or "done"})
+        break
+
+    patch = tools.current_patch()
+    if session is not None:
+        session.close()
+    return {
+        "instance_id": inst["instance_id"],
+        "model_name_or_path": MODEL_NAME if arm == "codepro" else f"{MODEL_NAME}-off",
+        "model_patch": patch,
+        "arm": arm,
+        "cost_usd": round(cost, 6),
+        "cached_tokens": cached,
+        "tool_calls": tools.calls,
+        "redundant_tool_calls": tools.redundant,
+        "patch_nonempty": bool(patch.strip()),
+        "halted": halted,
+    }
+
+
+def _repo_url(inst: dict) -> str:
+    """GitHub clone URL for an instance (monkeypatched to file:// in tests)."""
+    return f"https://github.com/{inst['repo']}.git"
+
+
+def _done_ids(path: Path) -> set[str]:
+    """instance_ids already written to a predictions JSONL (resume support)."""
+    if not path.exists():
+        return set()
+    ids = set()
+    for ln in path.read_text(encoding="utf-8").splitlines():
+        try:
+            ids.add(json.loads(ln)["instance_id"])
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return ids
+
+
+def _make_live_chat(cfg: SweConfig):
+    from aether_context.local_llm import OpenAICompatLLM
+    return OpenAICompatLLM(cfg.model, context_window=cfg.window)
+
+
+def run_swe_eval(cfg: SweConfig, instances: Optional[list[dict]] = None,
+                 chat_factory=None) -> dict:
+    """Drive every (instance, arm), honoring the shared $ cap and skipping done work.
+    Appends each record to runs/swe_eval/predictions_<arm>.jsonl. Resumable."""
+    cfg.out_dir.mkdir(parents=True, exist_ok=True)
+    rows = instances if instances is not None else select_instances(load_lite(cfg), cfg.instances)
+    chat_factory = chat_factory or (_make_live_chat if not cfg.dry_run else (lambda c: None))
+    budget = {"spent": 0.0}
+    summary: dict[str, Any] = {"arms": {a: {"done": 0, "patched": 0, "cost": 0.0}
+                                        for a in cfg.arms},
+                               "skipped": 0, "halted": None}
+
+    for arm in cfg.arms:
+        pred_path = cfg.out_dir / f"predictions_{arm}.jsonl"
+        done = _done_ids(pred_path)
+        chat = chat_factory(cfg)
+        for inst in rows:
+            if inst["instance_id"] in done:
+                summary["skipped"] += 1
+                continue
+            if budget["spent"] >= cfg.max_usd:
+                summary["halted"] = "budget_cap"
+                break
+            rec = run_instance(arm, inst, cfg, chat, budget, repo_url=_repo_url(inst))
+            with pred_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(rec) + "\n")
+            summary["arms"][arm]["done"] += 1
+            summary["arms"][arm]["patched"] += int(rec["patch_nonempty"])
+            summary["arms"][arm]["cost"] = round(
+                summary["arms"][arm]["cost"] + rec["cost_usd"], 6)
+            if rec.get("halted") in ("budget_cap", "cost_spike"):
+                summary["halted"] = rec["halted"]
+                break
+        if summary["halted"]:
+            break
+
+    summary["total_cost_usd"] = round(budget["spent"], 6)
+    (cfg.out_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary
+
+
+def _build_config(argv: Optional[list[str]] = None) -> SweConfig:
+    p = argparse.ArgumentParser(prog="swe_eval",
+                                description="SWE-bench codepro eval (generation phase).")
+    p.add_argument("--model", default=DEFAULT_MODEL)
+    p.add_argument("--arms", default="off,codepro")
+    p.add_argument("--instances", type=int, default=0, help="0 = all lite (300); N = first N")
+    p.add_argument("--window", type=int, default=8192)
+    p.add_argument("--max-steps", type=int, default=30)
+    p.add_argument("--pool-gb", type=int, default=50)
+    p.add_argument("--turbovec-bits", type=int, default=8, choices=(0, 4, 8))
+    mpo = p.add_mutually_exclusive_group()
+    mpo.add_argument("--mpo-chain", dest="mpo_chain", action="store_true", default=True)
+    mpo.add_argument("--no-mpo-chain", dest="mpo_chain", action="store_false")
+    p.add_argument("--recall-k", type=int, default=8)
+    p.add_argument("--max-usd", type=float, default=25.0)
+    p.add_argument("--out", default="runs/swe_eval")
+    p.add_argument("--dry-run", action="store_true")
+    a = p.parse_args(argv)
+    return SweConfig(
+        model=a.model, arms=tuple(x.strip() for x in a.arms.split(",") if x.strip()),
+        instances=a.instances, window=a.window, max_steps=a.max_steps, pool_gb=a.pool_gb,
+        turbovec_bits=a.turbovec_bits, mpo_chain=a.mpo_chain, recall_k=a.recall_k,
+        max_usd=a.max_usd, dry_run=a.dry_run, out_dir=Path(a.out),
+        work_dir=Path(a.out) / "checkouts")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    cfg = _build_config(argv)
+    if not cfg.dry_run and not (os.environ.get("OPENROUTER_API_KEY")
+                                or os.environ.get("OPENAI_API_KEY")):
+        print("No OPENROUTER_API_KEY — use --dry-run to exercise the harness.")
+        return 0
+    summary = run_swe_eval(cfg)
+    print(json.dumps(summary, indent=2))
+    print(f"predictions -> {cfg.out_dir}/predictions_<arm>.jsonl")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/swe_scoring.py
+++ b/bench/swe_scoring.py
@@ -1,0 +1,37 @@
+"""swe_scoring — Phase B wrapper. Runs the OFFICIAL swebench evaluation harness (Docker,
+VPS5) over a predictions JSONL, then parses the resolved-rate report. Generation is
+bench/swe_eval.py; this only scores. `parse_report` is pure + unit-tested (no Docker)."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+DATASET = "princeton-nlp/SWE-bench_Lite"
+
+
+def parse_report(report_path: Path) -> dict[str, Any]:
+    """Normalize a swebench run report into {total, resolved, resolved_rate, ids}."""
+    data = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    total = int(data.get("total_instances") or data.get("total") or 0)
+    resolved_ids = list(data.get("resolved_ids") or [])
+    resolved = int(data.get("resolved_instances") or len(resolved_ids))
+    rate = round(resolved / total, 4) if total else 0.0
+    return {"total": total, "resolved": resolved, "resolved_rate": rate,
+            "resolved_ids": resolved_ids,
+            "unresolved_ids": list(data.get("unresolved_ids") or [])}
+
+
+def run_evaluation(predictions_path: Path, run_id: str, *,
+                   max_workers: int = 4, dataset: str = DATASET) -> list[str]:
+    """Invoke the official swebench harness (Docker required). Returns the command run.
+    On VPS5: `pip install swebench` first. The report JSON lands in the CWD as
+    `<model>.<run_id>.json` per swebench's convention."""
+    cmd = ["python", "-m", "swebench.harness.run_evaluation",
+           "--dataset_name", dataset,
+           "--predictions_path", str(predictions_path),
+           "--run_id", run_id,
+           "--max_workers", str(max_workers)]
+    subprocess.run(cmd, check=True)
+    return cmd

--- a/bench/swe_tools.py
+++ b/bench/swe_tools.py
@@ -1,0 +1,139 @@
+"""Repo file tools for the SWE-bench codepro eval — read/grep/list/edit over a single
+git checkout, plus the unified-diff capture used as the SWE-bench model_patch. Pure
+(no network); the agent loop in swe_eval.py hosts these over a per-instance checkout."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+class RepoTools:
+    """Tools answered from a checked-out repo dir. Edits write into the working tree;
+    `current_patch()` returns `git diff` against the base commit = the model_patch."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+        self.calls = 0
+        self.redundant = 0
+        self._read: set[str] = set()
+
+    def _safe(self, rel: str) -> Path | None:
+        """Resolve rel under root; None if it escapes (path-traversal guard)."""
+        p = (self.root / rel).resolve()
+        try:
+            p.relative_to(self.root.resolve())
+        except ValueError:
+            return None
+        return p
+
+    def read_file(self, path: str) -> dict:
+        self.calls += 1
+        if path in self._read:
+            self.redundant += 1
+        self._read.add(path)
+        p = self._safe(path or "")
+        if p is None or not p.is_file():
+            return {"error": f"no file {path}"}
+        try:
+            return {"path": path,
+                    "content": p.read_text(encoding="utf-8", errors="replace")[:20000]}
+        except OSError as e:
+            return {"error": str(e)}
+
+    def grep(self, pattern: str, path_glob: str = "") -> dict:
+        self.calls += 1
+        cmd = ["git", "grep", "-n", "-I", "-e", pattern or ""]
+        if path_glob:
+            cmd += ["--", path_glob]
+        proc = subprocess.run(cmd, cwd=self.root, capture_output=True, text=True)
+        matches = []
+        for ln in proc.stdout.splitlines()[:100]:
+            parts = ln.split(":", 2)
+            if len(parts) == 3:
+                matches.append({"path": parts[0], "lineno": parts[1], "line": parts[2]})
+        return {"matches": matches}
+
+    def list_dir(self, path: str = ".") -> dict:
+        self.calls += 1
+        p = self._safe(path or ".")
+        if p is None or not p.is_dir():
+            return {"error": f"no dir {path}"}
+        entries = sorted(
+            (c.name + "/" if c.is_dir() else c.name) for c in p.iterdir()
+            if c.name != ".git")
+        return {"entries": entries}
+
+    def edit_file(self, path: str, old: str, new: str) -> dict:
+        self.calls += 1
+        p = self._safe(path or "")
+        if p is None or not p.is_file():
+            return {"error": f"no file {path}"}
+        src = p.read_text(encoding="utf-8", errors="replace")
+        if old not in src:
+            return {"error": f"old string not found in {path}"}
+        p.write_text(src.replace(old, new, 1), encoding="utf-8")
+        return {"ok": True, "path": path}
+
+    def current_patch(self) -> str:
+        """Unified diff of the working tree vs HEAD (the base commit) = model_patch."""
+        proc = subprocess.run(["git", "diff"], cwd=self.root, capture_output=True, text=True)
+        return proc.stdout
+
+    TOOLS_SCHEMA = [
+        {"type": "function", "function": {
+            "name": "read_file",
+            "description": "Read a repo file's contents by path.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}, "required": ["path"]}}},
+        {"type": "function", "function": {
+            "name": "grep",
+            "description": "Search the repo for a regex/string (git grep). Optional path glob.",
+            "parameters": {"type": "object",
+                           "properties": {"pattern": {"type": "string"},
+                                          "path_glob": {"type": "string"}},
+                           "required": ["pattern"]}}},
+        {"type": "function", "function": {
+            "name": "list_dir",
+            "description": "List entries in a repo directory.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}, "required": ["path"]}}},
+        {"type": "function", "function": {
+            "name": "edit_file",
+            "description": "Replace the first occurrence of `old` with `new` in a file.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"},
+                                          "old": {"type": "string"}, "new": {"type": "string"}},
+                           "required": ["path", "old", "new"]}}},
+    ]
+
+    def dispatch(self, name: str, args: dict) -> Any:
+        if name == "read_file":
+            return self.read_file(args.get("path", ""))
+        if name == "grep":
+            return self.grep(args.get("pattern", ""), args.get("path_glob", ""))
+        if name == "list_dir":
+            return self.list_dir(args.get("path", "."))
+        if name == "edit_file":
+            return self.edit_file(args.get("path", ""), args.get("old", ""), args.get("new", ""))
+        return {"error": f"unknown tool {name}"}
+
+
+def prepare_checkout(repo_url: str, base_commit: str, workdir: Path) -> Path:
+    """Clone `repo_url` into `workdir` and checkout `base_commit`. Idempotent: if workdir
+    already holds that commit, reuse it. Returns the checkout path. Used only so the agent's
+    file tools can READ the repo during generation; Phase B does its own isolated checkout."""
+    workdir = Path(workdir)
+    if (workdir / ".git").is_dir():
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=workdir,
+                              capture_output=True, text=True).stdout.strip()
+        if head == base_commit:
+            return workdir
+        import shutil
+        shutil.rmtree(workdir, ignore_errors=True)
+    workdir.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "clone", "-q", repo_url, str(workdir)], check=True,
+                   capture_output=True)
+    subprocess.run(["git", "checkout", "-q", base_commit], cwd=workdir, check=True,
+                   capture_output=True)
+    return workdir

--- a/bench/test_turbovec_bench.py
+++ b/bench/test_turbovec_bench.py
@@ -1,0 +1,17 @@
+"""Locks the TurboVec headline claim: 8-bit cuts footprint ~4x while keeping recall recall-safe."""
+from __future__ import annotations
+
+from bench.turbovec_bench import run
+
+
+def test_8bit_compresses_and_keeps_recall():
+    rows = run([2000], dim=256, queries=50, k=10, bits=8)
+    r = rows[0]
+    assert r["compression_x"] >= 3.5, r          # ~4x resident-footprint cut
+    assert r["recall_at_k"] >= 0.97, r           # recall-safe at 8-bit (claim >= 0.98)
+
+
+def test_footprint_ratio_holds_as_pool_grows():
+    rows = run([1000, 4000], dim=256, queries=20, k=10, bits=8)
+    # the ~4x footprint advantage is constant as the pool grows (the long-run resident-set win)
+    assert abs(rows[0]["compression_x"] - rows[1]["compression_x"]) < 0.1, rows

--- a/bench/turbovec_bench.py
+++ b/bench/turbovec_bench.py
@@ -1,0 +1,98 @@
+"""TurboVec proof harness — footprint + recall@k + query latency, fp32 vs 8-bit, across a GROWING pool.
+
+The headline TurboVec claim is: 8-bit scalar quantization cuts the resident vector footprint ~4x while
+keeping recall >= 0.98, and the gain compounds as the pool grows (more vectors stay resident -> fewer
+cold reads -> flatter latency under long runs). `drift_vs_window.py` measures end-to-end coherence; it does
+NOT isolate footprint/recall/latency. This does, with just numpy + the real codec (no API key, no Session).
+
+  python -m bench.turbovec_bench                 # default sweep
+  python -m bench.turbovec_bench --sizes 10000,50000,100000 --dim 256 --queries 200 --k 10 --bits 8
+"""
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+
+from aether_context.quantize import (compression_ratio, dequantize, packed_bytes_per_row, quantize)
+
+
+def _unit(n: int, d: int, rng) -> np.ndarray:
+    m = rng.standard_normal((n, d)).astype(np.float32)
+    m /= (np.linalg.norm(m, axis=1, keepdims=True) + 1e-9)
+    return m
+
+
+def _topk(mat: np.ndarray, q: np.ndarray, k: int) -> np.ndarray:
+    sims = mat @ q.T                      # (N, Q) cosine (unit vectors)
+    return np.argpartition(-sims, kth=min(k, mat.shape[0] - 1), axis=0)[:k].T  # (Q, k) indices
+
+
+def _latency_ms(mat: np.ndarray, queries: np.ndarray, k: int, reps: int = 3) -> tuple[float, float]:
+    times = []
+    for _ in range(reps):
+        for q in queries:
+            t = time.perf_counter()
+            sims = mat @ q
+            np.argpartition(-sims, kth=min(k, mat.shape[0] - 1))[:k]
+            times.append((time.perf_counter() - t) * 1000.0)
+    times.sort()
+    p50 = times[len(times) // 2]
+    p99 = times[min(len(times) - 1, int(len(times) * 0.99))]
+    return p50, p99
+
+
+def run(sizes, dim, queries, k, bits, seed=7) -> list[dict]:
+    rng = np.random.default_rng(seed)
+    rows = []
+    for n in sizes:
+        mat = _unit(n, dim, rng)
+        qs = _unit(queries, dim, rng)
+        # fp32 baseline: exact top-k + footprint + latency
+        fp32_topk = _topk(mat, qs, k)
+        fp32_bytes = n * dim * 4
+        fp32_p50, fp32_p99 = _latency_ms(mat, qs, k)
+        # 8-bit: quantize -> dequantize -> exact top-k on the reconstruction
+        codes, scales = quantize(mat, bits=bits)
+        deq = dequantize(codes, scales, dim, bits=bits).astype(np.float32)
+        q_topk = _topk(deq, qs, k)
+        q_bytes = packed_bytes_per_row(dim, bits) * n + scales.nbytes
+        q_p50, q_p99 = _latency_ms(deq, qs, k)
+        # recall@k = overlap of returned index sets, averaged over queries
+        recalls = [len(set(a.tolist()) & set(b.tolist())) / k for a, b in zip(fp32_topk, q_topk)]
+        rows.append({
+            "n": n, "dim": dim, "bits": bits,
+            "fp32_mb": round(fp32_bytes / 1e6, 1), "q_mb": round(q_bytes / 1e6, 1),
+            "compression_x": round(fp32_bytes / max(q_bytes, 1), 2),
+            "codec_ratio_x": round(compression_ratio(dim, bits), 2),
+            "recall_at_k": round(float(np.mean(recalls)), 4),
+            "fp32_p50_ms": round(fp32_p50, 3), "fp32_p99_ms": round(fp32_p99, 3),
+            "q_p50_ms": round(q_p50, 3), "q_p99_ms": round(q_p99, 3),
+        })
+    return rows
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="TurboVec footprint/recall/latency proof")
+    ap.add_argument("--sizes", default="10000,50000,100000")
+    ap.add_argument("--dim", type=int, default=256)
+    ap.add_argument("--queries", type=int, default=200)
+    ap.add_argument("--k", type=int, default=10)
+    ap.add_argument("--bits", type=int, default=8)
+    a = ap.parse_args(argv)
+    sizes = [int(s) for s in a.sizes.split(",") if s.strip()]
+    rows = run(sizes, a.dim, a.queries, a.k, a.bits)
+    hdr = ("n", "fp32_mb", "q_mb", "compression_x", "recall_at_k", "fp32_p99_ms", "q_p99_ms")
+    print(f"TurboVec {a.bits}-bit vs fp32 | dim={a.dim} k={a.k} queries={a.queries}")
+    print("  ".join(f"{h:>13}" for h in hdr))
+    for r in rows:
+        print("  ".join(f"{r[h]:>13}" for h in hdr))
+    worst_recall = min(r["recall_at_k"] for r in rows)
+    print(f"\nworst recall@{a.k} = {worst_recall:.4f} (claim: >= 0.98 at 8-bit)  |  "
+          f"footprint cut ~{rows[-1]['compression_x']}x at n={sizes[-1]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md
+++ b/docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md
@@ -1,0 +1,39 @@
+# SWE-bench CodePro Eval — Runbook
+
+## Phase A — generation (any host with OpenRouter key + git)
+    export OPENROUTER_API_KEY=...
+    # 1-instance smoke first:
+    python -m bench.swe_eval --instances 1 --arms off,codepro --max-usd 25
+    # full lite overnight:
+    python -m bench.swe_eval --instances 0 --arms off,codepro --max-usd 25
+    # -> runs/swe_eval/predictions_off.jsonl + predictions_codepro.jsonl (resumable; re-run to continue)
+
+## Phase B — scoring (VPS5, Docker, Linux)
+    ssh root@aether-vps5
+    pip install swebench
+    cd <repo>
+    python -m swebench.harness.run_evaluation \
+      --dataset_name princeton-nlp/SWE-bench_Lite \
+      --predictions_path runs/swe_eval/predictions_off.jsonl --run_id off --max_workers 4
+    python -m swebench.harness.run_evaluation \
+      --dataset_name princeton-nlp/SWE-bench_Lite \
+      --predictions_path runs/swe_eval/predictions_codepro.jsonl --run_id codepro --max_workers 4
+    # -> <model>.off.json / <model>.codepro.json reports
+
+## Headline
+    python - <<'PY'
+    from pathlib import Path
+    from bench.swe_scoring import parse_report
+    for arm in ("off", "codepro"):
+        r = parse_report(next(Path('.').glob(f'*.{arm}.json')))
+        print(arm, r["resolved"], "/", r["total"], "=", r["resolved_rate"])
+    PY
+
+## Live tuning knobs (re-run a subset, diff resolved-rate/cost)
+    --pool-gb --turbovec-bits {0,4,8} --no-mpo-chain --recall-k --max-steps --window --instances N
+
+## Notes
+- 1-instance smoke MUST pass Phase B (Docker build + test run) before the overnight 300.
+- $25 hard cap shared across arms+instances; halts clean + resumes (re-run same command).
+- codepro arm uses the LOCAL engine (no VPS5 atlas oracle) -> Docker CPU/disk only.
+- pool floor is 5 GB (engine guard); --pool-gb below 5 is rejected.

--- a/docs/superpowers/plans/2026-06-23-swe-codepro-eval.md
+++ b/docs/superpowers/plans/2026-06-23-swe-codepro-eval.md
@@ -1,0 +1,1096 @@
+# SWE-bench CodePro Eval — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure dsv4-pro coding capability before (raw, window-truncated) vs after (Unlimited-Context engine at max: overpool + TurboVec 8-bit + MPO chain) on real SWE-bench-lite, scored by the official `swebench` resolved-rate.
+
+**Architecture:** Two phases. Phase A (ours, `bench/swe_eval.py` + `bench/swe_tools.py`): an agentic tool-loop drives dsv4-pro over a per-instance git checkout to produce a patch → SWE-bench predictions JSONL. Phase B (`bench/swe_scoring.py` → official `swebench`): builds per-instance test Docker images on VPS5, computes resolved-rate. Reuses `api_eval.py` cost primitives + the `Session` engine.
+
+**Tech Stack:** Python stdlib + numpy, `aether_context` (`Session`, `StaticEncoder`, `quantize`), `OpenAICompatLLM` (OpenRouter dsv4-pro), `datasets` (load SWE-bench-lite), `swebench` (Phase B, VPS5+Docker), `git` CLI.
+
+**Branch:** `feat/turbovec-bench` (Unlimited-Context). Tests flat in `tests/`.
+
+**Reused symbols (do not redefine):**
+- `bench/api_eval.py`: `cost_usd(usage, *, price_in, price_out) -> float`, `cached_tokens(usage) -> int`.
+- `aether_context/session.py`: `Session(model, pool_gb=5, pool_quantize=0, mpo_chain=True, context_window=...)`; methods `.remember(text)`, `._key(topic=...) -> SliceKey`, `._cold_retrieve(key, query_vec, k) -> list[Slice]` (slice has `.text`), `.close()`. **TurboVec = `pool_quantize=8`.**
+- `aether_context/encoder.py`: `StaticEncoder(dim=256).encode(text) -> np.ndarray`.
+- `aether_context/local_llm.py`: `OpenAICompatLLM(model, context_window).chat(messages, tools=None, *, max_tokens=None) -> {"content","usage","tool_calls"}`.
+
+---
+
+## Task 0: Setup — deps + dirs
+
+**Files:**
+- Modify: `requirements-bench.txt` (create if absent)
+
+- [ ] **Step 1: Record bench deps**
+
+Create/append `requirements-bench.txt`:
+
+```
+datasets>=2.19
+swebench>=2.1.0
+```
+
+- [ ] **Step 2: Install locally (generation only; swebench Phase B runs on VPS5)**
+
+Run: `python -m pip install datasets`
+Expected: installs; `python -c "import datasets; print('ok')"` prints `ok`.
+(Do NOT need `swebench` locally — Phase B is VPS5/Docker. It's listed for the VPS5 host.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add requirements-bench.txt
+git commit -m "chore(bench): pin SWE-bench eval deps (datasets, swebench)"
+```
+
+---
+
+## Task 1: `swe_tools.py` — repo file tools (read_file)
+
+**Files:**
+- Create: `bench/swe_tools.py`
+- Test: `tests/test_swe_tools.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_swe_tools.py
+import subprocess
+from pathlib import Path
+import pytest
+from bench.swe_tools import RepoTools
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A tiny git repo at a known commit, for tools to read/edit."""
+    d = tmp_path / "repo"
+    d.mkdir()
+    _git(["init", "-q"], d)
+    _git(["config", "user.email", "t@t"], d)
+    _git(["config", "user.name", "t"], d)
+    (d / "a.py").write_text("def add(x, y):\n    return x - y  # bug\n", encoding="utf-8")
+    (d / "pkg").mkdir()
+    (d / "pkg" / "b.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(["add", "-A"], d)
+    _git(["commit", "-qm", "base"], d)
+    return d
+
+
+def test_read_file_returns_contents(repo):
+    t = RepoTools(repo)
+    out = t.read_file("a.py")
+    assert "def add" in out["content"]
+    assert out.get("error") is None
+
+
+def test_read_file_missing_is_error_not_raise(repo):
+    t = RepoTools(repo)
+    out = t.read_file("nope.py")
+    assert "error" in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_swe_tools.py -o addopts="" -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'bench.swe_tools'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# bench/swe_tools.py
+"""Repo file tools for the SWE-bench codepro eval — read/grep/list/edit over a single
+git checkout, plus the unified-diff capture used as the SWE-bench model_patch. Pure
+(no network); the agent loop in swe_eval.py hosts these over a per-instance checkout."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+class RepoTools:
+    """Tools answered from a checked-out repo dir. Edits write into the working tree;
+    `current_patch()` returns `git diff` against the base commit = the model_patch."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+        self.calls = 0
+        self.redundant = 0
+        self._read: set[str] = set()
+
+    def _safe(self, rel: str) -> Path | None:
+        """Resolve rel under root; None if it escapes (path-traversal guard)."""
+        p = (self.root / rel).resolve()
+        try:
+            p.relative_to(self.root.resolve())
+        except ValueError:
+            return None
+        return p
+
+    def read_file(self, path: str) -> dict:
+        self.calls += 1
+        if path in self._read:
+            self.redundant += 1
+        self._read.add(path)
+        p = self._safe(path or "")
+        if p is None or not p.is_file():
+            return {"error": f"no file {path}"}
+        try:
+            return {"path": path, "content": p.read_text(encoding="utf-8", errors="replace")[:20000]}
+        except OSError as e:
+            return {"error": str(e)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_swe_tools.py -o addopts="" -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_tools.py tests/test_swe_tools.py
+git commit -m "feat(bench): swe_tools RepoTools.read_file with path-traversal guard"
+```
+
+---
+
+## Task 2: `swe_tools.py` — grep, list_dir, edit_file, current_patch
+
+**Files:**
+- Modify: `bench/swe_tools.py`
+- Test: `tests/test_swe_tools.py`
+
+- [ ] **Step 1: Add failing tests**
+
+```python
+# append to tests/test_swe_tools.py
+def test_grep_finds_match(repo):
+    t = RepoTools(repo)
+    out = t.grep("return")
+    hits = " ".join(h["line"] for h in out["matches"])
+    assert "return" in hits
+    assert any(h["path"] == "a.py" for h in out["matches"])
+
+
+def test_list_dir(repo):
+    t = RepoTools(repo)
+    out = t.list_dir(".")
+    assert "a.py" in out["entries"]
+    assert "pkg/" in out["entries"]
+
+
+def test_edit_file_then_patch_is_unified_diff(repo):
+    t = RepoTools(repo)
+    r = t.edit_file("a.py", "    return x - y  # bug", "    return x + y")
+    assert r.get("error") is None
+    patch = t.current_patch()
+    assert patch.startswith("diff --git") or "--- a/a.py" in patch
+    assert "+    return x + y" in patch
+
+
+def test_edit_missing_oldstring_is_error(repo):
+    t = RepoTools(repo)
+    r = t.edit_file("a.py", "NONEXISTENT", "x")
+    assert "error" in r
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_tools.py -o addopts="" -q`
+Expected: FAIL — `AttributeError: 'RepoTools' object has no attribute 'grep'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `bench/swe_tools.py`:
+
+```python
+    def grep(self, pattern: str, path_glob: str = "") -> dict:
+        self.calls += 1
+        cmd = ["git", "grep", "-n", "-I", "-e", pattern or ""]
+        if path_glob:
+            cmd += ["--", path_glob]
+        proc = subprocess.run(cmd, cwd=self.root, capture_output=True, text=True)
+        matches = []
+        for ln in proc.stdout.splitlines()[:100]:
+            parts = ln.split(":", 2)
+            if len(parts) == 3:
+                matches.append({"path": parts[0], "lineno": parts[1], "line": parts[2]})
+        return {"matches": matches}
+
+    def list_dir(self, path: str = ".") -> dict:
+        self.calls += 1
+        p = self._safe(path or ".")
+        if p is None or not p.is_dir():
+            return {"error": f"no dir {path}"}
+        entries = sorted(
+            (c.name + "/" if c.is_dir() else c.name) for c in p.iterdir()
+            if c.name != ".git")
+        return {"entries": entries}
+
+    def edit_file(self, path: str, old: str, new: str) -> dict:
+        self.calls += 1
+        p = self._safe(path or "")
+        if p is None or not p.is_file():
+            return {"error": f"no file {path}"}
+        src = p.read_text(encoding="utf-8", errors="replace")
+        if old not in src:
+            return {"error": f"old string not found in {path}"}
+        p.write_text(src.replace(old, new, 1), encoding="utf-8")
+        return {"ok": True, "path": path}
+
+    def current_patch(self) -> str:
+        """Unified diff of the working tree vs HEAD (the base commit) = model_patch."""
+        proc = subprocess.run(["git", "diff"], cwd=self.root, capture_output=True, text=True)
+        return proc.stdout
+
+    TOOLS_SCHEMA = [
+        {"type": "function", "function": {
+            "name": "read_file",
+            "description": "Read a repo file's contents by path.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}, "required": ["path"]}}},
+        {"type": "function", "function": {
+            "name": "grep",
+            "description": "Search the repo for a regex/string (git grep). Optional path glob.",
+            "parameters": {"type": "object",
+                           "properties": {"pattern": {"type": "string"},
+                                          "path_glob": {"type": "string"}},
+                           "required": ["pattern"]}}},
+        {"type": "function", "function": {
+            "name": "list_dir",
+            "description": "List entries in a repo directory.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}, "required": ["path"]}}},
+        {"type": "function", "function": {
+            "name": "edit_file",
+            "description": "Replace the first occurrence of `old` with `new` in a file.",
+            "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"},
+                                          "old": {"type": "string"}, "new": {"type": "string"}},
+                           "required": ["path", "old", "new"]}}},
+    ]
+
+    def dispatch(self, name: str, args: dict) -> Any:
+        if name == "read_file":
+            return self.read_file(args.get("path", ""))
+        if name == "grep":
+            return self.grep(args.get("pattern", ""), args.get("path_glob", ""))
+        if name == "list_dir":
+            return self.list_dir(args.get("path", "."))
+        if name == "edit_file":
+            return self.edit_file(args.get("path", ""), args.get("old", ""), args.get("new", ""))
+        return {"error": f"unknown tool {name}"}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_tools.py -o addopts="" -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_tools.py tests/test_swe_tools.py
+git commit -m "feat(bench): swe_tools grep/list_dir/edit_file + unified-diff capture + schema"
+```
+
+---
+
+## Task 3: `swe_tools.py` — `prepare_checkout`
+
+**Files:**
+- Modify: `bench/swe_tools.py`
+- Test: `tests/test_swe_tools.py`
+
+- [ ] **Step 1: Add failing test (local file:// repo, no network)**
+
+```python
+# append to tests/test_swe_tools.py
+from bench.swe_tools import prepare_checkout
+
+
+def test_prepare_checkout_at_base_commit(tmp_path, repo):
+    # `repo` is a real git repo; clone it to a base commit via file:// (no network).
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                          capture_output=True, text=True).stdout.strip()
+    work = tmp_path / "work"
+    out = prepare_checkout(f"file://{repo.as_posix()}", base, work)
+    assert (out / "a.py").is_file()
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=out,
+                          capture_output=True, text=True).stdout.strip()
+    assert head == base
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_tools.py::test_prepare_checkout_at_base_commit -o addopts="" -q`
+Expected: FAIL — `ImportError: cannot import name 'prepare_checkout'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `bench/swe_tools.py`:
+
+```python
+def prepare_checkout(repo_url: str, base_commit: str, workdir: Path) -> Path:
+    """Clone `repo_url` into `workdir` and checkout `base_commit`. Idempotent: if workdir
+    already holds that commit, reuse it. Returns the checkout path. Used only so the agent's
+    file tools can READ the repo during generation; Phase B does its own isolated checkout."""
+    workdir = Path(workdir)
+    if (workdir / ".git").is_dir():
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=workdir,
+                              capture_output=True, text=True).stdout.strip()
+        if head == base_commit:
+            return workdir
+        import shutil
+        shutil.rmtree(workdir, ignore_errors=True)
+    workdir.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "clone", "-q", repo_url, str(workdir)], check=True,
+                   capture_output=True)
+    subprocess.run(["git", "checkout", "-q", base_commit], cwd=workdir, check=True,
+                   capture_output=True)
+    return workdir
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_tools.py -o addopts="" -q`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_tools.py tests/test_swe_tools.py
+git commit -m "feat(bench): swe_tools prepare_checkout (clone + checkout base_commit, idempotent)"
+```
+
+---
+
+## Task 4: `swe_eval.py` — config + dataset/instance selection
+
+**Files:**
+- Create: `bench/swe_eval.py`
+- Test: `tests/test_swe_eval.py`
+
+- [ ] **Step 1: Failing test**
+
+```python
+# tests/test_swe_eval.py
+from pathlib import Path
+from bench.swe_eval import SweConfig, select_instances
+
+
+_FAKE = [
+    {"instance_id": "p__c-3", "repo": "p/c", "base_commit": "c3", "problem_statement": "s3"},
+    {"instance_id": "p__c-1", "repo": "p/c", "base_commit": "c1", "problem_statement": "s1"},
+    {"instance_id": "p__c-2", "repo": "p/c", "base_commit": "c2", "problem_statement": "s2"},
+]
+
+
+def test_select_instances_sorted_and_capped():
+    got = select_instances(_FAKE, n=2)
+    assert [i["instance_id"] for i in got] == ["p__c-1", "p__c-2"]  # sorted, first 2
+
+
+def test_select_instances_all_when_n_zero():
+    got = select_instances(_FAKE, n=0)
+    assert len(got) == 3
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_eval.py -o addopts="" -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'bench.swe_eval'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# bench/swe_eval.py
+"""swe_eval — SWE-bench codepro eval (Phase A: generation). Drives dsv4-pro through an
+agentic file-tool loop over a per-instance checkout, off vs codepro-engine arms, and writes
+SWE-bench predictions JSONL. Phase B scoring is bench/swe_scoring.py (official swebench).
+
+Run (dry-run, no key): python -m bench.swe_eval --dry-run
+Run (live): OPENROUTER_API_KEY=... python -m bench.swe_eval --instances 1 --arms off,codepro
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+from aether_context.encoder import StaticEncoder
+from aether_context.session import Session
+from bench.api_eval import cached_tokens, cost_usd
+from bench.swe_tools import RepoTools, prepare_checkout
+
+DEFAULT_MODEL = "deepseek/deepseek-v4-pro"
+DATASET = "princeton-nlp/SWE-bench_Lite"
+MODEL_NAME = "dsv4pro-codepro"   # stamped into predictions model_name_or_path
+
+
+@dataclass
+class SweConfig:
+    model: str = DEFAULT_MODEL
+    arms: tuple[str, ...] = ("off", "codepro")
+    instances: int = 0            # 0 = all of lite (300); N = first N (sorted)
+    window: int = 8192            # off-arm truncation window
+    max_steps: int = 30           # tool steps per instance ("max reasoning" budget)
+    pool_gb: int = 50             # codepro overpool reach
+    turbovec_bits: int = 8        # codepro TurboVec quant (0/4/8)
+    mpo_chain: bool = True        # codepro MPO chain
+    recall_k: int = 8             # slices recalled per turn (codepro)
+    price_in: float = 0.3
+    price_out: float = 1.2
+    max_usd: float = 25.0         # hard global spend cap (shared across arms+instances)
+    cost_spike_usd: float = 0.50
+    dry_run: bool = False
+    out_dir: Path = field(default_factory=lambda: Path("runs/swe_eval"))
+    work_dir: Path = field(default_factory=lambda: Path("runs/swe_eval/checkouts"))
+
+
+def select_instances(rows: list[dict], n: int) -> list[dict]:
+    """Deterministic instance set: sort by instance_id, take first n (n=0 -> all)."""
+    ordered = sorted(rows, key=lambda r: r["instance_id"])
+    return ordered if n <= 0 else ordered[:n]
+
+
+def load_lite(cfg: SweConfig) -> list[dict]:
+    """Load SWE-bench-lite test split. Dry-run -> a synthetic 2-instance stand-in."""
+    if cfg.dry_run:
+        return [
+            {"instance_id": "syn__repo-1", "repo": "syn/repo", "base_commit": "HEAD",
+             "problem_statement": "Fix add() to add instead of subtract."},
+            {"instance_id": "syn__repo-2", "repo": "syn/repo", "base_commit": "HEAD",
+             "problem_statement": "Fix VALUE to 2."},
+        ]
+    from datasets import load_dataset
+    ds = load_dataset(DATASET, split="test")
+    return [dict(r) for r in ds]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_eval.py -o addopts="" -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_eval.py tests/test_swe_eval.py
+git commit -m "feat(bench): swe_eval SweConfig + deterministic instance selection + lite loader"
+```
+
+---
+
+## Task 5: `swe_eval.py` — single-instance arm runner (the agent loop)
+
+**Files:**
+- Modify: `bench/swe_eval.py`
+- Test: `tests/test_swe_eval.py`
+
+- [ ] **Step 1: Failing test (mock chat that edits then stops; both arms)**
+
+```python
+# append to tests/test_swe_eval.py
+import subprocess, json as _json
+from bench.swe_eval import run_instance
+
+
+class _PatchChat:
+    """Two steps: (1) call edit_file to fix the bug, (2) emit a final message."""
+    def __init__(self, *_a, **_k): self._t = 0
+    def chat(self, messages, tools=None, *, max_tokens=None):
+        self._t += 1
+        usage = {"prompt_tokens": 50, "completion_tokens": 10}
+        if self._t == 1:
+            return {"content": None, "usage": usage, "tool_calls": [
+                {"id": "c1", "type": "function", "function": {
+                    "name": "edit_file",
+                    "arguments": _json.dumps({"path": "a.py",
+                                              "old": "return x - y  # bug",
+                                              "new": "return x + y"})}}]}
+        return {"content": "done", "usage": usage, "tool_calls": []}
+
+
+def _make_repo(tmp_path):
+    d = tmp_path / "repo"; d.mkdir()
+    for a in (["init","-q"],["config","user.email","t@t"],["config","user.name","t"]):
+        subprocess.run(["git",*a], cwd=d, check=True, capture_output=True)
+    (d/"a.py").write_text("def add(x, y):\n    return x - y  # bug\n", encoding="utf-8")
+    subprocess.run(["git","add","-A"], cwd=d, check=True, capture_output=True)
+    subprocess.run(["git","commit","-qm","base"], cwd=d, check=True, capture_output=True)
+    return d
+
+
+def _base(repo):
+    return subprocess.run(["git","rev-parse","HEAD"], cwd=repo,
+                          capture_output=True, text=True).stdout.strip()
+
+
+def test_run_instance_produces_patch_off_arm(tmp_path):
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, work_dir=tmp_path/"wd")
+    inst = {"instance_id": "syn__repo-1", "repo": "syn/repo",
+            "base_commit": _base(repo), "problem_statement": "fix add"}
+    budget = {"spent": 0.0}
+    rec = run_instance("off", inst, cfg, _PatchChat(), budget,
+                       repo_url=f"file://{repo.as_posix()}")
+    assert rec["instance_id"] == "syn__repo-1"
+    assert "+    return x + y" in rec["model_patch"]
+    assert rec["arm"] == "off"
+
+
+def test_run_instance_codepro_arm_uses_engine(tmp_path):
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, work_dir=tmp_path/"wd", pool_gb=1)
+    inst = {"instance_id": "syn__repo-1", "repo": "syn/repo",
+            "base_commit": _base(repo), "problem_statement": "fix add"}
+    budget = {"spent": 0.0}
+    rec = run_instance("codepro", inst, cfg, _PatchChat(), budget,
+                       repo_url=f"file://{repo.as_posix()}")
+    assert "+    return x + y" in rec["model_patch"]
+    assert rec["arm"] == "codepro"
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_eval.py -k run_instance -o addopts="" -q`
+Expected: FAIL — `ImportError: cannot import name 'run_instance'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `bench/swe_eval.py`:
+
+```python
+def _truncate(messages: list[dict], window_tokens: int) -> list[dict]:
+    """OFF arm: keep system + a tail of messages fitting ~window (chars/4 estimate)."""
+    from aether_context.tokenizer import estimate
+    budget = window_tokens
+    head, tail = messages[:1], []
+    for m in reversed(messages[1:]):
+        c = estimate(m.get("content") or "")
+        if budget - c < 0:
+            break
+        budget -= c
+        tail.insert(0, m)
+    return head + tail
+
+
+_SYS = ("You are an expert software engineer fixing a real bug in a repository. Use read_file, "
+        "grep, and list_dir to investigate, then edit_file to apply a minimal fix. When the fix "
+        "is complete, reply with a one-line summary and STOP (no more tool calls). Make the repo's "
+        "own tests pass; change as little as possible.")
+
+
+def _empty_record(arm: str, inst: dict, halted: str) -> dict:
+    return {
+        "instance_id": inst["instance_id"],
+        "model_name_or_path": MODEL_NAME if arm == "codepro" else f"{MODEL_NAME}-off",
+        "model_patch": "", "arm": arm, "cost_usd": 0.0, "cached_tokens": 0,
+        "tool_calls": 0, "redundant_tool_calls": 0, "patch_nonempty": False,
+        "halted": halted,
+    }
+
+
+def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
+                 *, repo_url: Optional[str] = None) -> dict:
+    """Run ONE SWE instance under ONE arm. Returns a predictions record incl. model_patch.
+    OFF: window-truncated transcript. CODEPRO: Session(overpool+turbovec+chain) recall."""
+    url = repo_url or f"https://github.com/{inst['repo']}.git"
+    workdir = cfg.work_dir / arm / inst["instance_id"]
+    try:
+        checkout = prepare_checkout(url, inst["base_commit"], workdir)
+    except Exception as e:  # clone/checkout failed — record empty patch, keep the batch alive
+        return _empty_record(arm, inst, f"checkout_error: {type(e).__name__}")
+    tools = RepoTools(checkout)
+
+    session: Optional[Session] = None
+    encoder = StaticEncoder(dim=256)
+    if arm == "codepro":
+        session = Session("swe", pool_gb=cfg.pool_gb,
+                          pool_dir=cfg.out_dir / f"pool_{inst['instance_id']}_{arm}",
+                          context_window=cfg.window, mpo_chain=cfg.mpo_chain,
+                          pool_quantize=cfg.turbovec_bits)
+
+    user = (f"Repository: {inst['repo']} @ {inst['base_commit'][:10]}\n\n"
+            f"Problem:\n{inst['problem_statement']}\n\nInvestigate and fix it.")
+    transcript: list[dict] = [{"role": "system", "content": _SYS},
+                              {"role": "user", "content": user}]
+    cost = 0.0
+    cached = 0
+    halted: Optional[str] = None
+
+    for _step in range(cfg.max_steps):
+        if budget["spent"] >= cfg.max_usd:
+            halted = "budget_cap"
+            break
+        if session is not None:
+            qvec = encoder.encode(inst["problem_statement"])
+            recalled = session._cold_retrieve(session._key(), qvec, cfg.recall_k)
+            mem = "\n".join(f"[mem] {s.text}" for s in recalled) or "(empty)"
+            convo = _truncate([transcript[0],
+                               {"role": "system", "content": f"Working memory:\n{mem}"}]
+                              + transcript[1:], cfg.window)
+        else:
+            convo = _truncate(transcript, cfg.window)
+
+        out = chat.chat(convo, tools=RepoTools.TOOLS_SCHEMA)
+        usage = out.get("usage", {}) or {}
+        call_cost = cost_usd(usage, price_in=cfg.price_in, price_out=cfg.price_out)
+        cost += call_cost
+        budget["spent"] += call_cost
+        cached += cached_tokens(usage)
+        if call_cost > cfg.cost_spike_usd:
+            halted = "cost_spike"
+            break
+
+        tcs = out.get("tool_calls") or []
+        if tcs:
+            transcript.append({"role": "assistant", "content": out.get("content"),
+                               "tool_calls": tcs})
+            for tc in tcs:
+                fn = tc.get("function", {})
+                try:
+                    args = json.loads(fn.get("arguments") or "{}")
+                except json.JSONDecodeError:
+                    args = {}
+                result = tools.dispatch(fn.get("name", ""), args)
+                rjson = json.dumps(result)[:1500]
+                transcript.append({"role": "tool", "tool_call_id": tc.get("id", ""),
+                                   "content": rjson})
+                if session is not None:
+                    session.remember(f"{fn.get('name')}({args}): {rjson}")
+            continue
+        transcript.append({"role": "assistant", "content": out.get("content") or "done"})
+        break
+
+    patch = tools.current_patch()
+    if session is not None:
+        session.close()
+    return {
+        "instance_id": inst["instance_id"],
+        "model_name_or_path": MODEL_NAME if arm == "codepro" else f"{MODEL_NAME}-off",
+        "model_patch": patch,
+        "arm": arm,
+        "cost_usd": round(cost, 6),
+        "cached_tokens": cached,
+        "tool_calls": tools.calls,
+        "redundant_tool_calls": tools.redundant,
+        "patch_nonempty": bool(patch.strip()),
+        "halted": halted,
+    }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_eval.py -k run_instance -o addopts="" -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_eval.py tests/test_swe_eval.py
+git commit -m "feat(bench): swe_eval run_instance — off truncation vs codepro engine recall, patch capture"
+```
+
+---
+
+## Task 6: `swe_eval.py` — orchestrator (cap + resume + predictions JSONL)
+
+**Files:**
+- Modify: `bench/swe_eval.py`
+- Test: `tests/test_swe_eval.py`
+
+- [ ] **Step 1: Failing test (resume-skip + cap-halt)**
+
+```python
+# append to tests/test_swe_eval.py
+from bench.swe_eval import run_swe_eval
+
+
+def test_resume_skips_done_and_writes_predictions(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    insts = [{"instance_id":"syn__repo-1","repo":"syn/repo","base_commit":_base(repo),
+              "problem_statement":"fix add"}]
+    cfg = SweConfig(dry_run=True, arms=("off",), out_dir=tmp_path/"out",
+                    work_dir=tmp_path/"wd")
+    monkeypatch.setattr("bench.swe_eval._repo_url",
+                        lambda inst: f"file://{repo.as_posix()}")
+    run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    pred = (tmp_path/"out"/"predictions_off.jsonl").read_text(encoding="utf-8").strip()
+    assert "syn__repo-1" in pred
+    r2 = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    assert r2["skipped"] >= 1
+
+
+def test_global_cap_halts(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    insts = [{"instance_id":f"syn__repo-{i}","repo":"syn/repo","base_commit":_base(repo),
+              "problem_statement":"fix add"} for i in range(1,4)]
+    cfg = SweConfig(dry_run=True, arms=("off",), out_dir=tmp_path/"out2",
+                    work_dir=tmp_path/"wd2", max_usd=0.0)  # cap already reached
+    monkeypatch.setattr("bench.swe_eval._repo_url",
+                        lambda inst: f"file://{repo.as_posix()}")
+    r = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    assert r["halted"] == "budget_cap"
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_eval.py -k "resume or cap" -o addopts="" -q`
+Expected: FAIL — `ImportError: cannot import name 'run_swe_eval'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `bench/swe_eval.py`:
+
+```python
+def _repo_url(inst: dict) -> str:
+    """GitHub clone URL for an instance (monkeypatched to file:// in tests)."""
+    return f"https://github.com/{inst['repo']}.git"
+
+
+def _done_ids(path: Path) -> set[str]:
+    """instance_ids already written to a predictions JSONL (resume support)."""
+    if not path.exists():
+        return set()
+    ids = set()
+    for ln in path.read_text(encoding="utf-8").splitlines():
+        try:
+            ids.add(json.loads(ln)["instance_id"])
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return ids
+
+
+def _make_live_chat(cfg: SweConfig):
+    from aether_context.local_llm import OpenAICompatLLM
+    return OpenAICompatLLM(cfg.model, context_window=cfg.window)
+
+
+def run_swe_eval(cfg: SweConfig, instances: Optional[list[dict]] = None,
+                 chat_factory=None) -> dict:
+    """Drive every (instance, arm), honoring the shared $ cap and skipping done work.
+    Appends each record to runs/swe_eval/predictions_<arm>.jsonl. Resumable."""
+    cfg.out_dir.mkdir(parents=True, exist_ok=True)
+    rows = instances if instances is not None else select_instances(load_lite(cfg), cfg.instances)
+    chat_factory = chat_factory or (_make_live_chat if not cfg.dry_run else (lambda c: None))
+    budget = {"spent": 0.0}
+    summary: dict[str, Any] = {"arms": {a: {"done": 0, "patched": 0, "cost": 0.0}
+                                        for a in cfg.arms},
+                               "skipped": 0, "halted": None}
+
+    for arm in cfg.arms:
+        pred_path = cfg.out_dir / f"predictions_{arm}.jsonl"
+        done = _done_ids(pred_path)
+        chat = chat_factory(cfg)
+        for inst in rows:
+            if inst["instance_id"] in done:
+                summary["skipped"] += 1
+                continue
+            if budget["spent"] >= cfg.max_usd:
+                summary["halted"] = "budget_cap"
+                break
+            rec = run_instance(arm, inst, cfg, chat, budget, repo_url=_repo_url(inst))
+            with pred_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(rec) + "\n")
+            summary["arms"][arm]["done"] += 1
+            summary["arms"][arm]["patched"] += int(rec["patch_nonempty"])
+            summary["arms"][arm]["cost"] = round(
+                summary["arms"][arm]["cost"] + rec["cost_usd"], 6)
+            if rec.get("halted") in ("budget_cap", "cost_spike"):
+                summary["halted"] = rec["halted"]
+                break
+        if summary["halted"]:
+            break
+
+    summary["total_cost_usd"] = round(budget["spent"], 6)
+    (cfg.out_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_eval.py -o addopts="" -q`
+Expected: PASS (all swe_eval tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_eval.py tests/test_swe_eval.py
+git commit -m "feat(bench): swe_eval orchestrator — shared cap, resume-skip, predictions JSONL"
+```
+
+---
+
+## Task 7: `swe_eval.py` — CLI
+
+**Files:**
+- Modify: `bench/swe_eval.py`
+- Test: `tests/test_swe_eval.py`
+
+- [ ] **Step 1: Failing test**
+
+```python
+# append to tests/test_swe_eval.py
+from bench.swe_eval import _build_config
+
+
+def test_cli_flags_map_to_config():
+    cfg = _build_config(["--instances","5","--arms","off,codepro","--pool-gb","20",
+                         "--turbovec-bits","8","--no-mpo-chain","--max-usd","25",
+                         "--window","4096","--max-steps","12","--dry-run"])
+    assert cfg.instances == 5
+    assert cfg.arms == ("off","codepro")
+    assert cfg.pool_gb == 20 and cfg.turbovec_bits == 8
+    assert cfg.mpo_chain is False
+    assert cfg.max_usd == 25.0 and cfg.window == 4096 and cfg.max_steps == 12
+    assert cfg.dry_run is True
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_eval.py -k cli_flags -o addopts="" -q`
+Expected: FAIL — `ImportError: cannot import name '_build_config'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `bench/swe_eval.py`:
+
+```python
+def _build_config(argv: Optional[list[str]] = None) -> SweConfig:
+    p = argparse.ArgumentParser(prog="swe_eval",
+                                description="SWE-bench codepro eval (generation phase).")
+    p.add_argument("--model", default=DEFAULT_MODEL)
+    p.add_argument("--arms", default="off,codepro")
+    p.add_argument("--instances", type=int, default=0, help="0 = all lite (300); N = first N")
+    p.add_argument("--window", type=int, default=8192)
+    p.add_argument("--max-steps", type=int, default=30)
+    p.add_argument("--pool-gb", type=int, default=50)
+    p.add_argument("--turbovec-bits", type=int, default=8, choices=(0, 4, 8))
+    mpo = p.add_mutually_exclusive_group()
+    mpo.add_argument("--mpo-chain", dest="mpo_chain", action="store_true", default=True)
+    mpo.add_argument("--no-mpo-chain", dest="mpo_chain", action="store_false")
+    p.add_argument("--recall-k", type=int, default=8)
+    p.add_argument("--max-usd", type=float, default=25.0)
+    p.add_argument("--out", default="runs/swe_eval")
+    p.add_argument("--dry-run", action="store_true")
+    a = p.parse_args(argv)
+    return SweConfig(
+        model=a.model, arms=tuple(x.strip() for x in a.arms.split(",") if x.strip()),
+        instances=a.instances, window=a.window, max_steps=a.max_steps, pool_gb=a.pool_gb,
+        turbovec_bits=a.turbovec_bits, mpo_chain=a.mpo_chain, recall_k=a.recall_k,
+        max_usd=a.max_usd, dry_run=a.dry_run, out_dir=Path(a.out),
+        work_dir=Path(a.out) / "checkouts")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    cfg = _build_config(argv)
+    if not cfg.dry_run and not (os.environ.get("OPENROUTER_API_KEY")
+                                or os.environ.get("OPENAI_API_KEY")):
+        print("No OPENROUTER_API_KEY — use --dry-run to exercise the harness.")
+        return 0
+    summary = run_swe_eval(cfg)
+    print(json.dumps(summary, indent=2))
+    print(f"predictions -> {cfg.out_dir}/predictions_<arm>.jsonl")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run to verify pass + crash-proof dry-run**
+
+Run: `python -m pytest tests/test_swe_eval.py -o addopts="" -q`
+Expected: PASS (all).
+Run: `python -m bench.swe_eval --dry-run --arms off`
+Expected: prints a summary JSON; NO traceback. The synthetic `syn/repo` clone fails, so each
+record carries `halted: checkout_error...` and an empty patch (handled in Task 5's
+`run_instance` try/except). This proves the batch survives per-instance checkout failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_eval.py tests/test_swe_eval.py
+git commit -m "feat(bench): swe_eval CLI (off-vs-codepro, tuning flags, dry-run)"
+```
+
+---
+
+## Task 8: `swe_scoring.py` — official swebench wrapper + report parse
+
+**Files:**
+- Create: `bench/swe_scoring.py`
+- Test: `tests/test_swe_scoring.py`
+
+- [ ] **Step 1: Failing test (parse a captured report; no Docker)**
+
+```python
+# tests/test_swe_scoring.py
+import json
+from pathlib import Path
+from bench.swe_scoring import parse_report
+
+
+def test_parse_report_extracts_resolved(tmp_path):
+    report = {"total_instances": 3, "resolved_instances": 2,
+              "resolved_ids": ["a-1", "a-2"], "unresolved_ids": ["a-3"]}
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(report), encoding="utf-8")
+    out = parse_report(p)
+    assert out["resolved"] == 2
+    assert out["total"] == 3
+    assert out["resolved_rate"] == round(2 / 3, 4)
+    assert set(out["resolved_ids"]) == {"a-1", "a-2"}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_scoring.py -o addopts="" -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'bench.swe_scoring'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# bench/swe_scoring.py
+"""swe_scoring — Phase B wrapper. Runs the OFFICIAL swebench evaluation harness (Docker,
+VPS5) over a predictions JSONL, then parses the resolved-rate report. Generation is
+bench/swe_eval.py; this only scores. `parse_report` is pure + unit-tested (no Docker)."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+DATASET = "princeton-nlp/SWE-bench_Lite"
+
+
+def parse_report(report_path: Path) -> dict[str, Any]:
+    """Normalize a swebench run report into {total, resolved, resolved_rate, ids}."""
+    data = json.loads(Path(report_path).read_text(encoding="utf-8"))
+    total = int(data.get("total_instances") or data.get("total") or 0)
+    resolved_ids = list(data.get("resolved_ids") or [])
+    resolved = int(data.get("resolved_instances") or len(resolved_ids))
+    rate = round(resolved / total, 4) if total else 0.0
+    return {"total": total, "resolved": resolved, "resolved_rate": rate,
+            "resolved_ids": resolved_ids,
+            "unresolved_ids": list(data.get("unresolved_ids") or [])}
+
+
+def run_evaluation(predictions_path: Path, run_id: str, *,
+                   max_workers: int = 4, dataset: str = DATASET) -> list[str]:
+    """Invoke the official swebench harness (Docker required). Returns the command run.
+    On VPS5: `pip install swebench` first. The report JSON lands in the CWD as
+    `<model>.<run_id>.json` per swebench's convention."""
+    cmd = ["python", "-m", "swebench.harness.run_evaluation",
+           "--dataset_name", dataset,
+           "--predictions_path", str(predictions_path),
+           "--run_id", run_id,
+           "--max_workers", str(max_workers)]
+    subprocess.run(cmd, check=True)
+    return cmd
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_scoring.py -o addopts="" -q`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_scoring.py tests/test_swe_scoring.py
+git commit -m "feat(bench): swe_scoring — official swebench wrapper + pure report parser"
+```
+
+---
+
+## Task 9: Full dry-run gate + runbook doc
+
+**Files:**
+- Create: `docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md`
+
+- [ ] **Step 1: Whole-suite green**
+
+Run: `python -m pytest tests/test_swe_tools.py tests/test_swe_eval.py tests/test_swe_scoring.py -o addopts="" -q`
+Expected: PASS (all).
+
+- [ ] **Step 2: Write the runbook**
+
+Create `docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md`:
+
+```markdown
+# SWE-bench CodePro Eval — Runbook
+
+## Phase A — generation (any host with OpenRouter key + git)
+    export OPENROUTER_API_KEY=...
+    # 1-instance smoke first:
+    python -m bench.swe_eval --instances 1 --arms off,codepro --max-usd 25
+    # full lite overnight:
+    python -m bench.swe_eval --instances 0 --arms off,codepro --max-usd 25
+    # -> runs/swe_eval/predictions_off.jsonl + predictions_codepro.jsonl (resumable; re-run to continue)
+
+## Phase B — scoring (VPS5, Docker, Linux)
+    ssh root@aether-vps5
+    pip install swebench
+    cd <repo>
+    python -m swebench.harness.run_evaluation \
+      --dataset_name princeton-nlp/SWE-bench_Lite \
+      --predictions_path runs/swe_eval/predictions_off.jsonl --run_id off --max_workers 4
+    python -m swebench.harness.run_evaluation \
+      --dataset_name princeton-nlp/SWE-bench_Lite \
+      --predictions_path runs/swe_eval/predictions_codepro.jsonl --run_id codepro --max_workers 4
+    # -> <model>.off.json / <model>.codepro.json reports
+
+## Headline
+    python - <<'PY'
+    from pathlib import Path
+    from bench.swe_scoring import parse_report
+    for arm in ("off", "codepro"):
+        r = parse_report(next(Path('.').glob(f'*.{arm}.json')))
+        print(arm, r["resolved"], "/", r["total"], "=", r["resolved_rate"])
+    PY
+
+## Live tuning knobs (re-run a subset, diff resolved-rate/cost)
+    --pool-gb --turbovec-bits {0,4,8} --no-mpo-chain --recall-k --max-steps --window --instances N
+
+## Notes
+- 1-instance smoke MUST pass Phase B (Docker build + test run) before the overnight 300.
+- $25 hard cap shared across arms+instances; halts clean + resumes (re-run same command).
+- codepro arm uses the LOCAL engine (no VPS5 atlas oracle) -> Docker CPU/disk only.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md
+git commit -m "docs(bench): SWE-bench codepro eval runbook (generation + VPS5 scoring + tuning)"
+```
+
+---
+
+## Self-Review notes (spec coverage)
+
+- Two-phase (gen ours / score official): Tasks 5–8. ✓
+- off vs codepro engine-MAX (overpool+turbovec8+chain): `run_instance` Task 5 (`pool_quantize`, `mpo_chain`). ✓
+- Reuse api_eval loop primitives: imports `cost_usd`/`cached_tokens`; loop pattern mirrored. ✓
+- Repo file tools + diff capture: Tasks 1–3. ✓
+- $25 cap + resume: Task 6. ✓
+- dry-run + unit tests: Tasks 1–8; full gate Task 9. ✓
+- 1-instance smoke before 300 + VPS5 Docker: RUNBOOK Task 9. ✓
+- Live-tuning knobs: CLI Task 7 + RUNBOOK. ✓
+- RESULTS.md: generated post-run from reports (RUNBOOK headline snippet); the formatted doc
+  mirrors `docs/benchmarks/.../2026-06-14-deepseek-v4-pro/RESULTS.md` after the run lands.

--- a/docs/superpowers/specs/2026-06-23-swe-codepro-eval-design.md
+++ b/docs/superpowers/specs/2026-06-23-swe-codepro-eval-design.md
@@ -1,0 +1,119 @@
+# SWE-bench CodePro Eval — Design
+
+**Date:** 2026-06-23 · **Repo:** Unlimited-Context · **Branch:** `feat/turbovec-bench`
+**Status:** approved design, pre-implementation
+
+## Goal
+
+Measure dsv4-pro **coding** capability **before vs after** the "codepro full effort" engine,
+on real SWE-bench-lite, the **same way** as the 2026-06-14 DeepSeek-v4-pro recall eval
+(`bench/api_eval.py` — OpenRouter dsv4-pro adapter, agentic tool-loop, off-vs-on arms, hard
+spend cap). The baseline eval measured *memory recall*; this measures *resolved-rate* (do the
+repo's own tests pass after the agent's patch). Produces a headline off-vs-codepro number, then
+feeds a live-tuning loop.
+
+Non-goal: this does **not** route through the AETHER-CLOUD cloud `/agent` codepro endpoint or
+the VPS5 atlas oracle. "codepro" here = the local Unlimited-Context `Session` engine at max
+settings — the same engine that powers the cloud codepro lane. Atlas `caps`/turbovec wiring on
+VPS5 is tracked separately and is irrelevant to this measurement.
+
+## Two-phase architecture
+
+Don't reinvent test execution. Split generation (ours) from scoring (official `swebench`).
+
+### Phase A — generation (`bench/swe_eval.py`, ours)
+Per instance, per arm, run an agentic tool-loop that drives dsv4-pro to produce a candidate
+patch. Emit SWE-bench predictions JSONL: `{instance_id, model_name_or_path, model_patch}`.
+
+- **Adapter:** reuse `OpenAICompatLLM` (`openai/deepseek/deepseek-v4-pro` via OpenRouter) — same
+  as the baseline; streaming + tool-calling.
+- **Loop:** reuse the `api_eval.py` agentic loop verbatim; swap the toolset + corpus.
+- **Repo access:** per instance, shallow-clone the instance repo and `git checkout base_commit`
+  into a read-only per-instance workdir on the run host. The agent's file tools read from it.
+  (Phase B does its own isolated checkout inside Docker; this clone is only for the agent's
+  reading during generation.)
+
+### Phase B — evaluation (official `swebench`, on VPS5)
+`python -m swebench.harness.run_evaluation --predictions_path predictions_<arm>.jsonl
+--dataset princeton-nlp/SWE-bench_Lite --run_id <arm>` builds each instance's test Docker image
+and reports resolved/unresolved. **Dep:** `pip install swebench` on VPS5 (not currently
+installed). Docker required (Linux). Host = **VPS5** (154 GiB disk; runs the live atlas oracle
+too, but Phase B is Docker CPU/disk only and the codepro arm uses the local engine, so the
+oracle is untouched).
+
+## Arms (Engine MAX)
+
+| arm | context handling |
+|---|---|
+| `off` (baseline) | raw dsv4-pro; repo context the agent has pulled is truncated to the model's real window each turn (the "forgets early files" failure) |
+| `codepro` | Unlimited-Context `Session`: large overpool pool, **TurboVec 8-bit** quantized encode, **MPO chain ON**, higher `max_steps` ("max reasoning"). File reads are encoded into the engine; each turn the engine recalls the relevant code slices instead of re-dumping whole files → holds far more of the repo in reach past the window |
+
+Expected per the baseline (recall-phase cost −54%, coherence 0.15→1.0): the `codepro` arm sends a
+**compact recalled** context → **cheaper per turn** than `off`, which drags a large truncated
+transcript. The `off` arm is the cost driver. $25 hard cap is very likely sufficient for the
+full 600 runs (baseline never hit $0.20); a halt would be `off` bulk and the run resumes.
+
+## Agent tools (harness-hosted over the instance checkout)
+
+- `read_file(path)` — returns file contents (codepro: also encoded into the engine pool)
+- `grep(pattern, path_glob?)` — ripgrep over the checkout
+- `list_dir(path)` — tree listing
+- `edit_file(path, ...)` / emit final unified diff — captured as `model_patch`
+- `run_tests(node_id?)` — optional pre-submit self-check (best-effort; final truth is Phase B)
+
+Identical loop to `api_eval.py`; only the tool host + corpus differ.
+
+## Reproducibility / resume
+
+- Fixed, sorted 300-instance SWE-bench-lite list (seeded; reproducible).
+- Per-`(instance, arm)` result cached to disk (predictions + per-instance status JSONL); the run
+  **skips already-done** pairs on restart → survives crash and cap-halt; resumable to finish.
+- **Shared $25 hard cap** persisted across arms; halt-on-hit the instant it is reached, leaving a
+  clean partial. Mirrors the baseline's global-cap discipline.
+
+## Outputs
+
+- `runs/swe_eval/predictions_off.jsonl`, `predictions_codepro.jsonl`
+- `runs/swe_eval/results_<arm>.json` (per-instance resolved + cost + tool counts)
+- `docs/benchmarks/2026-06-23-swe-codepro/RESULTS.md` mirroring the baseline doc:
+  headline resolved-rate **off vs codepro**, total + per-phase cost, **per-instance flips**
+  (instances codepro resolves that raw can't), redundant-tool counts, context-recall signal.
+
+## Live-tuning knobs (CLI flags)
+
+`--pool-gb`, `--turbovec-bits`, `--mpo-chain {on,off}`, `--recall-k`, `--max-steps`, `--window`,
+`--instances N` (subset), `--arms off,codepro`. Tuning = re-run a subset with a different config
+and diff the resolved-rate / cost.
+
+## Components & boundaries
+
+- `bench/swe_eval.py` — orchestrator: dataset load, per-instance workdir, arm runner, cap, resume,
+  predictions writer. Depends on: `api_eval` loop primitives, `aether_context` (`Session`,
+  `quantize`), `OpenAICompatLLM`.
+- `bench/swe_tools.py` — the repo file toolset (read_file/grep/list_dir/edit_file/run_tests) over
+  a checkout dir. Pure, unit-testable with a fixture repo; no network.
+- `bench/swe_scoring.py` — thin wrapper to invoke + parse the official `swebench` evaluation
+  output into `results_<arm>.json`. Isolates the Docker/official-harness seam.
+- Reuse (no change): `OpenAICompatLLM`, `Session`, `quantize`, the agentic loop in `api_eval.py`
+  (extract the loop into a shared helper if needed so both evals call it — minimal, behavior-
+  preserving).
+
+## Testing
+
+- `swe_tools` unit tests against a tiny fixture repo (read/grep/edit/diff capture) — deterministic.
+- `swe_eval` dry-run mode (`--dry-run`) with a mock chat that emits a canned patch → asserts
+  predictions JSONL shape, resume/skip, cap-halt, both arms wire the engine vs truncation. No API,
+  no Docker.
+- `swe_scoring` parser test against a captured sample `swebench` report JSON.
+- Phase B itself (Docker) validated by a 1-instance live smoke before the overnight 300.
+
+## Risks
+
+1. **dsv4-pro tool-calling reliability on coding** — baseline proved the adapter works; coding
+   patches are larger. Mitigate: `max_steps` budget + a final "emit unified diff" forcing turn.
+2. **Patch applies but is empty/garbage** — Phase B marks unresolved (correct). Track "patch
+   non-empty & applies" as a secondary metric to separate generation failure from test failure.
+3. **$25 halts mid-run** — accepted; partial headline on completed subset, resumable.
+4. **VPS5 Docker disk** — lite images fit in 154 GiB; prune images between batches if needed.
+5. **swebench dataset/version drift** — pin `princeton-nlp/SWE-bench_Lite` + record the
+   `swebench` package version in RESULTS.md.

--- a/requirements-bench.txt
+++ b/requirements-bench.txt
@@ -1,0 +1,2 @@
+datasets>=2.19
+swebench>=2.1.0

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -21,10 +21,11 @@ from aether_agent import config as agent_config
 def test_defaults_when_no_file(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
     monkeypatch.delenv("AETHER_BASE_URL", raising=False)
+    monkeypatch.delenv("AETHER_BACKEND", raising=False)
     cfg = agent_config.load_config()
     assert cfg["baseUrl"] == "https://api.aethersystems.net/cloud"
     assert cfg["defaultModel"] == ""
-    assert cfg["backend"] == "auto"
+    assert cfg["backend"] == "local"  # local-first: a fresh clone never phones home
     assert cfg["permissionMode"] == "ask"
     assert cfg["autoApply"] is False
     assert cfg["telemetry"] is True
@@ -59,6 +60,15 @@ def test_base_url_env_overrides_saved_file(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("AETHER_BASE_URL", "https://env.example.net/cloud")
     cfg = agent_config.load_config()
     assert cfg["baseUrl"] == "https://env.example.net/cloud"
+
+
+def test_backend_env_overrides_default(tmp_path: Path, monkeypatch):
+    # AETHER_BACKEND opts a clone into the hosted API without editing config.json.
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("AETHER_BASE_URL", raising=False)
+    monkeypatch.setenv("AETHER_BACKEND", "cloud")
+    cfg = agent_config.load_config()
+    assert cfg["backend"] == "cloud"
 
 
 # --- corrupt json fallback ------------------------------------------------

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -150,6 +150,35 @@ def test_auth_login_with_token_stores_it(monkeypatch: pytest.MonkeyPatch, tmp_pa
     assert FileTokenStore().get() == "aek_testtoken123"
 
 
+def test_auth_login_enables_cloud_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Local is the default, but signing in opts you into the hosted API (auto)
+    # in one step — the cloud is never disabled, only off by default.
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("AETHER_TOKEN", raising=False)
+    monkeypatch.delenv("AETHER_BACKEND", raising=False)
+    from aether_agent.config import load_config
+
+    assert load_config()["backend"] == "local"  # fresh install: local-first
+    code = cli.main(["auth", "login", "--token", "aek_testtoken123"])
+    assert code == 0
+    assert load_config()["backend"] == "auto"  # sign-in moved it onto the cloud
+
+
+def test_auth_login_keeps_explicit_backend_choice(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A deliberate backend choice is never overwritten by login.
+    monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("AETHER_TOKEN", raising=False)
+    monkeypatch.delenv("AETHER_BACKEND", raising=False)
+    from aether_agent.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["backend"] = "cloud"
+    save_config(cfg)
+    code = cli.main(["auth", "login", "--token", "tok"])
+    assert code == 0
+    assert load_config()["backend"] == "cloud"  # unchanged
+
+
 def test_auth_logout_clears_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("AETHER_CONFIG_DIR", str(tmp_path))
     monkeypatch.delenv("AETHER_TOKEN", raising=False)

--- a/tests/test_pool_quantize.py
+++ b/tests/test_pool_quantize.py
@@ -1,0 +1,51 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""TurboVec pool integration: quantized on-disk codes, exact in-RAM search, persist + reopen.
+
+quantize_bits>0 stores compressed codes in the vectors file (smaller footprint) while keeping the
+float32 unit vector resident, so live search is recall-EXACT vs the float32 pool; a reopen dequantizes
+(8-bit, ~0.99 recall). bits=0 is the untouched default path."""
+import numpy as np
+
+from aether_context.config import PoolConfig
+from aether_context.context_pool import ContextPool, Slice
+
+
+def _unit(v):
+    return (v / np.linalg.norm(v)).astype(np.float32)
+
+
+def _pool(d, qbits):
+    cfg = PoolConfig(pool_gb=5, dim=256, index="flat", dir=d, quantize_bits=qbits)
+    return ContextPool(cfg, ceiling_bytes=10_000_000)
+
+
+def _fill(pool, vecs):
+    for i, v in enumerate(vecs):
+        pool.add(Slice(id=f"s{i}", session="x", vector=v, text=f"t{i}", tokens=1))
+
+
+def test_quantized_search_matches_float32(tmp_path):
+    rng = np.random.default_rng(3)
+    vecs = [_unit(rng.standard_normal(256)) for _ in range(200)]
+    p0, p8 = _pool(tmp_path / "f32", 0), _pool(tmp_path / "q8", 8)
+    _fill(p0, vecs)
+    _fill(p8, vecs)
+    q = vecs[7]
+    r0 = [s.id for s in p0.search(q, k=5)]
+    r8 = [s.id for s in p8.search(q, k=5)]
+    assert r0 == r8                      # float32 kept in RAM -> live search is recall-EXACT
+    assert p8.stats()["quantized"] is True and p0.stats()["quantized"] is False
+
+
+def test_quantized_persists_and_reopens(tmp_path):
+    rng = np.random.default_rng(5)
+    d = tmp_path / "q8"
+    p = _pool(d, 8)
+    _fill(p, [_unit(rng.standard_normal(256)) for _ in range(50)])
+    p.close()
+    assert (d / "vectors.q8").exists()   # codes on disk, not vectors.f32
+    p2 = _pool(d, 8)                      # reopen -> dequantizes on load
+    assert len(p2) == 50 and p2.stats()["quantized"] is True
+    assert len(p2.search(_unit(rng.standard_normal(256)), k=3)) == 3

--- a/tests/test_quantize.py
+++ b/tests/test_quantize.py
@@ -1,0 +1,58 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""TurboVec codec: round-trip + the recall@k parity GATE that decides a safe quantization ratio.
+
+Coherence rides on retrieval recall, so the codec is only safe at a ratio that keeps recall@k ~= the
+float32 baseline. Measured on high-entropy random unit vectors (worst case): 8-bit holds recall >= 0.98
+(~4x compression); 4-bit drops to ~0.83 and is therefore NOT recall-safe as a default — it stays
+available but flagged. Real (structured) embeddings do better than random, but the default must be safe.
+"""
+import numpy as np
+
+from aether_context.quantize import (compression_ratio, dequantize, packed_bytes_per_row, quantize)
+
+
+def _unit(m):
+    return (m / np.linalg.norm(m, axis=1, keepdims=True)).astype(np.float32)
+
+
+def _recall_at_k(bits, n=3000, dim=256, q=200, k=10, seed=1):
+    rng = np.random.default_rng(seed)
+    base = _unit(rng.standard_normal((n, dim)))
+    queries = _unit(rng.standard_normal((q, dim)))
+    approx = dequantize(*quantize(base, bits), dim, bits)
+    hits = 0
+    for i in range(q):
+        true_top = set(np.argsort(-(base @ queries[i]))[:k])
+        appx_top = set(np.argsort(-(approx @ queries[i]))[:k])
+        hits += len(true_top & appx_top)
+    return hits / (q * k)
+
+
+def test_bits0_is_identity():
+    m = _unit(np.random.default_rng(0).standard_normal((5, 256)))
+    back = dequantize(*quantize(m, 0), 256, 0)
+    assert np.allclose(m, back, atol=1e-6)
+
+
+def test_roundtrip_is_unit_and_packs_to_expected_bytes():
+    m = _unit(np.random.default_rng(2).standard_normal((7, 256)))
+    for bits in (4, 8):
+        codes, scales = quantize(m, bits)
+        assert codes.shape[1] == packed_bytes_per_row(256, bits)
+        d = dequantize(codes, scales, 256, bits)
+        assert np.allclose(np.linalg.norm(d, axis=1), 1.0, atol=1e-5)
+
+
+def test_8bit_is_recall_safe():
+    assert _recall_at_k(8) >= 0.98               # the coherence gate — 8-bit is the safe default
+
+
+def test_4bit_is_lossy_not_default_safe():
+    r4, r8 = _recall_at_k(4), _recall_at_k(8)
+    assert r4 < r8                               # 4-bit trades recall for size; documented, flag-only
+
+
+def test_compression_ratios():
+    assert compression_ratio(256, 8) > 3.5 and compression_ratio(256, 4) > 7.0

--- a/tests/test_swe_eval.py
+++ b/tests/test_swe_eval.py
@@ -1,0 +1,122 @@
+import json as _json
+import subprocess
+from pathlib import Path
+
+from bench.swe_eval import (SweConfig, _build_config, run_instance,
+                            run_swe_eval, select_instances)
+
+
+_FAKE = [
+    {"instance_id": "p__c-3", "repo": "p/c", "base_commit": "c3", "problem_statement": "s3"},
+    {"instance_id": "p__c-1", "repo": "p/c", "base_commit": "c1", "problem_statement": "s1"},
+    {"instance_id": "p__c-2", "repo": "p/c", "base_commit": "c2", "problem_statement": "s2"},
+]
+
+
+def test_select_instances_sorted_and_capped():
+    got = select_instances(_FAKE, n=2)
+    assert [i["instance_id"] for i in got] == ["p__c-1", "p__c-2"]  # sorted, first 2
+
+
+def test_select_instances_all_when_n_zero():
+    got = select_instances(_FAKE, n=0)
+    assert len(got) == 3
+
+
+class _PatchChat:
+    """Two steps: (1) call edit_file to fix the bug, (2) emit a final message."""
+    def __init__(self, *_a, **_k):
+        self._t = 0
+
+    def chat(self, messages, tools=None, *, max_tokens=None):
+        self._t += 1
+        usage = {"prompt_tokens": 50, "completion_tokens": 10}
+        if self._t == 1:
+            return {"content": None, "usage": usage, "tool_calls": [
+                {"id": "c1", "type": "function", "function": {
+                    "name": "edit_file",
+                    "arguments": _json.dumps({"path": "a.py",
+                                              "old": "return x - y  # bug",
+                                              "new": "return x + y"})}}]}
+        return {"content": "done", "usage": usage, "tool_calls": []}
+
+
+def _make_repo(tmp_path):
+    d = tmp_path / "repo"
+    d.mkdir()
+    for a in (["init", "-q"], ["config", "user.email", "t@t"], ["config", "user.name", "t"]):
+        subprocess.run(["git", *a], cwd=d, check=True, capture_output=True)
+    (d / "a.py").write_text("def add(x, y):\n    return x - y  # bug\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=d, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=d, check=True, capture_output=True)
+    return d
+
+
+def _base(repo):
+    return subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                          capture_output=True, text=True).stdout.strip()
+
+
+def test_run_instance_produces_patch_off_arm(tmp_path):
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd")
+    inst = {"instance_id": "syn__repo-1", "repo": "syn/repo",
+            "base_commit": _base(repo), "problem_statement": "fix add"}
+    budget = {"spent": 0.0}
+    rec = run_instance("off", inst, cfg, _PatchChat(), budget,
+                       repo_url=f"file://{repo.as_posix()}")
+    assert rec["instance_id"] == "syn__repo-1"
+    assert "+    return x + y" in rec["model_patch"]
+    assert rec["arm"] == "off"
+
+
+def test_run_instance_codepro_arm_uses_engine(tmp_path):
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out",
+                    pool_gb=5)  # 5 GB = engine pool floor
+    inst = {"instance_id": "syn__repo-1", "repo": "syn/repo",
+            "base_commit": _base(repo), "problem_statement": "fix add"}
+    budget = {"spent": 0.0}
+    rec = run_instance("codepro", inst, cfg, _PatchChat(), budget,
+                       repo_url=f"file://{repo.as_posix()}")
+    assert "+    return x + y" in rec["model_patch"]
+    assert rec["arm"] == "codepro"
+
+
+def test_resume_skips_done_and_writes_predictions(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    insts = [{"instance_id": "syn__repo-1", "repo": "syn/repo", "base_commit": _base(repo),
+              "problem_statement": "fix add"}]
+    cfg = SweConfig(dry_run=True, arms=("off",), out_dir=tmp_path / "out",
+                    work_dir=tmp_path / "wd")
+    monkeypatch.setattr("bench.swe_eval._repo_url",
+                        lambda inst: f"file://{repo.as_posix()}")
+    run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    pred = (tmp_path / "out" / "predictions_off.jsonl").read_text(encoding="utf-8").strip()
+    assert "syn__repo-1" in pred
+    r2 = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    assert r2["skipped"] >= 1
+
+
+def test_global_cap_halts(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    insts = [{"instance_id": f"syn__repo-{i}", "repo": "syn/repo", "base_commit": _base(repo),
+              "problem_statement": "fix add"} for i in range(1, 4)]
+    cfg = SweConfig(dry_run=True, arms=("off",), out_dir=tmp_path / "out2",
+                    work_dir=tmp_path / "wd2", max_usd=0.0)  # cap already reached
+    monkeypatch.setattr("bench.swe_eval._repo_url",
+                        lambda inst: f"file://{repo.as_posix()}")
+    r = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    assert r["halted"] == "budget_cap"
+
+
+def test_cli_flags_map_to_config():
+    cfg = _build_config(["--instances", "5", "--arms", "off,codepro", "--pool-gb", "20",
+                         "--turbovec-bits", "8", "--no-mpo-chain", "--max-usd", "25",
+                         "--window", "4096", "--max-steps", "12", "--dry-run"])
+    assert cfg.instances == 5
+    assert cfg.arms == ("off", "codepro")
+    assert cfg.pool_gb == 20 and cfg.turbovec_bits == 8
+    assert cfg.mpo_chain is False
+    assert cfg.max_usd == 25.0 and cfg.window == 4096 and cfg.max_steps == 12
+    assert cfg.dry_run is True

--- a/tests/test_swe_scoring.py
+++ b/tests/test_swe_scoring.py
@@ -1,0 +1,23 @@
+import json
+
+from bench.swe_scoring import parse_report
+
+
+def test_parse_report_extracts_resolved(tmp_path):
+    report = {"total_instances": 3, "resolved_instances": 2,
+              "resolved_ids": ["a-1", "a-2"], "unresolved_ids": ["a-3"]}
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(report), encoding="utf-8")
+    out = parse_report(p)
+    assert out["resolved"] == 2
+    assert out["total"] == 3
+    assert out["resolved_rate"] == round(2 / 3, 4)
+    assert set(out["resolved_ids"]) == {"a-1", "a-2"}
+
+
+def test_parse_report_zero_total_no_div_by_zero(tmp_path):
+    p = tmp_path / "empty.json"
+    p.write_text(json.dumps({"total_instances": 0}), encoding="utf-8")
+    out = parse_report(p)
+    assert out["resolved_rate"] == 0.0
+    assert out["resolved"] == 0

--- a/tests/test_swe_tools.py
+++ b/tests/test_swe_tools.py
@@ -1,0 +1,81 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bench.swe_tools import RepoTools, prepare_checkout
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A tiny git repo at a known commit, for tools to read/edit."""
+    d = tmp_path / "repo"
+    d.mkdir()
+    _git(["init", "-q"], d)
+    _git(["config", "user.email", "t@t"], d)
+    _git(["config", "user.name", "t"], d)
+    (d / "a.py").write_text("def add(x, y):\n    return x - y  # bug\n", encoding="utf-8")
+    (d / "pkg").mkdir()
+    (d / "pkg" / "b.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(["add", "-A"], d)
+    _git(["commit", "-qm", "base"], d)
+    return d
+
+
+def test_read_file_returns_contents(repo):
+    t = RepoTools(repo)
+    out = t.read_file("a.py")
+    assert "def add" in out["content"]
+    assert out.get("error") is None
+
+
+def test_read_file_missing_is_error_not_raise(repo):
+    t = RepoTools(repo)
+    out = t.read_file("nope.py")
+    assert "error" in out
+
+
+def test_grep_finds_match(repo):
+    t = RepoTools(repo)
+    out = t.grep("return")
+    hits = " ".join(h["line"] for h in out["matches"])
+    assert "return" in hits
+    assert any(h["path"] == "a.py" for h in out["matches"])
+
+
+def test_list_dir(repo):
+    t = RepoTools(repo)
+    out = t.list_dir(".")
+    assert "a.py" in out["entries"]
+    assert "pkg/" in out["entries"]
+
+
+def test_edit_file_then_patch_is_unified_diff(repo):
+    t = RepoTools(repo)
+    r = t.edit_file("a.py", "    return x - y  # bug", "    return x + y")
+    assert r.get("error") is None
+    patch = t.current_patch()
+    assert patch.startswith("diff --git") or "--- a/a.py" in patch
+    assert "+    return x + y" in patch
+
+
+def test_edit_missing_oldstring_is_error(repo):
+    t = RepoTools(repo)
+    r = t.edit_file("a.py", "NONEXISTENT", "x")
+    assert "error" in r
+
+
+def test_prepare_checkout_at_base_commit(tmp_path, repo):
+    # `repo` is a real git repo; clone it to a base commit via file:// (no network).
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                          capture_output=True, text=True).stdout.strip()
+    work = tmp_path / "work"
+    out = prepare_checkout(f"file://{repo.as_posix()}", base, work)
+    assert (out / "a.py").is_file()
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=out,
+                          capture_output=True, text=True).stdout.strip()
+    assert head == base


### PR DESCRIPTION
## Summary
- New two-phase SWE-bench-lite coding eval comparing dsv4-pro **off** (raw, window-truncated) vs **codepro** (Unlimited-Context engine MAX: overpool + TurboVec 8-bit + MPO chain).
- Phase A (`bench/swe_eval.py` + `bench/swe_tools.py`): agentic file-tool loop generates patches → SWE-bench predictions JSONL. Reuses `api_eval` cost primitives + `Session`/`quantize` engine.
- Phase B (`bench/swe_scoring.py` → official `swebench` on VPS5 Docker): resolved-rate.
- $25 hard cap (shared, halt-on-hit, resumable), per-instance checkout isolation, deterministic instance selection, live-tuning flags (pool-gb / turbovec-bits / mpo-chain / recall-k / max-steps / window).
- Spec + plan + runbook under `docs/`.

## Test Plan
- [x] `pytest tests/test_swe_tools.py tests/test_swe_eval.py tests/test_swe_scoring.py` — 16 passed
- [x] `pytest tests/test_api_eval.py` — 6 passed (no collateral breakage)
- [x] `python -m bench.swe_eval --dry-run` — no crash, graceful per-instance checkout-error isolation
- [ ] 1-instance live smoke (off+codepro) before overnight 300
- [ ] Phase B Docker scoring on VPS5