### PR TITLE
fix(bench): hung-call timeout + per-instance deadline

### DIFF
--- a/aether_context/local_llm.py
+++ b/aether_context/local_llm.py
@@ -476,8 +476,10 @@ class OllamaLLM:
 # ---------------------------------------------------------------------------
 #: OpenRouter default base URL when only OPENROUTER_API_KEY is set.
 _OPENROUTER_BASE = "https://openrouter.ai/api/v1"
-#: HTTP timeout (s) for the OpenAI-compatible adapter.
-_OPENAI_TIMEOUT = 600
+#: HTTP timeout (s) for the OpenAI-compatible adapter. Kept tight: a coding turn that
+#: hasn't responded in 3 min is a hung connection — fail fast so the batch can continue
+#: (a 600s hang once stalled a whole sequential run ~30 min). Override via OPENAI_HTTP_TIMEOUT.
+_OPENAI_TIMEOUT = int(os.environ.get("OPENAI_HTTP_TIMEOUT", "180"))
 
 
 class OpenAICompatLLM:

--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -40,6 +40,7 @@ class SweConfig:
     price_out: float = 1.2
     max_usd: float = 25.0         # hard global spend cap (shared across arms+instances)
     cost_spike_usd: float = 0.50
+    instance_timeout_s: float = 600.0   # per-instance wall-clock guard (a hung call can't stall the batch)
     dry_run: bool = False
     out_dir: Path = field(default_factory=lambda: Path("runs/swe_eval"))
     work_dir: Path = field(default_factory=lambda: Path("runs/swe_eval/checkouts"))
@@ -217,9 +218,14 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
             convo = [convo[0], {"role": "system", "content": f"Working memory:\n{mem}"}] + convo[1:]
         return convo + (extra or [])
 
+    import time as _time
+    _deadline = _time.monotonic() + cfg.instance_timeout_s
     for _step in range(cfg.max_steps):
         if budget["spent"] >= cfg.max_usd:
             halted = "budget_cap"
+            break
+        if _time.monotonic() > _deadline:  # one instance must not stall the batch
+            halted = "instance_timeout"
             break
         near_end = _step >= cfg.max_steps - 3
         schema = _SUBMIT_SCHEMA if near_end else schema_all


### PR DESCRIPTION
Full run stalled ~30min on one instance (600s HTTP timeout, hung connection). Lower _OPENAI_TIMEOUT 600->180 (env OPENAI_HTTP_TIMEOUT) + add SweConfig.instance_timeout_s (600s default) wall-clock guard in run_instance so one hang can't stall the batch (timeout->instance errors->batch continues). 23 tests pass.