### PR TITLE
fix(bench): two-phase diff submission (real root cause of empty patches)

### DIFF
--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -78,12 +78,38 @@ def _truncate(messages: list[dict], window_tokens: int) -> list[dict]:
     return head + tail
 
 
-_SYS = ("You are an expert software engineer fixing a real bug in a repository. Investigate with "
-        "read_file, grep, and list_dir — but you have a LIMITED tool budget, so do NOT over-explore. "
-        "Once you have located the cause (usually within ~15 tool calls), you MUST call edit_file to "
-        "apply the fix. An answer with no edit_file call scores ZERO — always make at least one "
-        "edit_file change before you finish. Keep the fix minimal so the repo's own tests pass. "
-        "When done, reply with a one-line summary and STOP.")
+_SYS = ("You are an expert software engineer fixing a real bug in a repository. First INVESTIGATE "
+        "with read_file, grep, and list_dir to locate the cause. You have a limited tool budget, so "
+        "be efficient — do not re-read the same files. When you have enough understanding, stop "
+        "calling tools (reply with a brief note) and you will then be asked to produce the fix.")
+
+# The investigation phase exposes ONLY the read-only tools; the model produces the actual
+# fix in the forced patch turn below (dsv4-pro reliably emits a unified diff but will not
+# drive a stateful editor — it investigates until the budget is gone otherwise).
+_READONLY_SCHEMA = [t for t in RepoTools.TOOLS_SCHEMA
+                    if t["function"]["name"] in ("read_file", "grep", "list_dir")]
+
+_PATCH_INSTRUCTION = (
+    "Now produce the fix. Output the COMPLETE change as a unified diff in `git diff` format "
+    "(lines starting with `diff --git a/<path> b/<path>`, `--- a/<path>`, `+++ b/<path>`, then "
+    "`@@` hunks). Use real file paths relative to the repo root, from the files you read. Output "
+    "ONLY the diff inside a single ```diff code block — no prose, no explanation. Keep it minimal.")
+
+
+def _extract_diff(text: str) -> str:
+    """Pull a unified diff out of the model's text (fenced ```diff block or a raw
+    `diff --git`/`--- a/` region to end). Returns '' when no diff is present."""
+    import re
+    if not text:
+        return ""
+    m = re.search(r"```(?:diff|patch)?\s*\n(.*?)```", text, re.S)
+    body = m.group(1) if m else text
+    for marker in ("diff --git", "\n--- a/", "--- a/"):
+        i = body.find(marker)
+        if i != -1:
+            out = body[i:].strip()
+            return out + "\n" if out else ""
+    return ""
 
 
 def _empty_record(arm: str, inst: dict, halted: str) -> dict:
@@ -123,19 +149,25 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
     cost = 0.0
     cached = 0
     halted: Optional[str] = None
-    nudged = False
 
+    def _account(out: dict) -> bool:
+        """Tally cost/cached for one chat call. Returns False if a cost spike trips."""
+        nonlocal cost, cached, halted
+        usage = out.get("usage", {}) or {}
+        call_cost = cost_usd(usage, price_in=cfg.price_in, price_out=cfg.price_out)
+        cost += call_cost
+        budget["spent"] += call_cost
+        cached += cached_tokens(usage)
+        if call_cost > cfg.cost_spike_usd:
+            halted = "cost_spike"
+            return False
+        return True
+
+    # ── Phase 1: investigation (read-only tools, bounded) ──────────────
     for _step in range(cfg.max_steps):
         if budget["spent"] >= cfg.max_usd:
             halted = "budget_cap"
             break
-        # Near the end of the tool budget, force the edit phase: a turn spent still
-        # investigating with no edit yields an empty patch (auto-unresolved).
-        if not nudged and _step >= cfg.max_steps - 5 and not tools.current_patch().strip():
-            transcript.append({"role": "system", "content": (
-                "TOOL BUDGET ALMOST GONE. Stop investigating. Call edit_file NOW with your best "
-                "fix — an empty patch scores zero.")})
-            nudged = True
         if session is not None:
             qvec = encoder.encode(inst["problem_statement"])
             recalled = session._cold_retrieve(session._key(), qvec, cfg.recall_k)
