### PR TITLE
fix(bench): SEARCH/REPLACE patch submission (dsv4-pro diff root cause)

### DIFF
--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -90,26 +91,32 @@ _READONLY_SCHEMA = [t for t in RepoTools.TOOLS_SCHEMA
                     if t["function"]["name"] in ("read_file", "grep", "list_dir")]
 
 _PATCH_INSTRUCTION = (
-    "Now produce the fix. Output the COMPLETE change as a unified diff in `git diff` format "
-    "(lines starting with `diff --git a/<path> b/<path>`, `--- a/<path>`, `+++ b/<path>`, then "
-    "`@@` hunks). Use real file paths relative to the repo root, from the files you read. Output "
-    "ONLY the diff inside a single ```diff code block — no prose, no explanation. Keep it minimal.")
+    "Now produce the fix. Do NOT call any tools. Output one or more edit blocks in EXACTLY this "
+    "format, one per change:\n\n"
+    "<path/relative/to/repo/root>\n"
+    "<<<<<<< SEARCH\n"
+    "<exact lines that currently exist in the file>\n"
+    "=======\n"
+    "<replacement lines>\n"
+    ">>>>>>> REPLACE\n\n"
+    "The SEARCH text must match the current file content EXACTLY (whitespace included) — copy it "
+    "from what you read. Keep edits minimal. Output ONLY the blocks, no prose.")
+
+# Aider-style SEARCH/REPLACE block. dsv4-pro will not write a line-numbered unified diff from
+# memory (it just keeps trying to re-read), but it can reproduce an exact snippet + replacement.
+# Applying via edit_file makes the off-vs-codepro gap a function of whether the model REMEMBERS
+# the exact code: off (truncated transcript) misremembers -> SEARCH miss; codepro recalls it.
+_BLOCK_RE = re.compile(
+    r"(?P<path>[^\n<>=]+?)\n<{5,7} SEARCH\n(?P<search>.*?)\n={5,7}\n(?P<replace>.*?)\n>{5,7} REPLACE",
+    re.S)
 
 
-def _extract_diff(text: str) -> str:
-    """Pull a unified diff out of the model's text (fenced ```diff block or a raw
-    `diff --git`/`--- a/` region to end). Returns '' when no diff is present."""
-    import re
+def _parse_blocks(text: str) -> list[tuple[str, str, str]]:
+    """Extract (path, search, replace) edit blocks from the model's patch-turn text."""
     if not text:
-        return ""
-    m = re.search(r"```(?:diff|patch)?\s*\n(.*?)```", text, re.S)
-    body = m.group(1) if m else text
-    for marker in ("diff --git", "\n--- a/", "--- a/"):
-        i = body.find(marker)
-        if i != -1:
-            out = body[i:].strip()
-            return out + "\n" if out else ""
-    return ""
+        return []
+    return [(m.group("path").strip().strip("`").strip(),
+             m.group("search"), m.group("replace")) for m in _BLOCK_RE.finditer(text)]
 
 
 def _empty_record(arm: str, inst: dict, halted: str) -> dict:
@@ -204,9 +211,14 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
             if session is not None:
                 session.remember(f"{fn.get('name')}({args}): {rjson}")
 
-    # ── Phase 2: forced patch turn (no tools) — capture the unified diff ──
-    patch = ""
-    if halted not in ("cost_spike",) and budget["spent"] < cfg.max_usd:
+    # ── Phase 2: forced patch turn(s) — SEARCH/REPLACE blocks, applied to the checkout ──
+    # Up to 2 attempts: the second gets feedback on which SEARCH blocks didn't match (so a
+    # near-miss can self-correct). model_patch = git diff of whatever applied.
+    applied = 0
+    instruction = _PATCH_INSTRUCTION
+    for _attempt in range(2):
+        if halted == "cost_spike" or budget["spent"] >= cfg.max_usd:
+            break
         if session is not None:
             qvec = encoder.encode(inst["problem_statement"])
             recalled = session._cold_retrieve(session._key(), qvec, cfg.recall_k)
@@ -216,11 +228,27 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
                               + transcript[1:], cfg.window)
         else:
             convo = _truncate(transcript, cfg.window)
