### PR TITLE
feat(bench): complexity-gated propose↔critique reasoning escalation

### DIFF
--- a/bench/swe_debate.py
+++ b/bench/swe_debate.py
@@ -39,7 +39,7 @@ def classify_complexity(problem: str, files_seen: int = 0) -> str:
     return "medium"
 
 
-from bench.swe_eval import _parse_blocks  # safe: swe_eval imports swe_debate only lazily
+from bench.swe_parse import _parse_blocks  # shared parser module (no swe_eval import)
 
 _PROPOSE_SYS = (
     "You are the PROPOSER. Produce a minimal fix as SEARCH/REPLACE edit blocks, EXACTLY:\n"
@@ -88,13 +88,17 @@ def debate_patch(chat: Any, tools: Any, ground_fn: Callable[[str], str], problem
         # this candidate's SEARCH blocks (which always quote the ORIGINAL file) apply cleanly,
         # and current_patch() reflects ONLY the latest candidate (the best attempt so far).
         subprocess.run(["git", "checkout", "-q", "--", "."], cwd=tools.root,
-                       capture_output=True)
+                       capture_output=True, check=True)
         applied_here = 0
         for path, search, replace in _parse_blocks(out.get("content") or ""):
             res = tools.edit_file(path, search, replace)
             if isinstance(res, dict) and res.get("ok"):
                 applied_here += 1
                 applied_total += 1
+        if applied_here == 0:
+            focus = problem + "\n\nYour previous output had no applicable edit blocks. " \
+                    "Resend valid SEARCH/REPLACE blocks."
+            continue
         patch = tools.current_patch()
         crit_msgs = [{"role": "system", "content": _CRITIQUE_SYS},
                      {"role": "user", "content": f"CRITIQUE this fix for:\n{problem}\n\nProposed patch:\n{patch}"}]

--- a/bench/swe_debate.py
+++ b/bench/swe_debate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from typing import Any, Callable, Optional
 
 # Words that mark a genuinely hard instance — the kind a flat agent drops.
@@ -36,3 +37,73 @@ def classify_complexity(problem: str, files_seen: int = 0) -> str:
     if len(p) <= _LIGHT_LEN and _LIGHT_RE.search(p) and files_seen <= 1:
         return "light"
     return "medium"
+
+
+from bench.swe_eval import _parse_blocks  # safe: swe_eval imports swe_debate only lazily
+
+_PROPOSE_SYS = (
+    "You are the PROPOSER. Produce a minimal fix as SEARCH/REPLACE edit blocks, EXACTLY:\n"
+    "<path>\n<<<<<<< SEARCH\n<exact current lines>\n=======\n<replacement>\n>>>>>>> REPLACE\n"
+    "Output ONLY the blocks. Use the grounded context to get SEARCH text right.")
+_CRITIQUE_SYS = (
+    "You are the CRITIC. Attack the proposed fix: does it address the FAILING behaviour? "
+    "Wrong file/location? Missed edge case? Will the repo's tests still fail? "
+    "Reply JSON ONLY: {\"accept\": true|false, \"objections\": [\"...\"]}. Accept only if the "
+    "fix is correct and complete.")
+
+
+def _parse_verdict(text: str) -> dict:
+    """Tolerant parse of the critic's JSON verdict; unparseable => reject (keep iterating)."""
+    m = re.search(r"\{.*\}", text or "", re.S)
+    if m:
+        try:
+            d = json.loads(m.group(0))
+            return {"accept": bool(d.get("accept")), "objections": list(d.get("objections") or [])}
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+    return {"accept": False, "objections": ["unparseable verdict"]}
+
+
+def debate_patch(chat: Any, tools: Any, ground_fn: Callable[[str], str], problem: str, *,
+                 rounds: int = 2, max_output_tokens: int = 4096,
+                 account: Optional[Callable[[dict], bool]] = None) -> dict:
+    """Propose↔critique loop. The proposer drafts SEARCH/REPLACE edits (grounded per round on
+    the current focus); the critic accepts/rejects with objections; on reject the proposer
+    revises against them and re-grounds. Applies the latest candidate via tools.edit_file each
+    round (so current_patch() reflects the best attempt). Returns
+    {accepted, applied, rounds_used}. account(out) (optional) tallies cost; if it returns
+    False (cost spike) the loop stops."""
+    focus = problem
+    applied_total = 0
+    accepted = False
+    used = 0
+    for used in range(1, rounds + 1):
+        ground = ground_fn(focus) or ""
+        prop_msgs = [{"role": "system", "content": _PROPOSE_SYS},
+                     {"role": "user", "content": f"Problem:\n{problem}\n\nContext:\n{ground}\n\nPropose the fix."}]
+        out = chat.chat(prop_msgs, tools=None, max_tokens=max_output_tokens)
+        if account is not None and not account(out):
+            break
+        # Each round is a fresh attempt from the base tree: discard the prior round's edits so
+        # this candidate's SEARCH blocks (which always quote the ORIGINAL file) apply cleanly,
+        # and current_patch() reflects ONLY the latest candidate (the best attempt so far).
+        subprocess.run(["git", "checkout", "-q", "--", "."], cwd=tools.root,
+                       capture_output=True)
+        applied_here = 0
+        for path, search, replace in _parse_blocks(out.get("content") or ""):
+            res = tools.edit_file(path, search, replace)
+            if isinstance(res, dict) and res.get("ok"):
+                applied_here += 1
+                applied_total += 1
+        patch = tools.current_patch()
+        crit_msgs = [{"role": "system", "content": _CRITIQUE_SYS},
+                     {"role": "user", "content": f"CRITIQUE this fix for:\n{problem}\n\nProposed patch:\n{patch}"}]
+        out = chat.chat(crit_msgs, tools=None, max_tokens=max_output_tokens)
+        if account is not None and not account(out):
+            break
+        verdict = _parse_verdict(out.get("content") or "")
+        if verdict["accept"] and applied_here:
+            accepted = True
+            break
+        focus = problem + "\n\nFix these objections: " + "; ".join(verdict["objections"])
+    return {"accepted": accepted, "applied": applied_total, "rounds_used": used}

--- a/bench/swe_debate.py
+++ b/bench/swe_debate.py
@@ -1,0 +1,38 @@
+# bench/swe_debate.py
+"""Complexity-gated propose↔critique reasoning escalation for the SWE-bench agent.
+
+classify_complexity: cheap, deterministic gate (keywords + length). debate_patch: a
+propose↔critique loop that drafts a fix, has a critic attack it, revises against the
+objections (re-grounding each round), and applies the best candidate. Both reusable +
+unit-testable with a mock chat; no live API required.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Callable, Optional
+
+# Words that mark a genuinely hard instance — the kind a flat agent drops.
+_HEAVY_RE = re.compile(
+    r"\b(security|vulnerab|exploit|race condition|deadlock|concurren|"
+    r"intermittent|edge case|regression|segfault|corrupt|workaround|"
+    r"thread.?safe|memory leak|undefined behaviou?r)\b", re.I)
+_HEAVY_LEN = 600   # problem statements this long (chars) are treated as heavy
+_LIGHT_LEN = 120   # short + no hard keyword => light
+
+# A "light" task is short AND obviously trivial (cosmetic). Length alone isn't enough —
+# a short functional change ("update the parser...") is medium, not light.
+_LIGHT_RE = re.compile(
+    r"\b(typo|docstring|comment|rename|whitespace|spelling|lint|formatting|import order)\b", re.I)
+
+
+def classify_complexity(problem: str, files_seen: int = 0) -> str:
+    """Return 'light' | 'medium' | 'heavy'. Deterministic: hard keyword or a long/broad
+    statement => heavy; short AND trivially-cosmetic => light; otherwise medium. `files_seen`
+    (distinct files touched during investigation) nudges toward heavy when many are involved."""
+    p = problem or ""
+    if _HEAVY_RE.search(p) or len(p) >= _HEAVY_LEN or files_seen >= 4:
+        return "heavy"
+    if len(p) <= _LIGHT_LEN and _LIGHT_RE.search(p) and files_seen <= 1:
+        return "light"
+    return "medium"

--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -456,6 +456,9 @@ def _build_config(argv: Optional[list[str]] = None) -> SweConfig:
     p.add_argument("--recall-k", type=int, default=8)
     p.add_argument("--atlas-ground", action="store_true",
                    help="codepro arm: inject VPS5-atlas API facts (needs AETHER-CLOUD on VPS2)")
+    p.add_argument("--debate", action="store_true",
+                   help="codepro_debate arm: gate heavy instances into a propose↔critique loop")
+    p.add_argument("--debate-rounds", type=int, default=2)
     p.add_argument("--max-output-tokens", type=int, default=4096,
                    help="cap per-call output tokens (avoids 402 on low-credit keys + cuts cost)")
     p.add_argument("--max-usd", type=float, default=25.0)
@@ -467,6 +470,7 @@ def _build_config(argv: Optional[list[str]] = None) -> SweConfig:
         instances=a.instances, window=a.window, max_steps=a.max_steps, pool_gb=a.pool_gb,
         turbovec_bits=a.turbovec_bits, mpo_chain=a.mpo_chain, recall_k=a.recall_k,
         atlas_ground=a.atlas_ground, max_output_tokens=a.max_output_tokens,
+        debate=a.debate, debate_rounds=a.debate_rounds,
         max_usd=a.max_usd, dry_run=a.dry_run, out_dir=Path(a.out),
         work_dir=Path(a.out) / "checkouts")
 

--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -43,6 +43,8 @@ class SweConfig:
     instance_timeout_s: float = 600.0   # per-instance wall-clock guard (a hung call can't stall the batch)
     atlas_ground: bool = False    # codepro arm: also inject VPS5-atlas API facts (needs AETHER-CLOUD on VPS2)
     max_output_tokens: int = 4096  # cap per-call output; unset => provider defaults to 65k => 402 on a low-credit key + needless cost
+    debate: bool = False          # codepro_debate arm: gate hard instances into propose↔critique
+    debate_rounds: int = 2        # max propose↔critique rounds on a heavy instance
     dry_run: bool = False
     out_dir: Path = field(default_factory=lambda: Path("runs/swe_eval"))
     work_dir: Path = field(default_factory=lambda: Path("runs/swe_eval/checkouts"))
@@ -201,7 +203,7 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
 
     session: Optional[Session] = None
     encoder = StaticEncoder(dim=256)
-    if arm == "codepro":
+    if arm in ("codepro", "codepro_debate"):
         session = Session("swe", pool_gb=cfg.pool_gb,
                           pool_dir=cfg.out_dir / f"pool_{inst['instance_id']}_{arm}",
                           context_window=cfg.window, mpo_chain=cfg.mpo_chain,
@@ -333,6 +335,21 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
             break
         history.append({"role": "user", "content": _PATCH_INSTRUCTION})
 
+    # ── Complexity gate: heavy + codepro_debate -> propose↔critique escalation ──
+    complexity = None
+    if arm == "codepro_debate" and cfg.debate:
+        from bench import swe_debate as _dbg  # lazy import (no circular dependency)
+        complexity = _dbg.classify_complexity(inst["problem_statement"], len(tools._read))
+        if complexity == "heavy" and not tools.current_patch().strip() and budget["spent"] < cfg.max_usd:
+            def _ground(q: str) -> str:
+                if session is None:
+                    return ""
+                qv = encoder.encode(q)
+                hits = session._cold_retrieve(session._key(), qv, cfg.recall_k)
+                return "\n".join(f"[mem] {s.text}" for s in hits)
+            _dbg.debate_patch(chat, tools, _ground, inst["problem_statement"],
+                              rounds=cfg.debate_rounds, max_output_tokens=cfg.max_output_tokens,
+                              account=_account)
     patch = tools.current_patch()
     if session is not None:
         session.close()
@@ -347,6 +364,7 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
         "redundant_tool_calls": tools.redundant,
         "patch_nonempty": bool(patch.strip()),
         "halted": halted,
+        "complexity": complexity,
     }
 
 

--- a/bench/swe_eval.py
+++ b/bench/swe_eval.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 from aether_context.encoder import StaticEncoder
 from aether_context.session import Session
 from bench.api_eval import cached_tokens, cost_usd
+from bench.swe_parse import _parse_blocks  # noqa: F401  (re-exported; tests import from here)
 from bench.swe_tools import RepoTools, prepare_checkout
 
 DEFAULT_MODEL = "deepseek/deepseek-v4-pro"
@@ -132,23 +133,6 @@ def _submit_edits(out: dict) -> Optional[str]:
                 return None
     return None
 
-# Aider-style SEARCH/REPLACE block. dsv4-pro will not write a line-numbered unified diff from
-# memory (it just keeps trying to re-read), but it can reproduce an exact snippet + replacement.
-# Applying via edit_file makes the off-vs-codepro gap a function of whether the model REMEMBERS
-# the exact code: off (truncated transcript) misremembers -> SEARCH miss; codepro recalls it.
-_BLOCK_RE = re.compile(
-    r"(?P<path>[^\n<>=]+?)\n<{5,7} SEARCH\n(?P<search>.*?)\n={5,7}\n(?P<replace>.*?)\n>{5,7} REPLACE",
-    re.S)
-
-
-def _parse_blocks(text: str) -> list[tuple[str, str, str]]:
-    """Extract (path, search, replace) edit blocks from the model's patch-turn text."""
-    if not text:
-        return []
-    return [(m.group("path").strip().strip("`").strip(),
-             m.group("search"), m.group("replace")) for m in _BLOCK_RE.finditer(text)]
-
-
 def _atlas_facts(problem: str, k: int = 8) -> str:
     """Query the VPS5 atlas oracle (signed) for API/library facts relevant to `problem` and
     render a grounding block, or '' on any failure. Reuses AETHER-CLOUD's signed client +
@@ -179,7 +163,7 @@ def _atlas_facts(problem: str, k: int = 8) -> str:
 def _empty_record(arm: str, inst: dict, halted: str) -> dict:
     return {
         "instance_id": inst["instance_id"],
-        "model_name_or_path": MODEL_NAME if arm == "codepro" else f"{MODEL_NAME}-off",
+        "model_name_or_path": MODEL_NAME if arm in ("codepro", "codepro_debate") else f"{MODEL_NAME}-off",
         "model_patch": "", "arm": arm, "cost_usd": 0.0, "cached_tokens": 0,
         "tool_calls": 0, "redundant_tool_calls": 0, "patch_nonempty": False,
         "halted": halted,
@@ -355,7 +339,7 @@ def run_instance(arm: str, inst: dict, cfg: SweConfig, chat, budget: dict,
         session.close()
     return {
         "instance_id": inst["instance_id"],
-        "model_name_or_path": MODEL_NAME if arm == "codepro" else f"{MODEL_NAME}-off",
+        "model_name_or_path": MODEL_NAME if arm in ("codepro", "codepro_debate") else f"{MODEL_NAME}-off",
         "model_patch": patch,
         "arm": arm,
         "cost_usd": round(cost, 6),

--- a/bench/swe_parse.py
+++ b/bench/swe_parse.py
@@ -1,0 +1,27 @@
+# bench/swe_parse.py
+"""Shared SEARCH/REPLACE block parsing for the SWE-bench agent.
+
+Both swe_eval (the agent loop) and swe_debate (the propose↔critique escalation) need to
+extract Aider-style SEARCH/REPLACE edit blocks from model text. Keeping the regex + parser
+here (rather than in swe_eval) avoids the circular-import fragility of swe_debate importing
+from swe_eval while swe_eval lazily imports swe_debate.
+"""
+from __future__ import annotations
+
+import re
+
+# Aider-style SEARCH/REPLACE block. dsv4-pro will not write a line-numbered unified diff from
+# memory (it just keeps trying to re-read), but it can reproduce an exact snippet + replacement.
+# Applying via edit_file makes the off-vs-codepro gap a function of whether the model REMEMBERS
+# the exact code: off (truncated transcript) misremembers -> SEARCH miss; codepro recalls it.
+_BLOCK_RE = re.compile(
+    r"(?P<path>[^\n<>=]+?)\n<{5,7} SEARCH\n(?P<search>.*?)\n={5,7}\n(?P<replace>.*?)\n>{5,7} REPLACE",
+    re.S)
+
+
+def _parse_blocks(text: str) -> list[tuple[str, str, str]]:
+    """Extract (path, search, replace) edit blocks from the model's patch-turn text."""
+    if not text:
+        return []
+    return [(m.group("path").strip().strip("`").strip(),
+             m.group("search"), m.group("replace")) for m in _BLOCK_RE.finditer(text)]

--- a/docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md
+++ b/docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md
@@ -37,3 +37,13 @@
 - $25 hard cap shared across arms+instances; halts clean + resumes (re-run same command).
 - codepro arm uses the LOCAL engine (no VPS5 atlas oracle) -> Docker CPU/disk only.
 - pool floor is 5 GB (engine guard); --pool-gb below 5 is rejected.
+
+## Reasoning escalation (codepro_debate)
+
+    # 3-arm comparison; heavy instances escalate into propose↔critique
+    python -m bench.swe_eval --instances 0 --arms off,codepro,codepro_debate \
+      --debate --debate-rounds 2 --max-output-tokens 4096 --max-usd 35 --out runs/debate
+
+Score all three arms (VPS5) as usual. Headline metric: resolved-rate on the **heavy** subset
+(`complexity == "heavy"` in predictions) — codepro_debate vs codepro. Also track escalation rate
+(% heavy) and extra $/heavy instance.

--- a/docs/superpowers/plans/2026-06-25-codepro-reasoning-escalation.md
+++ b/docs/superpowers/plans/2026-06-25-codepro-reasoning-escalation.md
@@ -1,0 +1,488 @@
+# Complexity-Gated Propose↔Critique Reasoning Escalation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On hard SWE-bench instances, escalate the agent from its flat read→submit loop into a propose↔critique debate (grounded by the engine, win locked into memory) to lift resolved-rate beyond ~2×.
+
+**Architecture:** New `bench/swe_debate.py` holds a pure complexity gate + a propose↔critique loop. `bench/swe_eval.py` gets a flag-gated `codepro_debate` arm: investigate as today, classify the instance, and on `heavy` produce the patch via the debate (else the normal flat submit). Flag-off ⇒ byte-identical to current codepro.
+
+**Tech Stack:** Python stdlib + the existing bench (`swe_eval`, `swe_tools`, `aether_context.Session`). Same OpenAI-compat `chat(messages, tools, max_tokens)` adapter. No new deps. Dry-run testable with mock chat.
+
+**Branch:** `feat/reasoning-escalation`.
+
+**Reused symbols (do NOT redefine):**
+- `bench/swe_eval.py`: `_parse_blocks(text) -> list[(path,search,replace)]`, `SweConfig`, `run_instance`, `_make_live_chat`.
+- `bench/swe_tools.py`: `RepoTools.edit_file(path,old,new) -> dict` (whitespace-tolerant), `.current_patch() -> str`, `.read_file(path)`, `._read` (set of read paths).
+- Chat contract: `chat.chat(messages, tools=None, *, max_tokens=None) -> {"content","tool_calls","usage"}`.
+
+**Import discipline (avoid circular import):** `swe_debate.py` may `from bench.swe_eval import _parse_blocks` at top. `swe_eval.py` imports `swe_debate` **lazily inside `run_instance`** (function-level), never at module top.
+
+---
+
+## Task 1: complexity gate
+
+**Files:**
+- Create: `bench/swe_debate.py`
+- Test: `tests/test_swe_debate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_swe_debate.py
+from bench.swe_debate import classify_complexity
+
+
+def test_heavy_on_hard_keywords():
+    assert classify_complexity("There is a security vulnerability in the auth check") == "heavy"
+    assert classify_complexity("intermittent race condition causes a deadlock") == "heavy"
+
+
+def test_heavy_on_long_problem():
+    assert classify_complexity("x " * 400) == "heavy"  # very long statement
+
+
+def test_light_on_short_simple():
+    assert classify_complexity("Fix typo in the docstring of add()") == "light"
+
+
+def test_medium_default():
+    assert classify_complexity("Update the parser to handle empty input lists") == "medium"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/test_swe_debate.py -o addopts="" -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'bench.swe_debate'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# bench/swe_debate.py
+"""Complexity-gated propose↔critique reasoning escalation for the SWE-bench agent.
+
+classify_complexity: cheap, deterministic gate (keywords + length). debate_patch: a
+propose↔critique loop that drafts a fix, has a critic attack it, revises against the
+objections (re-grounding each round), and applies the best candidate. Both reusable +
+unit-testable with a mock chat; no live API required.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Callable, Optional
+
+# Words that mark a genuinely hard instance — the kind a flat agent drops.
+_HEAVY_RE = re.compile(
+    r"\b(security|vulnerab|exploit|race condition|deadlock|concurren|"
+    r"intermittent|edge case|regression|segfault|corrupt|workaround|"
+    r"thread.?safe|memory leak|undefined behaviou?r)\b", re.I)
+_HEAVY_LEN = 600   # problem statements this long (chars) are treated as heavy
+_LIGHT_LEN = 120   # short + no hard keyword => light
+
+
+def classify_complexity(problem: str, files_seen: int = 0) -> str:
+    """Return 'light' | 'medium' | 'heavy'. Deterministic: hard keyword or a long/broad
+    statement => heavy; short + simple => light; otherwise medium. `files_seen` (distinct
+    files touched during investigation) nudges toward heavy when many are involved."""
+    p = problem or ""
+    if _HEAVY_RE.search(p) or len(p) >= _HEAVY_LEN or files_seen >= 4:
+        return "heavy"
+    if len(p) <= _LIGHT_LEN and files_seen <= 1:
+        return "light"
+    return "medium"
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_debate.py -o addopts="" -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_debate.py tests/test_swe_debate.py
+git commit -m "feat(bench): complexity gate (classify_complexity) for reasoning escalation"
+```
+
+---
+
+## Task 2: propose↔critique debate loop
+
+**Files:**
+- Modify: `bench/swe_debate.py`
+- Test: `tests/test_swe_debate.py`
+
+- [ ] **Step 1: Add failing tests**
+
+```python
+# append to tests/test_swe_debate.py
+import json
+import subprocess
+from bench.swe_debate import debate_patch, _parse_verdict
+
+
+def test_parse_verdict_tolerant():
+    assert _parse_verdict('{"accept": true, "objections": []}')["accept"] is True
+    v = _parse_verdict('junk {"accept": false, "objections": ["wrong file"]} tail')
+    assert v["accept"] is False and v["objections"] == ["wrong file"]
+    assert _parse_verdict("not json")["accept"] is False  # unparseable -> reject (keep iterating)
+
+
+def _repo(tmp_path):
+    d = tmp_path / "r"; d.mkdir()
+    for a in (["init","-q"],["config","user.email","t@t"],["config","user.name","t"]):
+        subprocess.run(["git",*a], cwd=d, check=True, capture_output=True)
+    (d/"a.py").write_text("def add(x, y):\n    return x - y  # bug\n", encoding="utf-8")
+    subprocess.run(["git","add","-A"], cwd=d, check=True, capture_output=True)
+    subprocess.run(["git","commit","-qm","b"], cwd=d, check=True, capture_output=True)
+    return d
+
+
+_SR_BAD = ("a.py\n<<<<<<< SEARCH\n    return x - y  # bug\n=======\n    return x * y\n>>>>>>> REPLACE\n")
+_SR_GOOD = ("a.py\n<<<<<<< SEARCH\n    return x - y  # bug\n=======\n    return x + y\n>>>>>>> REPLACE\n")
+
+
+class _DebateChat:
+    """propose#1 -> bad fix; critic#1 -> reject; propose#2 -> good fix; critic#2 -> accept.
+    Distinguishes propose vs critique by a marker in the last user message."""
+    def __init__(self):
+        self.props = 0
+    def chat(self, messages, tools=None, *, max_tokens=None):
+        u = messages[-1]["content"]
+        usage = {"prompt_tokens": 20, "completion_tokens": 10}
+        if "CRITIQUE" in u:
+            ok = "return x + y" in u  # the proposed patch text is echoed into the critique prompt
+            verdict = {"accept": bool(ok), "objections": [] if ok else ["wrong operator"]}
+            return {"content": json.dumps(verdict), "usage": usage, "tool_calls": []}
+        self.props += 1
+        return {"content": _SR_BAD if self.props == 1 else _SR_GOOD, "usage": usage, "tool_calls": []}
+
+
+def test_debate_revises_until_accept_and_applies(tmp_path):
+    from bench.swe_tools import RepoTools
+    t = RepoTools(_repo(tmp_path))
+    r = debate_patch(_DebateChat(), t, ground_fn=lambda q: "", problem="fix add",
+                     rounds=3, max_output_tokens=512)
+    assert r["accepted"] is True
+    assert r["applied"] >= 1
+    assert "+    return x + y" in t.current_patch()
+
+
+def test_debate_round_cap_submits_best(tmp_path):
+    from bench.swe_tools import RepoTools
+    class _AlwaysReject(_DebateChat):
+        def chat(self, messages, tools=None, *, max_tokens=None):
+            u = messages[-1]["content"]; usage = {"prompt_tokens":20,"completion_tokens":10}
+            if "CRITIQUE" in u:
+                return {"content": json.dumps({"accept": False, "objections": ["nope"]}),
+                        "usage": usage, "tool_calls": []}
+            return {"content": _SR_GOOD, "usage": usage, "tool_calls": []}
+    t = RepoTools(_repo(tmp_path))
+    r = debate_patch(_AlwaysReject(), t, ground_fn=lambda q: "", problem="fix add", rounds=2)
+    assert r["accepted"] is False
+    assert r["applied"] >= 1  # best candidate still applied
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_debate.py -k "verdict or debate" -o addopts="" -q`
+Expected: FAIL — `ImportError: cannot import name 'debate_patch'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `bench/swe_debate.py`:
+
+```python
+from bench.swe_eval import _parse_blocks  # safe: swe_eval imports swe_debate only lazily
+
+_PROPOSE_SYS = (
+    "You are the PROPOSER. Produce a minimal fix as SEARCH/REPLACE edit blocks, EXACTLY:\n"
+    "<path>\n<<<<<<< SEARCH\n<exact current lines>\n=======\n<replacement>\n>>>>>>> REPLACE\n"
+    "Output ONLY the blocks. Use the grounded context to get SEARCH text right.")
+_CRITIQUE_SYS = (
+    "You are the CRITIC. Attack the proposed fix: does it address the FAILING behaviour? "
+    "Wrong file/location? Missed edge case? Will the repo's tests still fail? "
+    "Reply JSON ONLY: {\"accept\": true|false, \"objections\": [\"...\"]}. Accept only if the "
+    "fix is correct and complete.")
+
+
+def _parse_verdict(text: str) -> dict:
+    """Tolerant parse of the critic's JSON verdict; unparseable => reject (keep iterating)."""
+    m = re.search(r"\{.*\}", text or "", re.S)
+    if m:
+        try:
+            d = json.loads(m.group(0))
+            return {"accept": bool(d.get("accept")), "objections": list(d.get("objections") or [])}
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+    return {"accept": False, "objections": ["unparseable verdict"]}
+
+
+def debate_patch(chat: Any, tools: Any, ground_fn: Callable[[str], str], problem: str, *,
+                 rounds: int = 2, max_output_tokens: int = 4096,
+                 account: Optional[Callable[[dict], bool]] = None) -> dict:
+    """Propose↔critique loop. The proposer drafts SEARCH/REPLACE edits (grounded per round on
+    the current focus); the critic accepts/rejects with objections; on reject the proposer
+    revises against them and re-grounds. Applies the latest candidate via tools.edit_file each
+    round (so current_patch() reflects the best attempt). Returns
+    {accepted, applied, rounds_used}. `account(out)` (optional) tallies cost; if it returns
+    False (cost spike) the loop stops."""
+    focus = problem
+    applied_total = 0
+    accepted = False
+    used = 0
+    for used in range(1, rounds + 1):
+        ground = ground_fn(focus) or ""
+        prop_msgs = [{"role": "system", "content": _PROPOSE_SYS},
+                     {"role": "user", "content": f"Problem:\n{problem}\n\nContext:\n{ground}\n\nPropose the fix."}]
+        out = chat.chat(prop_msgs, tools=None, max_tokens=max_output_tokens)
+        if account is not None and not account(out):
+            break
+        applied_here = 0
+        for path, search, replace in _parse_blocks(out.get("content") or ""):
+            res = tools.edit_file(path, search, replace)
+            if isinstance(res, dict) and res.get("ok"):
+                applied_here += 1
+                applied_total += 1
+        patch = tools.current_patch()
+        crit_msgs = [{"role": "system", "content": _CRITIQUE_SYS},
+                     {"role": "user", "content": f"CRITIQUE this fix for:\n{problem}\n\nProposed patch:\n{patch}"}]
+        out = chat.chat(crit_msgs, tools=None, max_tokens=max_output_tokens)
+        if account is not None and not account(out):
+            break
+        verdict = _parse_verdict(out.get("content") or "")
+        if verdict["accept"] and applied_here:
+            accepted = True
+            break
+        focus = problem + "\n\nFix these objections: " + "; ".join(verdict["objections"])
+    return {"accepted": accepted, "applied": applied_total, "rounds_used": used}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_debate.py -o addopts="" -q`
+Expected: PASS (all swe_debate tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_debate.py tests/test_swe_debate.py
+git commit -m "feat(bench): propose↔critique debate loop (per-round ground, apply best candidate)"
+```
+
+---
+
+## Task 3: wire the `codepro_debate` arm into swe_eval
+
+**Files:**
+- Modify: `bench/swe_eval.py` (SweConfig ~line 44; session build ~line 204; gate replaces `patch = tools.current_patch()` ~line 336; return dict)
+- Test: `tests/test_swe_eval.py`
+
+- [ ] **Step 1: Add failing test**
+
+```python
+# append to tests/test_swe_eval.py
+def test_codepro_debate_heavy_routes_to_debate(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr("bench.swe_debate.classify_complexity", lambda *a, **k: "heavy")
+    def _fake_debate(chat, tools, ground_fn, problem, **kw):
+        tools.edit_file("a.py", "    return x - y  # bug", "    return x + y")
+        return {"accepted": True, "applied": 1, "rounds_used": 1}
+    monkeypatch.setattr("bench.swe_debate.debate_patch", _fake_debate)
+    cfg = SweConfig(dry_run=True, arms=("codepro_debate",), out_dir=tmp_path/"o",
+                    work_dir=tmp_path/"w", pool_gb=5, debate=True)
+    rec = run_instance("codepro_debate", _inst(repo), cfg, _SRChat(), {"spent":0.0},
+                       repo_url=f"file://{repo.as_posix()}")
+    assert rec["arm"] == "codepro_debate"
+    assert rec["patch_nonempty"] is True
+    assert rec.get("complexity") == "heavy"
+    assert "+    return x + y" in rec["model_patch"]
+
+
+def test_codepro_debate_flag_off_no_debate(tmp_path):
+    # debate=False -> codepro_debate behaves like plain codepro (no debate call), no crash
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, arms=("codepro_debate",), out_dir=tmp_path/"o2",
+                    work_dir=tmp_path/"w2", pool_gb=5, debate=False)
+    rec = run_instance("codepro_debate", _inst(repo), cfg, _SRChat(), {"spent":0.0},
+                       repo_url=f"file://{repo.as_posix()}")
+    assert rec["arm"] == "codepro_debate"
+    assert rec.get("complexity") is None  # gate not run when debate flag off
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_eval.py -k codepro_debate -o addopts="" -q`
+Expected: FAIL — `TypeError: SweConfig.__init__() got an unexpected keyword argument 'debate'`.
+
+- [ ] **Step 3: Implement — SweConfig flags**
+
+In `bench/swe_eval.py`, after the `max_output_tokens` field add:
+
+```python
+    debate: bool = False          # codepro_debate arm: gate hard instances into propose↔critique
+    debate_rounds: int = 2        # max propose↔critique rounds on a heavy instance
+```
+
+- [ ] **Step 4: Implement — build the engine for the debate arm**
+
+Change the session-build condition (line ~204) from `if arm == "codepro":` to:
+
+```python
+    if arm in ("codepro", "codepro_debate"):
+```
+
+- [ ] **Step 5: Implement — gate + debate**
+
+Replace the single line `patch = tools.current_patch()` (line ~336, just before the return dict) with:
+
+```python
+    # ── Complexity gate: heavy + codepro_debate -> propose↔critique escalation ──
+    complexity = None
+    if arm == "codepro_debate" and cfg.debate:
+        from bench import swe_debate as _dbg  # lazy import (no circular dependency)
+        complexity = _dbg.classify_complexity(inst["problem_statement"], len(tools._read))
+        if complexity == "heavy" and not tools.current_patch().strip() and budget["spent"] < cfg.max_usd:
+            def _ground(q: str) -> str:
+                if session is None:
+                    return ""
+                qv = encoder.encode(q)
+                hits = session._cold_retrieve(session._key(), qv, cfg.recall_k)
+                return "\n".join(f"[mem] {s.text}" for s in hits)
+            _dbg.debate_patch(chat, tools, _ground, inst["problem_statement"],
+                              rounds=cfg.debate_rounds, max_output_tokens=cfg.max_output_tokens,
+                              account=_account)
+    patch = tools.current_patch()
+```
+
+- [ ] **Step 6: Implement — record complexity**
+
+In the `run_instance` return dict (the `return { "instance_id": ... }` block), add this key after `"halted": halted,`:
+
+```python
+        "complexity": complexity,
+```
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_eval.py -o addopts="" -q`
+Expected: PASS (all, incl new codepro_debate tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bench/swe_eval.py tests/test_swe_eval.py
+git commit -m "feat(bench): codepro_debate arm — gate heavy instances into the debate (flag-gated)"
+```
+
+---
+
+## Task 4: CLI flags + arm
+
+**Files:**
+- Modify: `bench/swe_eval.py` (`_build_config`)
+- Test: `tests/test_swe_eval.py`
+
+- [ ] **Step 1: Add failing test**
+
+```python
+# append to tests/test_swe_eval.py
+def test_cli_debate_flags():
+    cfg = _build_config(["--arms","codepro_debate","--debate","--debate-rounds","3","--dry-run"])
+    assert cfg.arms == ("codepro_debate",)
+    assert cfg.debate is True
+    assert cfg.debate_rounds == 3
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `python -m pytest tests/test_swe_eval.py -k cli_debate -o addopts="" -q`
+Expected: FAIL — argparse rejects `--debate`.
+
+- [ ] **Step 3: Implement**
+
+In `_build_config`, after the `--atlas-ground` argument add:
+
+```python
+    p.add_argument("--debate", action="store_true",
+                   help="codepro_debate arm: gate heavy instances into a propose↔critique loop")
+    p.add_argument("--debate-rounds", type=int, default=2)
+```
+
+And in the returned `SweConfig(...)`, add (alongside `atlas_ground=a.atlas_ground,`):
+
+```python
+        debate=a.debate, debate_rounds=a.debate_rounds,
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python -m pytest tests/test_swe_eval.py -o addopts="" -q`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bench/swe_eval.py tests/test_swe_eval.py
+git commit -m "feat(bench): --debate / --debate-rounds CLI for codepro_debate"
+```
+
+---
+
+## Task 5: full gate + runbook note
+
+**Files:**
+- Modify: `docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md`
+
+- [ ] **Step 1: Whole suite green**
+
+Run: `python -m pytest tests/test_swe_debate.py tests/test_swe_eval.py tests/test_swe_tools.py tests/test_swe_scoring.py -o addopts="" -q`
+Expected: PASS (all).
+
+- [ ] **Step 2: Dry-run the new arm end to end (no API)**
+
+Run: `python -m bench.swe_eval --dry-run --arms codepro_debate --debate`
+Expected: prints a summary JSON, no traceback (synthetic instances; checkout-error records are fine).
+
+- [ ] **Step 3: Append runbook section**
+
+Add to `docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md`:
+
+```markdown
+## Reasoning escalation (codepro_debate)
+
+    # 3-arm comparison; heavy instances escalate into propose↔critique
+    python -m bench.swe_eval --instances 0 --arms off,codepro,codepro_debate \
+      --debate --debate-rounds 2 --max-output-tokens 4096 --max-usd 35 --out runs/debate
+
+Score all three arms (VPS5) as usual. Headline metric: resolved-rate on the **heavy** subset
+(`complexity == "heavy"` in predictions) — codepro_debate vs codepro. Also track escalation rate
+(% heavy) and extra $/heavy instance.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/benchmarks/2026-06-23-swe-codepro/RUNBOOK.md
+git commit -m "docs(bench): runbook — codepro_debate 3-arm run + heavy-subset metric"
+```
+
+---
+
+## Self-Review (spec coverage)
+
+- Complexity gate (Arbiter light/medium/heavy parity): Task 1. ✓
+- Propose↔critique debate, per-round grounding, apply best candidate, round cap: Task 2. ✓
+- MPO-lock: debate runs against the live `Session` (built for codepro_debate); read results were
+  already `session.remember`'d during the flat investigation, and `_ground` recalls them →
+  within-run compounding. (Explicit post-resolve win-record is a follow-on; not needed for v1.) ✓
+- `codepro_debate` arm + flag-off byte-identical: Task 3 (gated on `arm=="codepro_debate" and
+  cfg.debate`; the session-build change is inert for other arms; `complexity` is None when off). ✓
+- CLI + record `complexity` for the heavy-subset metric: Tasks 3, 4. ✓
+- Dry-run + unit tests, no live API: Tasks 1–5. ✓
+- GLM-5.2 / atlas write-back OUT of scope: not in any task. ✓
+
+**Type consistency:** `classify_complexity(problem, files_seen=0)->str`;
+`debate_patch(chat,tools,ground_fn,problem,*,rounds,max_output_tokens,account)->{accepted,applied,rounds_used}`;
+`_parse_verdict(text)->{accept,objections}`; SweConfig `debate`/`debate_rounds`; record key
+`complexity`. Consistent across tasks.

--- a/docs/superpowers/specs/2026-06-25-codepro-reasoning-escalation-design.md
+++ b/docs/superpowers/specs/2026-06-25-codepro-reasoning-escalation-design.md
@@ -1,0 +1,120 @@
+# Complexity-Gated Propose↔Critique Reasoning Escalation — Design
+
+**Date:** 2026-06-25 · **Repo:** Unlimited-Context (harness/engine) · **Status:** approved direction, pre-plan
+
+## Goal
+
+Lift SWE-bench resolved-rate beyond the measured ~2× (codepro 27 vs off 14 @ N=180) by making the
+agent **think harder only when it needs to**. Today the bench agent is a flat read→grep→submit
+loop with no escalation — it drops exactly the hard instances (vulns, workarounds, multi-file
+fixes) where both `off` and current `codepro` fail. Add a **complexity gate** that, on hard
+instances, escalates into a **propose↔critique debate** grounded by OpenMythos and locked into the
+MPO chain so the win compounds.
+
+Two wins, by design:
+- **Time:** easy/medium instances stay on the cheap flat loop; only *heavy* ones pay the debate cost.
+- **Solve:** the debate cracks hard instances a standard agent abandons.
+
+## Mental-model correction (grounding this design)
+
+From reading the live systems:
+- **Serena** (`lib/serena_intake.py`) = intake/clarity gate. **Arbiter** (`lib/orchestrator/core/arbiter.py`)
+  = pre-synthesis judge that already carries a `complexity_label: light|medium|heavy` + risk flags
+  and escalates (sonnet→opus). The "two sides arguing" = Serena (proposer/intake) vs Arbiter
+  (critic/judge) inside the orchestrator.
+- **OpenMythos** (`lib.orchestrator.atlas.openmythos`) is **retrieval, not reasoning** — single-pass
+  dual-retrieve `ground()`. It *feeds* a reasoner; it isn't one.
+- The bench agent uses **neither** today. This design brings the Serena/Arbiter *pattern* (propose
+  vs critique) into the agent loop, with OpenMythos as the per-round grounding, and the MPO chain as
+  the memory that compounds wins.
+
+## Scope
+
+**This spec (one implementation plan):** complexity gate + propose↔critique debate + per-round
+OpenMythos grounding + MPO-lock of wins + a `codepro_debate` bench arm + measurement on the heavy
+subset.
+
+**Follow-on (separate specs, noted not built here):**
+- **GLM-5.2 weight-tune:** host GLM-5.2 (open/hostable) on the VPS; LoRA on engine+debate traces
+  (recall → escalate → correct-patch) so the model natively escalates and exploits recall.
+- **Atlas write-back:** on a resolve, record the winning fix/pattern into the VPS5 atlas →
+  cross-run compounding (next session/problem easier), beyond the within-run MPO lock.
+
+## Components & boundaries
+
+New file **`bench/swe_debate.py`** (keeps `swe_eval.py` lean; one clear purpose):
+
+1. **`classify_complexity(problem, signals) -> "light"|"medium"|"heavy"`**
+   Cheap classifier. Heuristic first (problem-statement length; keywords: "security/vuln/race/
+   deadlock/edge case/regression/intermittent/fails when"; # candidate files surfaced during the
+   first K investigation steps), with an optional single LLM self-assessment for ambiguous cases.
+   Mirrors Arbiter's light/medium/heavy. Threshold tunable; default: escalate on `heavy` only.
+
+2. **`debate_patch(chat, tools, ground_fn, problem, *, rounds, max_tokens) -> (patch, trace)`**
+   The propose↔critique loop (both roles = the agent model; GLM-5.2 later):
+   - **Propose (Serena-role):** draft a SEARCH/REPLACE fix + 1-line rationale, given the
+     OpenMythos-grounded context for the current focus.
+   - **Critique (Arbiter-role):** attack it — "does this fix the *failing behavior*? wrong
+     location? missed edge case? breaks tests?" → `{accept|reject, objections[]}`.
+   - **Revise:** on reject, proposer revises against objections; `ground_fn` re-grounds on the
+     objection focus (ties in iterative retrieve). Loop ≤ `rounds` (default 2). Stop on accept or
+     exhaustion → return best candidate (apply via the empty-patch-hardened `edit_file`).
+
+3. **Per-round OpenMythos grounding** — `ground_fn(query)` calls `openmythos.ground(query=...)`
+   with the round's focus (the critic's objection / proposer's gap), not just the static problem.
+   `ground()` already takes `query`; the only change is calling it per round with a focused query.
+
+4. **MPO-lock the win** — on convergence/resolve, `session.remember()` the
+   (problem → winning fix + key reasoning) so later instances in the run recall it (within-run
+   compounding). Cross-run = atlas write-back (follow-on).
+
+5. **`swe_eval` wiring** — new arm `codepro_debate` (or `--debate` on codepro): build the engine as
+   today; in `run_instance`, after a short investigation, call `classify_complexity`; if `heavy`,
+   route to `debate_patch`; else flat loop (byte-identical to current codepro). Flag-gated → off =
+   identical behavior.
+
+## Data flow
+
+```
+instance → flat investigate (K steps, populate engine + signals)
+        → classify_complexity
+            light/medium → flat submit  (cheap, unchanged)
+            heavy        → debate_patch:
+                             propose (grounded) → critique → [reject → reground+revise]* → submit
+        → on resolve: session.remember(win)   # MPO lock, compounds within run
+```
+
+## Measurement
+
+Bench arms: `off`, `codepro`, **`codepro_debate`**. Same instances. Report:
+- Overall resolved-rate codepro vs codepro_debate.
+- **Heavy-subset** resolve delta (where the lever must bite — the headline for this feature).
+- Debate cost (extra $/heavy instance) + escalation rate (% classified heavy) → the time/solve trade.
+- Empty-patch rate (should also fall — critique catches non-fixes).
+
+Success = codepro_debate > codepro on the heavy subset at acceptable extra cost, with overall
+resolved-rate up.
+
+## Testing
+
+- `classify_complexity` unit tests (keyword/length/file-count → label; ambiguous → escalate).
+- `debate_patch` dry-run with a scripted mock: proposer emits a bad patch → critic rejects with an
+  objection → proposer fixes → critic accepts → patch applied. Assert round cap, best-candidate
+  fallback on no-accept.
+- `swe_eval` flag-off path byte-identical (existing tests); `--debate` light path = flat loop.
+- No live API in unit tests (mock chat + stub ground_fn).
+
+## Risks
+
+- **Debate cost** — gated to heavy only; escalation-rate metric guards runaway spend; round cap.
+- **Critic false-accept / false-reject** — cap rounds, always submit best candidate; track
+  accept-but-unresolved to tune the critic prompt.
+- **Misclassification** — tunable threshold; default conservative (escalate only clear-heavy) to
+  protect cost; can flip to escalate-on-ambiguous if heavy-subset wins justify it.
+- **Blocked on credit** — like all live runs, needs the OpenRouter top-up; build + dry-run now,
+  measure after.
+
+## Out of scope (here)
+
+GLM-5.2 hosting/LoRA; atlas write-back ingest; cross-run compounding; multi-model (separate
+proposer/critic models) — all follow-on specs once this measures positive.

--- a/tests/test_swe_debate.py
+++ b/tests/test_swe_debate.py
@@ -16,3 +16,68 @@ def test_light_on_short_simple():
 
 def test_medium_default():
     assert classify_complexity("Update the parser to handle empty input lists") == "medium"
+
+
+import json
+import subprocess
+from bench.swe_debate import debate_patch, _parse_verdict
+
+
+def test_parse_verdict_tolerant():
+    assert _parse_verdict('{"accept": true, "objections": []}')["accept"] is True
+    v = _parse_verdict('junk {"accept": false, "objections": ["wrong file"]} tail')
+    assert v["accept"] is False and v["objections"] == ["wrong file"]
+    assert _parse_verdict("not json")["accept"] is False
+
+
+def _repo(tmp_path):
+    d = tmp_path / "r"; d.mkdir()
+    for a in (["init","-q"],["config","user.email","t@t"],["config","user.name","t"]):
+        subprocess.run(["git",*a], cwd=d, check=True, capture_output=True)
+    (d/"a.py").write_text("def add(x, y):\n    return x - y  # bug\n", encoding="utf-8")
+    subprocess.run(["git","add","-A"], cwd=d, check=True, capture_output=True)
+    subprocess.run(["git","commit","-qm","b"], cwd=d, check=True, capture_output=True)
+    return d
+
+
+_SR_BAD = ("a.py\n<<<<<<< SEARCH\n    return x - y  # bug\n=======\n    return x * y\n>>>>>>> REPLACE\n")
+_SR_GOOD = ("a.py\n<<<<<<< SEARCH\n    return x - y  # bug\n=======\n    return x + y\n>>>>>>> REPLACE\n")
+
+
+class _DebateChat:
+    def __init__(self):
+        self.props = 0
+    def chat(self, messages, tools=None, *, max_tokens=None):
+        u = messages[-1]["content"]
+        usage = {"prompt_tokens": 20, "completion_tokens": 10}
+        if "CRITIQUE" in u:
+            ok = "return x + y" in u
+            verdict = {"accept": bool(ok), "objections": [] if ok else ["wrong operator"]}
+            return {"content": json.dumps(verdict), "usage": usage, "tool_calls": []}
+        self.props += 1
+        return {"content": _SR_BAD if self.props == 1 else _SR_GOOD, "usage": usage, "tool_calls": []}
+
+
+def test_debate_revises_until_accept_and_applies(tmp_path):
+    from bench.swe_tools import RepoTools
+    t = RepoTools(_repo(tmp_path))
+    r = debate_patch(_DebateChat(), t, ground_fn=lambda q: "", problem="fix add",
+                     rounds=3, max_output_tokens=512)
+    assert r["accepted"] is True
+    assert r["applied"] >= 1
+    assert "+    return x + y" in t.current_patch()
+
+
+def test_debate_round_cap_submits_best(tmp_path):
+    from bench.swe_tools import RepoTools
+    class _AlwaysReject(_DebateChat):
+        def chat(self, messages, tools=None, *, max_tokens=None):
+            u = messages[-1]["content"]; usage = {"prompt_tokens":20,"completion_tokens":10}
+            if "CRITIQUE" in u:
+                return {"content": json.dumps({"accept": False, "objections": ["nope"]}),
+                        "usage": usage, "tool_calls": []}
+            return {"content": _SR_GOOD, "usage": usage, "tool_calls": []}
+    t = RepoTools(_repo(tmp_path))
+    r = debate_patch(_AlwaysReject(), t, ground_fn=lambda q: "", problem="fix add", rounds=2)
+    assert r["accepted"] is False
+    assert r["applied"] >= 1

--- a/tests/test_swe_debate.py
+++ b/tests/test_swe_debate.py
@@ -1,0 +1,18 @@
+from bench.swe_debate import classify_complexity
+
+
+def test_heavy_on_hard_keywords():
+    assert classify_complexity("There is a security vulnerability in the auth check") == "heavy"
+    assert classify_complexity("intermittent race condition causes a deadlock") == "heavy"
+
+
+def test_heavy_on_long_problem():
+    assert classify_complexity("x " * 400) == "heavy"
+
+
+def test_light_on_short_simple():
+    assert classify_complexity("Fix typo in the docstring of add()") == "light"
+
+
+def test_medium_default():
+    assert classify_complexity("Update the parser to handle empty input lists") == "medium"

--- a/tests/test_swe_eval.py
+++ b/tests/test_swe_eval.py
@@ -204,6 +204,15 @@ def test_codepro_debate_flag_off_no_debate(tmp_path):
     assert rec.get("complexity") is None
 
 
+def test_codepro_debate_model_name_not_off(tmp_path):
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, arms=("codepro_debate",), out_dir=tmp_path/"mn",
+                    work_dir=tmp_path/"mw", pool_gb=5, debate=False)
+    rec = run_instance("codepro_debate", _inst(repo), cfg, _SRChat(), {"spent":0.0},
+                       repo_url=f"file://{repo.as_posix()}")
+    assert not rec["model_name_or_path"].endswith("-off")
+
+
 def test_cli_debate_flags():
     cfg = _build_config(["--arms","codepro_debate","--debate","--debate-rounds","3","--dry-run"])
     assert cfg.arms == ("codepro_debate",)

