### PR TITLE
perf(bench): clone cache + interleaved arms

### DIFF
--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -159,7 +159,10 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
     """Run ONE SWE instance under ONE arm. Returns a predictions record incl. model_patch.
     OFF: window-truncated transcript. CODEPRO: Session(overpool+turbovec+chain) recall."""
     url = repo_url or f"https://github.com/{inst['repo']}.git"
-    workdir = cfg.work_dir / arm / inst["instance_id"]
+    # Per-REPO checkout dir (shared across instances + arms, sequential) so each repo clones
+    # once; prepare_checkout hard-resets it to this instance's base_commit.
+    repo_slug = re.sub(r"[^A-Za-z0-9]+", "_", inst["repo"])
+    workdir = cfg.work_dir / repo_slug
     try:
         checkout = prepare_checkout(url, inst["base_commit"], workdir)
     except Exception as e:  # clone/checkout failed — record empty patch, keep the batch alive
@@ -329,19 +332,26 @@ def run_swe_eval(cfg: SweConfig, instances: Optional[list[dict]] = None,
                                         for a in cfg.arms},
                                "skipped": 0, "halted": None}
 
-    for arm in cfg.arms:
-        pred_path = cfg.out_dir / f"predictions_{arm}.jsonl"
-        done = _done_ids(pred_path)
-        chat = chat_factory(cfg)
-        for inst in rows:
-            if inst["instance_id"] in done:
+    # Arms run INNER, instances OUTER: every instance gets all arms before moving on, so a
+    # partial (cap-halted) run still yields a valid off-vs-codepro comparison on the instances
+    # completed so far. Same model across arms -> one chat client reused. Per-arm predictions
+    # JSONL + done-set keeps it resumable.
+    pred_paths = {a: cfg.out_dir / f"predictions_{a}.jsonl" for a in cfg.arms}
+    done = {a: _done_ids(pred_paths[a]) for a in cfg.arms}
+    chat = chat_factory(cfg)
+
+    for inst in rows:
+        if summary["halted"]:
+            break
+        for arm in cfg.arms:
+            if inst["instance_id"] in done[arm]:
                 summary["skipped"] += 1
                 continue
             if budget["spent"] >= cfg.max_usd:
                 summary["halted"] = "budget_cap"
                 break
             rec = run_instance(arm, inst, cfg, chat, budget, repo_url=_repo_url(inst))
-            with pred_path.open("a", encoding="utf-8") as fh:
+            with pred_paths[arm].open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(rec) + "\n")
             summary["arms"][arm]["done"] += 1
             summary["arms"][arm]["patched"] += int(rec["patch_nonempty"])
@@ -350,8 +360,6 @@ def run_swe_eval(cfg: SweConfig, instances: Optional[list[dict]] = None,
             if rec.get("halted") in ("budget_cap", "cost_spike"):
                 summary["halted"] = rec["halted"]
                 break
-        if summary["halted"]:
-            break
 
     summary["total_cost_usd"] = round(budget["spent"], 6)
     (cfg.out_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")

--- a/bench/swe_tools.py
+++ b/bench/swe_tools.py
@@ -122,17 +122,25 @@ class RepoTools:
 
 
 def prepare_checkout(repo_url: str, base_commit: str, workdir: Path) -> Path:
-    """Clone `repo_url` into `workdir` and checkout `base_commit`. Idempotent: if workdir
-    already holds that commit, reuse it. Returns the checkout path. Used only so the agent's
-    file tools can READ the repo during generation; Phase B does its own isolated checkout."""
+    """Make `workdir` a clean checkout of `repo_url` at `base_commit`.
+
+    `workdir` is keyed PER REPO (not per instance): the first instance of a repo clones it
+    once (network); every later instance of the same repo just hard-resets to its base_commit
+    + cleans — SWE-bench-lite repeats ~12 repos across 300 instances, so this turns ~600 network
+    clones into ~12. Used only so the agent's file tools can READ the repo during generation;
+    Phase B does its own isolated checkout."""
     workdir = Path(workdir)
     if (workdir / ".git").is_dir():
-        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=workdir,
-                              capture_output=True, text=True).stdout.strip()
-        if head == base_commit:
-            return workdir
-        import shutil
-        shutil.rmtree(workdir, ignore_errors=True)
+        # cached clone of this repo — fetch the commit if missing, then hard-reset clean
+        have = subprocess.run(["git", "cat-file", "-e", f"{base_commit}^{{commit}}"],
+                              cwd=workdir, capture_output=True)
+        if have.returncode != 0:
+            subprocess.run(["git", "fetch", "-q", "origin", base_commit],
+                           cwd=workdir, capture_output=True)  # best-effort; full clone usually has it
+        subprocess.run(["git", "checkout", "-q", "-f", base_commit], cwd=workdir,
+                       check=True, capture_output=True)
+        subprocess.run(["git", "clean", "-qdfx"], cwd=workdir, check=True, capture_output=True)
+        return workdir
     workdir.parent.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "clone", "-q", repo_url, str(workdir)], check=True,
                    capture_output=True)

--- a/tests/test_swe_tools.py
+++ b/tests/test_swe_tools.py
@@ -80,6 +80,20 @@ def test_grep_survives_non_utf8_bytes(repo):
     assert "matches" in out
 
 
+def test_prepare_checkout_reuses_and_resets(tmp_path, repo):
+    # Per-repo cache: second call on the same workdir must NOT re-clone — it hard-resets the
+    # (dirtied) tree back to base_commit clean.
+    base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                          capture_output=True, text=True).stdout.strip()
+    work = tmp_path / "cache"
+    prepare_checkout(f"file://{repo.as_posix()}", base, work)
+    (work / "a.py").write_text("DIRTIED", encoding="utf-8")          # mutate the cached tree
+    (work / "junk.txt").write_text("junk", encoding="utf-8")          # add an untracked file
+    prepare_checkout(f"file://{repo.as_posix()}", base, work)         # reuse path
+    assert "def add" in (work / "a.py").read_text(encoding="utf-8")   # reset
+    assert not (work / "junk.txt").exists()                           # cleaned
+
+
 def test_prepare_checkout_at_base_commit(tmp_path, repo):
     # `repo` is a real git repo; clone it to a base commit via file:// (no network).
     base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,


### PR DESCRIPTION
Full run was ~3min/instance (per-instance network clones of big repos) and arms ran outer (no codepro contrast until off fully done). Cache clones per-repo (SWE-lite repeats ~12 repos -> ~12 clones not 600; reuse = checkout -f + clean) and interleave arms per instance so a partial/cap-halted run yields a valid off-vs-codepro headline. 23 tests pass.