@@ -146,47 +178,49 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
         else:
             convo = _truncate(transcript, cfg.window)
 
-        out = chat.chat(convo, tools=RepoTools.TOOLS_SCHEMA)
-        usage = out.get("usage", {}) or {}
-        call_cost = cost_usd(usage, price_in=cfg.price_in, price_out=cfg.price_out)
-        cost += call_cost
-        budget["spent"] += call_cost
-        cached += cached_tokens(usage)
-        if call_cost > cfg.cost_spike_usd:
-            halted = "cost_spike"
+        out = chat.chat(convo, tools=_READONLY_SCHEMA)
+        if not _account(out):
             break
 
         tcs = out.get("tool_calls") or []
-        if tcs:
-            transcript.append({"role": "assistant", "content": out.get("content"),
-                               "tool_calls": tcs})
-            for tc in tcs:
-                fn = tc.get("function", {})
-                try:
-                    args = json.loads(fn.get("arguments") or "{}")
-                except json.JSONDecodeError:
-                    args = {}
-                try:
-                    result = tools.dispatch(fn.get("name", ""), args)
-                except Exception as e:  # a tool crash must not kill the instance
-                    result = {"error": f"{type(e).__name__}: {e}"}
-                rjson = json.dumps(result)[:1500]
-                transcript.append({"role": "tool", "tool_call_id": tc.get("id", ""),
-                                   "content": rjson})
-                if session is not None:
-                    session.remember(f"{fn.get('name')}({args}): {rjson}")
-            continue
-        # No tool call = the model thinks it's done. Only accept that if a patch exists;
-        # otherwise it "finished" without editing -> push back and keep going (the step
-        # budget still bounds the loop).
-        transcript.append({"role": "assistant", "content": out.get("content") or "done"})
-        if tools.current_patch().strip():
-            break
-        transcript.append({"role": "system", "content": (
-            "You finished WITHOUT calling edit_file, so the patch is empty (scores zero). "
-            "Do not stop yet — call edit_file now to apply your fix to the repository.")})
+        if not tcs:
+            transcript.append({"role": "assistant", "content": out.get("content") or "ready"})
+            break  # model signalled it's done investigating -> go produce the patch
+        transcript.append({"role": "assistant", "content": out.get("content"),
+                           "tool_calls": tcs})
+        for tc in tcs:
+            fn = tc.get("function", {})
+            try:
+                args = json.loads(fn.get("arguments") or "{}")
+            except json.JSONDecodeError:
+                args = {}
+            try:
+                result = tools.dispatch(fn.get("name", ""), args)
+            except Exception as e:  # a tool crash must not kill the instance
+                result = {"error": f"{type(e).__name__}: {e}"}
+            rjson = json.dumps(result)[:1500]
+            transcript.append({"role": "tool", "tool_call_id": tc.get("id", ""),
+                               "content": rjson})
+            if session is not None:
+                session.remember(f"{fn.get('name')}({args}): {rjson}")
 