--- a/tests/test_swe_eval.py
+++ b/tests/test_swe_eval.py
@@ -175,3 +175,30 @@ def test_cli_flags_map_to_config():
     assert cfg.mpo_chain is False
     assert cfg.max_usd == 25.0 and cfg.window == 4096 and cfg.max_steps == 12
     assert cfg.dry_run is True
+
+
+def test_codepro_debate_heavy_routes_to_debate(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr("bench.swe_debate.classify_complexity", lambda *a, **k: "heavy")
+    def _fake_debate(chat, tools, ground_fn, problem, **kw):
+        tools.edit_file("a.py", "    return x - y  # bug", "    return x + y")
+        return {"accepted": True, "applied": 1, "rounds_used": 1}
+    monkeypatch.setattr("bench.swe_debate.debate_patch", _fake_debate)
+    cfg = SweConfig(dry_run=True, arms=("codepro_debate",), out_dir=tmp_path/"o",
+                    work_dir=tmp_path/"w", pool_gb=5, debate=True)
+    rec = run_instance("codepro_debate", _inst(repo), cfg, _SRChat(), {"spent":0.0},
+                       repo_url=f"file://{repo.as_posix()}")
+    assert rec["arm"] == "codepro_debate"
+    assert rec["patch_nonempty"] is True
+    assert rec.get("complexity") == "heavy"
+    assert "+    return x + y" in rec["model_patch"]
+
+
+def test_codepro_debate_flag_off_no_debate(tmp_path):
+    repo = _make_repo(tmp_path)
+    cfg = SweConfig(dry_run=True, arms=("codepro_debate",), out_dir=tmp_path/"o2",
+                    work_dir=tmp_path/"w2", pool_gb=5, debate=False)
+    rec = run_instance("codepro_debate", _inst(repo), cfg, _SRChat(), {"spent":0.0},
+                       repo_url=f"file://{repo.as_posix()}")
+    assert rec["arm"] == "codepro_debate"
+    assert rec.get("complexity") is None

--- a/tests/test_swe_eval.py
+++ b/tests/test_swe_eval.py
@@ -202,3 +202,10 @@ def test_codepro_debate_flag_off_no_debate(tmp_path):
                        repo_url=f"file://{repo.as_posix()}")
     assert rec["arm"] == "codepro_debate"
     assert rec.get("complexity") is None
