### PR TITLE
fix(bench): SWE eval robustness — non-UTF8 grep/diff + tool-dispatch guard

### DIFF
--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -156,7 +156,10 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
                     args = json.loads(fn.get("arguments") or "{}")
                 except json.JSONDecodeError:
                     args = {}
-                result = tools.dispatch(fn.get("name", ""), args)
+                try:
+                    result = tools.dispatch(fn.get("name", ""), args)
+                except Exception as e:  # a tool crash must not kill the instance
+                    result = {"error": f"{type(e).__name__}: {e}"}
                 rjson = json.dumps(result)[:1500]
                 transcript.append({"role": "tool", "tool_call_id": tc.get("id", ""),
                                    "content": rjson})

--- a/bench/swe_tools.py
+++ b/bench/swe_tools.py
@@ -46,7 +46,8 @@ class RepoTools:
         cmd = ["git", "grep", "-n", "-I", "-e", pattern or ""]
         if path_glob:
             cmd += ["--", path_glob]
-        proc = subprocess.run(cmd, cwd=self.root, capture_output=True, text=True)
+        proc = subprocess.run(cmd, cwd=self.root, capture_output=True, text=True,
+                              errors="replace")  # repos contain non-UTF8 bytes
         matches = []
         for ln in proc.stdout.splitlines()[:100]:
             parts = ln.split(":", 2)
@@ -77,7 +78,8 @@ class RepoTools:
 
     def current_patch(self) -> str:
         """Unified diff of the working tree vs HEAD (the base commit) = model_patch."""
-        proc = subprocess.run(["git", "diff"], cwd=self.root, capture_output=True, text=True)
+        proc = subprocess.run(["git", "diff"], cwd=self.root, capture_output=True,
+                              text=True, errors="replace")  # binary diffs -> non-UTF8 bytes
         return proc.stdout
 
     TOOLS_SCHEMA = [

--- a/tests/test_swe_tools.py
+++ b/tests/test_swe_tools.py
@@ -69,6 +69,17 @@ def test_edit_missing_oldstring_is_error(repo):
     assert "error" in r
 
 
+def test_grep_survives_non_utf8_bytes(repo):
+    # A real repo contains non-UTF8 bytes; git grep -I skips binary, but text decode of
+    # any stray bytes must not crash the tool (errors="replace").
+    (repo / "weird.txt").write_bytes(b"return value \xc0\xc1 here\n")
+    _git(["add", "-A"], repo)
+    _git(["commit", "-qm", "weird"], repo)
+    t = RepoTools(repo)
+    out = t.grep("return")  # must not raise UnicodeDecodeError
+    assert "matches" in out
+
+
 def test_prepare_checkout_at_base_commit(tmp_path, repo):
     # `repo` is a real git repo; clone it to a base commit via file:// (no network).
     base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,


### PR DESCRIPTION
Smoke on astropy hit UnicodeDecodeError in git grep (text=True). Add errors=replace to grep + current_patch; wrap tool dispatch so one tool crash can't kill an instance. +regression test.