-    patch = tools.current_patch()
+    # ── Phase 2: forced patch turn (no tools) — capture the unified diff ──
+    patch = ""
+    if halted not in ("cost_spike",) and budget["spent"] < cfg.max_usd:
+        if session is not None:
+            qvec = encoder.encode(inst["problem_statement"])
+            recalled = session._cold_retrieve(session._key(), qvec, cfg.recall_k)
+            mem = "\n".join(f"[mem] {s.text}" for s in recalled) or "(empty)"
+            convo = _truncate([transcript[0],
+                               {"role": "system", "content": f"Working memory:\n{mem}"}]
+                              + transcript[1:], cfg.window)
+        else:
+            convo = _truncate(transcript, cfg.window)
+        convo = convo + [{"role": "user", "content": _PATCH_INSTRUCTION}]
+        out = chat.chat(convo, tools=None)
+        _account(out)
+        patch = _extract_diff(out.get("content") or "")
+
     if session is not None:
         session.close()
     return {

--- a/tests/test_swe_eval.py
+++ b/tests/test_swe_eval.py
@@ -1,8 +1,7 @@
-import json as _json
 import subprocess
 from pathlib import Path
 
-from bench.swe_eval import (SweConfig, _build_config, run_instance,
+from bench.swe_eval import (SweConfig, _build_config, _extract_diff, run_instance,
                             run_swe_eval, select_instances)
 
 
@@ -23,22 +22,34 @@ def test_select_instances_all_when_n_zero():
     assert len(got) == 3
 
 
-class _PatchChat:
-    """Two steps: (1) call edit_file to fix the bug, (2) emit a final message."""
+_DIFF = ("diff --git a/a.py b/a.py\n"
+         "--- a/a.py\n+++ b/a.py\n"
+         "@@ -1,2 +1,2 @@\n def add(x, y):\n"
+         "-    return x - y  # bug\n+    return x + y\n")
+
+
+class _DiffChat:
+    """Investigation turns (tools set) -> 'ready' no tool call; patch turn (tools=None)
+    -> a fenced unified diff. Mirrors how dsv4-pro is driven in the two-phase loop."""
     def __init__(self, *_a, **_k):
-        self._t = 0
+        pass
 
     def chat(self, messages, tools=None, *, max_tokens=None):
-        self._t += 1
         usage = {"prompt_tokens": 50, "completion_tokens": 10}
-        if self._t == 1:
-            return {"content": None, "usage": usage, "tool_calls": [
-                {"id": "c1", "type": "function", "function": {
-                    "name": "edit_file",
-                    "arguments": _json.dumps({"path": "a.py",
-                                              "old": "return x - y  # bug",
-                                              "new": "return x + y"})}}]}
-        return {"content": "done", "usage": usage, "tool_calls": []}
+        if tools is None:  # forced patch turn
+            return {"content": "```diff\n" + _DIFF + "```", "usage": usage, "tool_calls": []}
+        return {"content": "ready", "usage": usage, "tool_calls": []}  # stop investigating
+
+
+class _NoDiffChat:
+    """Never emits a diff (prose only) -> empty patch."""
+    def __init__(self, *_a, **_k):
+        pass
+
+    def chat(self, messages, tools=None, *, max_tokens=None):
+        usage = {"prompt_tokens": 50, "completion_tokens": 10}
+        return {"content": "I think the bug is in a.py somewhere.", "usage": usage,
+                "tool_calls": []}
 
 
 def _make_repo(tmp_path):
@@ -57,78 +68,63 @@ def _base(repo):
                           capture_output=True, text=True).stdout.strip()
 
 
-class _LazyChat:
-    """Step 1: 'done' with NO tool call (empty patch). After pushback, step 2 edits."""
-    def __init__(self, *_a, **_k):
-        self._t = 0
-
-    def chat(self, messages, tools=None, *, max_tokens=None):
-        self._t += 1
-        usage = {"prompt_tokens": 50, "completion_tokens": 10}
-        if self._t == 1:
-            return {"content": "I analyzed it, the fix is obvious. Done.",
-                    "usage": usage, "tool_calls": []}
-        if self._t == 2:
-            return {"content": None, "usage": usage, "tool_calls": [
-                {"id": "c1", "type": "function", "function": {
-                    "name": "edit_file",
-                    "arguments": _json.dumps({"path": "a.py",
-                                              "old": "return x - y  # bug",
-                                              "new": "return x + y"})}}]}
-        return {"content": "done", "usage": usage, "tool_calls": []}
-
-
-def test_finish_without_edit_is_rejected_until_patch_exists(tmp_path):
-    repo = _make_repo(tmp_path)
-    cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out",
-                    max_steps=10)
-    inst = {"instance_id": "syn__repo-1", "repo": "syn/repo",
+def _inst(repo):
+    return {"instance_id": "syn__repo-1", "repo": "syn/repo",
             "base_commit": _base(repo), "problem_statement": "fix add"}
-    rec = run_instance("off", inst, cfg, _LazyChat(), {"spent": 0.0},
-                       repo_url=f"file://{repo.as_posix()}")
-    # The first 'done' (no edit) was rejected; the model then edited -> patch lands.
-    assert rec["patch_nonempty"] is True
-    assert "+    return x + y" in rec["model_patch"]
 
 
-def test_run_instance_produces_patch_off_arm(tmp_path):
+def test_extract_diff_from_fenced_block():
+    out = _extract_diff("Here is the fix:\n```diff\n" + _DIFF + "```\nDone.")
+    assert out.startswith("diff --git a/a.py")
+    assert "+    return x + y" in out
+
+
+def test_extract_diff_empty_when_no_diff():
+    assert _extract_diff("I could not find the bug.") == ""
+
+
+def test_run_instance_captures_diff_off_arm(tmp_path):
     repo = _make_repo(tmp_path)
-    cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd")
-    inst = {"instance_id": "syn__repo-1", "repo": "syn/repo",
-            "base_commit": _base(repo), "problem_statement": "fix add"}
-    budget = {"spent": 0.0}
-    rec = run_instance("off", inst, cfg, _PatchChat(), budget,
+    cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out")
+    rec = run_instance("off", _inst(repo), cfg, _DiffChat(), {"spent": 0.0},
                        repo_url=f"file://{repo.as_posix()}")
-    assert rec["instance_id"] == "syn__repo-1"
-    assert "+    return x + y" in rec["model_patch"]
     assert rec["arm"] == "off"
+    assert rec["patch_nonempty"] is True
+    assert "diff --git a/a.py" in rec["model_patch"]
+    assert "+    return x + y" in rec["model_patch"]
 
 
 def test_run_instance_codepro_arm_uses_engine(tmp_path):
     repo = _make_repo(tmp_path)
     cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out",
                     pool_gb=5)  # 5 GB = engine pool floor
-    inst = {"instance_id": "syn__repo-1", "repo": "syn/repo",
-            "base_commit": _base(repo), "problem_statement": "fix add"}
-    budget = {"spent": 0.0}
-    rec = run_instance("codepro", inst, cfg, _PatchChat(), budget,
+    rec = run_instance("codepro", _inst(repo), cfg, _DiffChat(), {"spent": 0.0},
                        repo_url=f"file://{repo.as_posix()}")
-    assert "+    return x + y" in rec["model_patch"]
     assert rec["arm"] == "codepro"
+    assert rec["patch_nonempty"] is True
+    assert "+    return x + y" in rec["model_patch"]
+
+
+def test_run_instance_no_diff_is_empty_patch(tmp_path):
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out")
+    rec = run_instance("off", _inst(repo), cfg, _NoDiffChat(), {"spent": 0.0},
+                       repo_url=f"file://{repo.as_posix()}")
+    assert rec["patch_nonempty"] is False
+    assert rec["model_patch"] == ""
 
 
 def test_resume_skips_done_and_writes_predictions(tmp_path, monkeypatch):
     repo = _make_repo(tmp_path)
-    insts = [{"instance_id": "syn__repo-1", "repo": "syn/repo", "base_commit": _base(repo),
-              "problem_statement": "fix add"}]
+    insts = [_inst(repo)]
     cfg = SweConfig(dry_run=True, arms=("off",), out_dir=tmp_path / "out",
                     work_dir=tmp_path / "wd")
     monkeypatch.setattr("bench.swe_eval._repo_url",
                         lambda inst: f"file://{repo.as_posix()}")
-    run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _DiffChat())
     pred = (tmp_path / "out" / "predictions_off.jsonl").read_text(encoding="utf-8").strip()
     assert "syn__repo-1" in pred
-    r2 = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    r2 = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _DiffChat())
     assert r2["skipped"] >= 1
 
 
@@ -140,7 +136,7 @@ def test_global_cap_halts(tmp_path, monkeypatch):
                     work_dir=tmp_path / "wd2", max_usd=0.0)  # cap already reached
     monkeypatch.setattr("bench.swe_eval._repo_url",
                         lambda inst: f"file://{repo.as_posix()}")
-    r = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _PatchChat())
+    r = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _DiffChat())
     assert r["halted"] == "budget_cap"
 
 


### PR DESCRIPTION
dsv4-pro emitted ZERO text and ZERO edits across the full step budget — pure read/grep until cap. Switch to the standard SWE scaffold: phase 1 = read-only investigation (bounded), phase 2 = forced no-tool turn asking for a unified diff, captured (via _extract_diff) as model_patch. Phase B applies+tests it. This also makes off-vs-codepro purely a function of retained context. Tests rewritten to the diff contract (20 pass).