### PR TITLE
fix(bench): cut empty-patch rate (fuzzy SEARCH match + re-feed on miss)

### DIFF
--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -279,8 +279,9 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
         # 1) submit_patch -> apply SEARCH/REPLACE blocks
         edits = _submit_edits(out)
         if edits is not None:
-            fails = []
+            fails, tried = [], []
             for path, search, replace in _parse_blocks(edits):
+                tried.append(path)
                 res = tools.edit_file(path, search, replace)
                 if isinstance(res, dict) and res.get("ok"):
                     applied += 1
@@ -289,10 +290,19 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
             history.append({"role": "assistant", "content": (say or "") + "\n(submitted patch)"})
             if applied and not fails:
                 break
+            # On a miss, RE-FEED the current file content so the next attempt copies the exact
+            # text (the #1 empty-patch cause is a SEARCH block whose whitespace didn't match).
+            ctx = []
+            for pth in list(dict.fromkeys(tried))[:2]:
+                r = tools.read_file(pth)
+                if isinstance(r, dict) and r.get("content"):
+                    ctx.append(f"--- {pth} (current — copy SEARCH text from here) ---\n"
+                               + r["content"][:_TOOL_RESULT_CAP])
             history.append({"role": "user", "content": (
-                "No edits applied — SEARCH text must match the file EXACTLY. "
-                + ("Failures:\n" + "\n".join(fails) if fails else "No valid blocks found.")
-                + "\nResend ALL needed blocks via submit_patch.")})
+                ("Some edits did not apply:\n" + "\n".join(fails) if fails
+                 else "No valid edit blocks found.")
+                + "\nResend ALL needed blocks via submit_patch; SEARCH must match the file below "
+                "character-for-character.\n\n" + "\n\n".join(ctx))})
             continue
 
         # 2) read/grep/list -> serve; fold result back as TEXT; store FULL in engine (off keeps tail)

--- a/bench/swe_tools.py
+++ b/bench/swe_tools.py
@@ -71,10 +71,21 @@ class RepoTools:
         if p is None or not p.is_file():
             return {"error": f"no file {path}"}
         src = p.read_text(encoding="utf-8", errors="replace")
-        if old not in src:
-            return {"error": f"old string not found in {path}"}
-        p.write_text(src.replace(old, new, 1), encoding="utf-8")
-        return {"ok": True, "path": path}
+        # 1) exact match
+        if old in src:
+            p.write_text(src.replace(old, new, 1), encoding="utf-8")
+            return {"ok": True, "path": path}
+        # 2) whitespace-tolerant UNIQUE line-block match — models misremember exact
+        # indentation/trailing space; locate the real span and apply the model's `new`
+        # (which it usually indents correctly). Unique-only, so no wrong-place edits.
+        m = _match_block_lines(src, old)
+        if m is not None:
+            i, length = m
+            lines = src.split("\n")
+            out = lines[:i] + new.split("\n") + lines[i + length:]
+            p.write_text("\n".join(out), encoding="utf-8")
+            return {"ok": True, "path": path, "fuzzy": True}
+        return {"error": f"old string not found in {path}"}
 
     def current_patch(self) -> str:
         """Unified diff of the working tree vs HEAD (the base commit) = model_patch."""
@@ -119,6 +130,26 @@ class RepoTools:
         if name == "edit_file":
             return self.edit_file(args.get("path", ""), args.get("old", ""), args.get("new", ""))
         return {"error": f"unknown tool {name}"}
+
+
+def _match_block_lines(src: str, old: str) -> "tuple[int, int] | None":
+    """Find `old` as a contiguous block of lines in `src`, tolerating whitespace the model
+    got wrong. Returns (start_line_index, length) only when the match is UNIQUE (so we never
+    edit the wrong place); None otherwise. Tries rstrip (trailing ws) then strip (indentation)."""
+    old_lines = old.strip("\n").split("\n")
+    if not old_lines or not old.strip():
+        return None
+    src_lines = src.split("\n")
+    n = len(old_lines)
+    if n > len(src_lines):
+        return None
+    for norm in (lambda s: s.rstrip(), lambda s: s.strip()):
+        o = [norm(x) for x in old_lines]
+        sl = [norm(x) for x in src_lines]
+        hits = [i for i in range(len(sl) - n + 1) if sl[i:i + n] == o]
+        if len(hits) == 1:
+            return (hits[0], n)
+    return None
 
 
 def prepare_checkout(repo_url: str, base_commit: str, workdir: Path) -> Path:

--- a/tests/test_swe_tools.py
+++ b/tests/test_swe_tools.py
@@ -69,6 +69,33 @@ def test_edit_missing_oldstring_is_error(repo):
     assert "error" in r
 
 
+def test_edit_fuzzy_trailing_whitespace(repo):
+    # SEARCH has trailing spaces the file doesn't — should still apply (fuzzy, unique).
+    t = RepoTools(repo)
+    r = t.edit_file("a.py", "    return x - y  # bug   ", "    return x + y")
+    assert r.get("ok") and r.get("fuzzy")
+    assert "+    return x + y" in t.current_patch()
+
+
+def test_edit_fuzzy_indentation(repo):
+    # SEARCH over-indented vs a col-0 line (pkg/b.py = "VALUE = 1") — not a substring, so
+    # exact fails; strip-match locates it uniquely and applies the model's `new`.
+    t = RepoTools(repo)
+    r = t.edit_file("pkg/b.py", "    VALUE = 1", "VALUE = 2")
+    assert r.get("ok") and r.get("fuzzy")
+    assert "+VALUE = 2" in t.current_patch()
+
+
+def test_edit_ambiguous_does_not_apply(repo):
+    # Two identical lines -> not unique -> refuse (no wrong-place edit).
+    (repo / "dup.py").write_text("x = 1\nx = 1\n", encoding="utf-8")
+    _git(["add", "-A"], repo)
+    _git(["commit", "-qm", "dup"], repo)
+    t = RepoTools(repo)
+    r = t.edit_file("dup.py", "x = 1 ", "x = 2")  # trailing-space variant, 2 matches
+    assert "error" in r
+
+
 def test_grep_survives_non_utf8_bytes(repo):
     # A real repo contains non-UTF8 bytes; git grep -I skips binary, but text decode of
     # any stray bytes must not crash the tool (errors="replace").


### PR DESCRIPTION
Top tuning lever from N180: codepro 27% empty patches (each = guaranteed 0). #1 cause = SEARCH block whitespace not matching exactly. Fixes: (1) edit_file falls back to a whitespace-tolerant UNIQUE line-block match (rstrip then strip), applying the model's correctly-indented new to the real span — unique-only so never edits the wrong place; (2) on a failed submit, re-feed the current file content so the retry copies exact text. 26 tests pass (incl fuzzy trailing-ws / indentation / ambiguous-refuse).