+
+
+def test_cli_debate_flags():
+    cfg = _build_config(["--arms","codepro_debate","--debate","--debate-rounds","3","--dry-run"])
+    assert cfg.arms == ("codepro_debate",)
+    assert cfg.debate is True
+    assert cfg.debate_rounds == 3


### PR DESCRIPTION
## Summary
The next lever to push SWE-bench resolved-rate past ~2×: make the agent **think harder only when it needs to**. Today the bench agent is a flat read→submit loop that drops hard instances (vulns/workarounds/multi-file). This adds a complexity gate that, on **heavy** instances, escalates into a **propose↔critique debate** grounded by the engine and locked into MPO recall.

## What's in
- `bench/swe_debate.py` — `classify_complexity` (light/medium/heavy gate, deterministic) + `debate_patch` (propose↔critique loop: proposer drafts SEARCH/REPLACE, critic attacks, revise+re-ground on reject, per-round clean-tree reset, round cap, apply best candidate).
- `bench/swe_parse.py` — extracted `_parse_blocks`/`_BLOCK_RE` (shared by swe_eval + swe_debate; removes circular-import risk).
- `bench/swe_eval.py` — new `codepro_debate` arm (flag-gated `--debate`/`--debate-rounds`); on heavy + no patch yet, runs the debate grounded by session recall; records `complexity` per prediction. **Flag-off ⇒ byte-identical to codepro.**
- Spec + plan under `docs/superpowers/`; runbook 3-arm section.

## Tests
37 pass (gate, debate loop incl revise-until-accept + round-cap-submits-best, wiring heavy-routes + flag-off, CLI, parse). Dry-run clean, no live API. Reviewed: scoring-attribution bug (debate arm was stamped `-off`) fixed; circular import de-risked; empty-proposal critique skipped; `check=True` on git reset.

## Out of scope (follow-on specs)
GLM-5.2 host + LoRA on engine+debate traces; atlas write-back (cross-run compounding). Live runs blocked on OpenRouter credit top-up.

## Measure (after top-up)
3-arm run off / codepro / codepro_debate; headline = resolved-rate on the **heavy** subset (`complexity=="heavy"`), + escalation rate + extra $/heavy.