-        convo = convo + [{"role": "user", "content": _PATCH_INSTRUCTION}]
+        convo = convo + [{"role": "user", "content": instruction}]
         out = chat.chat(convo, tools=None)
-        _account(out)
-        patch = _extract_diff(out.get("content") or "")
+        if not _account(out):
+            break
+        blocks = _parse_blocks(out.get("content") or "")
+        if not blocks:
+            break  # nothing usable -> give up (empty patch = unresolved)
+        fails = []
+        for path, search, replace in blocks:
+            res = tools.edit_file(path, search, replace)
+            if isinstance(res, dict) and res.get("ok"):
+                applied += 1
+            else:
+                fails.append(f"{path}: {res.get('error') if isinstance(res, dict) else 'failed'}")
+        if applied and not fails:
+            break
+        instruction = (_PATCH_INSTRUCTION + "\n\nThese blocks did NOT match the file and were "
+                       "skipped — fix the SEARCH text to match EXACTLY and resend ALL needed "
+                       "blocks:\n" + "\n".join(fails))
 
+    patch = tools.current_patch()
     if session is not None:
         session.close()
     return {

--- a/tests/test_swe_eval.py
+++ b/tests/test_swe_eval.py
@@ -1,7 +1,7 @@
 import subprocess
 from pathlib import Path
 
-from bench.swe_eval import (SweConfig, _build_config, _extract_diff, run_instance,
+from bench.swe_eval import (SweConfig, _build_config, _parse_blocks, run_instance,
                             run_swe_eval, select_instances)
 
 
@@ -22,34 +22,35 @@ def test_select_instances_all_when_n_zero():
     assert len(got) == 3
 
 
-_DIFF = ("diff --git a/a.py b/a.py\n"
-         "--- a/a.py\n+++ b/a.py\n"
-         "@@ -1,2 +1,2 @@\n def add(x, y):\n"
-         "-    return x - y  # bug\n+    return x + y\n")
+# An Aider-style SEARCH/REPLACE block that fixes the seeded bug in a.py.
+_SR = ("a.py\n"
+       "<<<<<<< SEARCH\n"
+       "    return x - y  # bug\n"
+       "=======\n"
+       "    return x + y\n"
+       ">>>>>>> REPLACE\n")
 
 
-class _DiffChat:
-    """Investigation turns (tools set) -> 'ready' no tool call; patch turn (tools=None)
-    -> a fenced unified diff. Mirrors how dsv4-pro is driven in the two-phase loop."""
+class _SRChat:
+    """Investigation turns (tools set) -> 'ready'; patch turn (tools=None) -> SR block."""
     def __init__(self, *_a, **_k):
         pass
 
     def chat(self, messages, tools=None, *, max_tokens=None):
         usage = {"prompt_tokens": 50, "completion_tokens": 10}
         if tools is None:  # forced patch turn
-            return {"content": "```diff\n" + _DIFF + "```", "usage": usage, "tool_calls": []}
-        return {"content": "ready", "usage": usage, "tool_calls": []}  # stop investigating
+            return {"content": "Here is the fix:\n" + _SR, "usage": usage, "tool_calls": []}
+        return {"content": "ready", "usage": usage, "tool_calls": []}
 
 
-class _NoDiffChat:
-    """Never emits a diff (prose only) -> empty patch."""
+class _NoEditChat:
+    """Never emits a usable edit block -> empty patch."""
     def __init__(self, *_a, **_k):
         pass
 
     def chat(self, messages, tools=None, *, max_tokens=None):
-        usage = {"prompt_tokens": 50, "completion_tokens": 10}
-        return {"content": "I think the bug is in a.py somewhere.", "usage": usage,
-                "tool_calls": []}
+        return {"content": "I think the bug is somewhere in a.py.",
+                "usage": {"prompt_tokens": 50, "completion_tokens": 10}, "tool_calls": []}
 
 
 def _make_repo(tmp_path):
@@ -73,20 +74,23 @@ def _inst(repo):
             "base_commit": _base(repo), "problem_statement": "fix add"}
 
 
-def test_extract_diff_from_fenced_block():
-    out = _extract_diff("Here is the fix:\n```diff\n" + _DIFF + "```\nDone.")
-    assert out.startswith("diff --git a/a.py")
-    assert "+    return x + y" in out
+def test_parse_blocks_extracts_path_search_replace():
+    blocks = _parse_blocks("prose\n" + _SR + "\nmore prose")
+    assert len(blocks) == 1
+    path, search, replace = blocks[0]
+    assert path == "a.py"
+    assert "return x - y  # bug" in search
+    assert "return x + y" in replace
 
 
-def test_extract_diff_empty_when_no_diff():
-    assert _extract_diff("I could not find the bug.") == ""
+def test_parse_blocks_empty_when_none():
+    assert _parse_blocks("no edit blocks here") == []
 
 
-def test_run_instance_captures_diff_off_arm(tmp_path):
+def test_run_instance_applies_block_off_arm(tmp_path):
     repo = _make_repo(tmp_path)
     cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out")
-    rec = run_instance("off", _inst(repo), cfg, _DiffChat(), {"spent": 0.0},
+    rec = run_instance("off", _inst(repo), cfg, _SRChat(), {"spent": 0.0},
                        repo_url=f"file://{repo.as_posix()}")
     assert rec["arm"] == "off"
     assert rec["patch_nonempty"] is True
@@ -98,17 +102,17 @@ def test_run_instance_codepro_arm_uses_engine(tmp_path):
     repo = _make_repo(tmp_path)
     cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out",
                     pool_gb=5)  # 5 GB = engine pool floor
-    rec = run_instance("codepro", _inst(repo), cfg, _DiffChat(), {"spent": 0.0},
+    rec = run_instance("codepro", _inst(repo), cfg, _SRChat(), {"spent": 0.0},
                        repo_url=f"file://{repo.as_posix()}")
     assert rec["arm"] == "codepro"
     assert rec["patch_nonempty"] is True
     assert "+    return x + y" in rec["model_patch"]
 
 
-def test_run_instance_no_diff_is_empty_patch(tmp_path):
+def test_run_instance_no_block_is_empty_patch(tmp_path):
     repo = _make_repo(tmp_path)
     cfg = SweConfig(dry_run=True, work_dir=tmp_path / "wd", out_dir=tmp_path / "out")
-    rec = run_instance("off", _inst(repo), cfg, _NoDiffChat(), {"spent": 0.0},
+    rec = run_instance("off", _inst(repo), cfg, _NoEditChat(), {"spent": 0.0},
                        repo_url=f"file://{repo.as_posix()}")
     assert rec["patch_nonempty"] is False
     assert rec["model_patch"] == ""
@@ -121,10 +125,10 @@ def test_resume_skips_done_and_writes_predictions(tmp_path, monkeypatch):
                     work_dir=tmp_path / "wd")
     monkeypatch.setattr("bench.swe_eval._repo_url",
                         lambda inst: f"file://{repo.as_posix()}")
-    run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _DiffChat())
+    run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _SRChat())
     pred = (tmp_path / "out" / "predictions_off.jsonl").read_text(encoding="utf-8").strip()
     assert "syn__repo-1" in pred
-    r2 = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _DiffChat())
+    r2 = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _SRChat())
     assert r2["skipped"] >= 1
 
 
@@ -136,7 +140,7 @@ def test_global_cap_halts(tmp_path, monkeypatch):
                     work_dir=tmp_path / "wd2", max_usd=0.0)  # cap already reached
     monkeypatch.setattr("bench.swe_eval._repo_url",
                         lambda inst: f"file://{repo.as_posix()}")
-    r = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _DiffChat())
+    r = run_swe_eval(cfg, instances=insts, chat_factory=lambda cfg: _SRChat())
     assert r["halted"] == "budget_cap"
 
 


### PR DESCRIPTION
Phase-2 capture showed dsv4-pro emitting its native DSML tool syntax as text (compulsive re-reads) and never a unified diff. Switch to Aider-style SEARCH/REPLACE blocks (path + exact old + new), applied via edit_file; model_patch = resulting git diff. 2 attempts with mismatch feedback. Makes off-vs-codepro a function of whether the model remembers the exact code (off truncates -> SEARCH miss; codepro recalls). 20 tests pass.