### PR TITLE
fix(bench): submit_patch-only phase 2 (dsv4-pro tool compulsion)

### DIFF
--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -91,16 +91,40 @@ _READONLY_SCHEMA = [t for t in RepoTools.TOOLS_SCHEMA
                     if t["function"]["name"] in ("read_file", "grep", "list_dir")]
 
 _PATCH_INSTRUCTION = (
-    "Now produce the fix. Do NOT call any tools. Output one or more edit blocks in EXACTLY this "
-    "format, one per change:\n\n"
+    "You have finished investigating and can no longer read files. Call the submit_patch tool "
+    "now with your complete fix. The `edits` argument must contain one or more blocks in EXACTLY "
+    "this format, one per change:\n\n"
     "<path/relative/to/repo/root>\n"
     "<<<<<<< SEARCH\n"
     "<exact lines that currently exist in the file>\n"
     "=======\n"
     "<replacement lines>\n"
     ">>>>>>> REPLACE\n\n"
-    "The SEARCH text must match the current file content EXACTLY (whitespace included) — copy it "
-    "from what you read. Keep edits minimal. Output ONLY the blocks, no prose.")
+    "The SEARCH text must match the current file content EXACTLY (whitespace included), from what "
+    "you read. submit_patch is the ONLY tool available — you must call it.")
+
+# Phase-2 exposes ONLY this tool. dsv4-pro compulsively calls tools and will not write from
+# memory when asked in plain text (it keeps trying to re-read); giving it a single submit tool
+# turns that compulsion into the patch submission.
+_SUBMIT_SCHEMA = [{"type": "function", "function": {
+    "name": "submit_patch",
+    "description": "Submit the final fix as SEARCH/REPLACE edit blocks.",
+    "parameters": {"type": "object",
+                   "properties": {"edits": {"type": "string",
+                                            "description": "One or more SEARCH/REPLACE blocks."}},
+                   "required": ["edits"]}}}]
+
+
+def _submit_edits(out: dict) -> Optional[str]:
+    """Return the `edits` string from a submit_patch tool call, or None."""
+    for tc in (out.get("tool_calls") or []):
+        fn = tc.get("function", {})
+        if fn.get("name") == "submit_patch":
+            try:
+                return (json.loads(fn.get("arguments") or "{}") or {}).get("edits")
+            except json.JSONDecodeError:
+                return None
+    return None
 
 # Aider-style SEARCH/REPLACE block. dsv4-pro will not write a line-numbered unified diff from
 # memory (it just keeps trying to re-read), but it can reproduce an exact snippet + replacement.
@@ -229,10 +253,12 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
         else:
             convo = _truncate(transcript, cfg.window)
         convo = convo + [{"role": "user", "content": instruction}]
-        out = chat.chat(convo, tools=None)
+        out = chat.chat(convo, tools=_SUBMIT_SCHEMA)
         if not _account(out):
             break
-        blocks = _parse_blocks(out.get("content") or "")
+        # Prefer the submit_patch tool arg; fall back to any blocks in free text.
+        edits = _submit_edits(out)
+        blocks = _parse_blocks(edits if edits is not None else (out.get("content") or ""))
         if not blocks:
             break  # nothing usable -> give up (empty patch = unresolved)
         fails = []

--- a/tests/test_swe_eval.py
+++ b/tests/test_swe_eval.py
@@ -1,8 +1,10 @@
 import subprocess
 from pathlib import Path
 
-from bench.swe_eval import (SweConfig, _build_config, _parse_blocks, run_instance,
-                            run_swe_eval, select_instances)
+import json as _json
+
+from bench.swe_eval import (SweConfig, _build_config, _parse_blocks, _submit_edits,
+                            run_instance, run_swe_eval, select_instances)
 
 
 _FAKE = [
@@ -31,15 +33,23 @@ _SR = ("a.py\n"
        ">>>>>>> REPLACE\n")
 
 
+def _is_submit(tools) -> bool:
+    return bool(tools) and any(
+        t.get("function", {}).get("name") == "submit_patch" for t in tools)
+
+
 class _SRChat:
-    """Investigation turns (tools set) -> 'ready'; patch turn (tools=None) -> SR block."""
+    """Investigation turns -> 'ready'; patch turn (submit_patch tool) -> submit_patch call."""
     def __init__(self, *_a, **_k):
         pass
 
     def chat(self, messages, tools=None, *, max_tokens=None):
         usage = {"prompt_tokens": 50, "completion_tokens": 10}
-        if tools is None:  # forced patch turn
-            return {"content": "Here is the fix:\n" + _SR, "usage": usage, "tool_calls": []}
+        if _is_submit(tools):  # forced patch turn
+            return {"content": None, "usage": usage, "tool_calls": [
+                {"id": "s1", "type": "function", "function": {
+                    "name": "submit_patch",
+                    "arguments": _json.dumps({"edits": _SR})}}]}
         return {"content": "ready", "usage": usage, "tool_calls": []}
 
 
@@ -85,6 +95,16 @@ def test_parse_blocks_extracts_path_search_replace():
 
 def test_parse_blocks_empty_when_none():
     assert _parse_blocks("no edit blocks here") == []
+
+
+def test_submit_edits_reads_tool_arg():
+    out = {"tool_calls": [{"function": {"name": "submit_patch",
+                                        "arguments": _json.dumps({"edits": _SR})}}]}
+    assert _submit_edits(out) == _SR
+
+
+def test_submit_edits_none_when_absent():
+    assert _submit_edits({"tool_calls": []}) is None
 
 
 def test_run_instance_applies_block_off_arm(tmp_path):


### PR DESCRIPTION
dsv4-pro kept emitting read_file even with tools removed + 'do not call tools'. Work with it: phase 2 offers exactly ONE tool, submit_patch(edits=SEARCH/REPLACE blocks). The model that compulsively calls tools calls the only one available; we parse + apply the blocks. 22 tests pass.