### PR TITLE
feat: add scoped durable memory management

### DIFF
--- a/aether_context/__init__.py
+++ b/aether_context/__init__.py
@@ -18,12 +18,14 @@ deterministic model (offline, zero deps) — great for trying the API, tests, an
 
 Public surface (intentionally tiny):
   * :class:`Session` — the lifecycle controller you drive.
+  * :class:`MemoryRecord` / :class:`MemoryPage` - vector-free memory management DTOs.
   * :func:`load_model` — resolve a model spec / bring-your-own backend to a ``LocalLLM``.
   * :data:`__version__` — the package version.
 """
+from aether_context.context_pool import MemoryPage, MemoryRecord
 from aether_context.local_llm import load_model
 from aether_context.session import Session
 
 __version__ = "0.1.0"
 
-__all__ = ["Session", "load_model", "__version__"]
+__all__ = ["Session", "MemoryRecord", "MemoryPage", "load_model", "__version__"]

--- a/aether_context/context_pool.py
+++ b/aether_context/context_pool.py
@@ -34,11 +34,16 @@ requires the optional ``hnswlib`` to have been present when the pool was written
 """
 from __future__ import annotations
 
+import base64
+import copy
 import json
 import math
 import os
+import threading
 import warnings
+from datetime import datetime, timezone
 from dataclasses import dataclass, field
+from functools import wraps
 from pathlib import Path
 from typing import Any
 
@@ -46,7 +51,14 @@ import numpy as np
 
 from aether_context._log import get_logger
 from aether_context.config import PoolConfig, TOKENS_PER_GB
-from aether_context.errors import PoolBudgetError, PoolCorrupt
+from aether_context.errors import (
+    AetherContextError,
+    MemoryConflict,
+    MemoryCursorError,
+    MemoryNotFound,
+    PoolBudgetError,
+    PoolCorrupt,
+)
 from aether_context.quantize import dequantize, packed_bytes_per_row, quantize
 from aether_context.witness import Witness
 
@@ -60,6 +72,15 @@ try:  # pragma: no cover - import availability is environment-dependent
 except ImportError:  # pragma: no cover - the common CI path (flat fallback)
     _hnswlib = None
     _HNSWLIB_AVAILABLE = False
+
+_MEMORY_VERSION_KEY = "_version"
+_MEMORY_CREATED_KEY = "_created_at"
+_MEMORY_UPDATED_KEY = "_updated_at"
+_MEMORY_STORAGE_META = frozenset(
+    {_MEMORY_VERSION_KEY, _MEMORY_CREATED_KEY, _MEMORY_UPDATED_KEY}
+)
+_MEMORY_PRIVATE_META = _MEMORY_STORAGE_META | {"_ct"}
+_MAX_MEMORY_PAGE = 200
 
 # --- persistence constants ---------------------------------------------------
 #: On-disk format version for the sidecar/header. Bump on any layout change.
@@ -121,6 +142,54 @@ class Slice:
     tokens: int
     meta: dict[str, Any] = field(default_factory=dict)
     score: float = 0.0
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    """Vector-free snapshot of one session-owned durable memory."""
+
+    id: str
+    text: str
+    tokens: int
+    meta: dict[str, Any]
+    score: float
+    version: int
+    created_at: str | None
+    updated_at: str | None
+
+
+@dataclass(frozen=True)
+class MemoryPage:
+    """Bounded page of vector-free memories for one session."""
+
+    items: tuple[MemoryRecord, ...]
+    next_cursor: str | None
+    total: int
+
+
+def _utc_now() -> str:
+    """Current UTC time in a stable, JSON-safe representation."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _synchronized(method: Any) -> Any:
+    """Run a ContextPool method under its single re-entrant state lock."""
+
+    @wraps(method)
+    def wrapped(self: "ContextPool", *args: Any, **kwargs: Any) -> Any:
+        with self._lock:
+            return method(self, *args, **kwargs)
+
+    return wrapped
+
+
+def _memory_version(sl: Slice) -> int:
+    """Read an optimistic version, treating pre-versioning records as version 1."""
+    try:
+        version = int(sl.meta.get(_MEMORY_VERSION_KEY, 1))
+    except (TypeError, ValueError):
+        return 1
+    return max(1, version)
 
 
 class _FlatIndex:
@@ -248,6 +317,7 @@ class ContextPool:
     """
 
     def __init__(self, config: PoolConfig, *, ceiling_bytes: int | None = None) -> None:
+        self._lock = threading.RLock()
         self._config = config
         self._dim = config.dim
         # TurboVec: 0 = float32 (default; this whole class is byte-identical to before). >0 stores
@@ -340,19 +410,23 @@ class ContextPool:
 
     # -- introspection ---------------------------------------------------------
     @property
+    @_synchronized
     def index_kind(self) -> str:
         """The resolved index kind actually in use (``"flat"`` or ``"hnsw"``)."""
         return self._index.kind
 
     @property
+    @_synchronized
     def ceiling_bytes(self) -> int:
         """The byte ceiling the governor holds the pool at or below."""
         return self._ceiling_bytes
 
+    @_synchronized
     def __len__(self) -> int:
         return len(self._slices)
 
     # -- write -----------------------------------------------------------------
+    @_synchronized
     def add(self, sl: Slice) -> None:
         """Store ``sl`` (overwriting any slice with the same id), then enforce the budget.
 
@@ -378,13 +452,28 @@ class ContextPool:
         stored_vec = self._unit(vec)
         assert self._mmap is not None
         self._write_row(row, sl.id, stored_vec)
+        existing = self._slices.get(sl.id)
+        meta = copy.deepcopy(sl.meta)
+        fallback_version = _memory_version(existing) if existing is not None else 1
+        try:
+            version = int(meta.get(_MEMORY_VERSION_KEY, fallback_version))
+        except (TypeError, ValueError):
+            version = fallback_version
+        meta[_MEMORY_VERSION_KEY] = max(1, version)
+        now = _utc_now()
+        if existing is not None:
+            created_at = existing.meta.get(_MEMORY_CREATED_KEY, now)
+        else:
+            created_at = now
+        meta.setdefault(_MEMORY_CREATED_KEY, created_at)
+        meta.setdefault(_MEMORY_UPDATED_KEY, meta[_MEMORY_CREATED_KEY])
         self._slices[sl.id] = Slice(
             id=sl.id,
             session=sl.session,
             vector=stored_vec.copy(),
             text=sl.text,
             tokens=int(sl.tokens),
-            meta=dict(sl.meta),
+            meta=meta,
             score=float(sl.score),
         )
         # Touch at the current write tick so the witness's temporal lock-in can protect this
@@ -395,6 +484,7 @@ class ContextPool:
         self.evict_to_budget()
 
     # -- read ------------------------------------------------------------------
+    @_synchronized
     def search(
         self, query_vec: np.ndarray, k: int, session: str | None = None,
         *, sources: set[str] | None = None,
@@ -424,12 +514,33 @@ class ContextPool:
             return self._search_global(query, k)
         return self._search_filtered(query, k, session, sources)
 
+    @staticmethod
+    def _retrieval_slice(sl: Slice) -> Slice:
+        """Return a detached retrieval snapshot without storage-owned metadata."""
+        return Slice(
+            id=sl.id,
+            session=sl.session,
+            vector=sl.vector.copy(),
+            text=sl.text,
+            tokens=int(sl.tokens),
+            meta={
+                key: copy.deepcopy(value)
+                for key, value in sl.meta.items()
+                if key not in _MEMORY_STORAGE_META
+            },
+            score=float(sl.score),
+        )
+
+
     def _search_global(self, query: np.ndarray, k: int) -> list[Slice]:
         """Unfiltered top-``k`` over every live slice (uses the resolved ANN index)."""
         matrix = self._live_matrix()
         self._refresh_index(matrix)
         pairs = self._index.search(matrix, query, k)
-        return [self._slices[self._order[row]] for row, _ in pairs]
+        return [
+            self._retrieval_slice(self._slices[self._order[row]])
+            for row, _ in pairs
+        ]
 
     def _search_filtered(
         self, query: np.ndarray, k: int, session: str | None, sources: set[str] | None,
@@ -457,9 +568,259 @@ class ContextPool:
         kk = min(k, len(rows))
         top = np.argpartition(-cosines, kk - 1)[:kk]
         top = top[np.argsort(-cosines[top], kind="stable")]
-        return [self._slices[self._order[rows[int(j)]]] for j in top]
+        return [
+            self._retrieval_slice(self._slices[self._order[rows[int(j)]]])
+            for j in top
+        ]
+
+    # -- scoped memory management ---------------------------------------------
+    def _memory_record(self, sl: Slice) -> MemoryRecord:
+        """Return a detached, vector-free public snapshot."""
+        public_meta = {
+            key: copy.deepcopy(value)
+            for key, value in sl.meta.items()
+            if key not in _MEMORY_PRIVATE_META
+        }
+        created_at = sl.meta.get(_MEMORY_CREATED_KEY)
+        updated_at = sl.meta.get(_MEMORY_UPDATED_KEY)
+        return MemoryRecord(
+            id=sl.id,
+            text=sl.text,
+            tokens=int(sl.tokens),
+            meta=public_meta,
+            score=float(sl.score),
+            version=_memory_version(sl),
+            created_at=str(created_at) if created_at is not None else None,
+            updated_at=str(updated_at) if updated_at is not None else None,
+        )
+
+    def _scoped_memory(self, session_id: str, memory_id: str) -> Slice:
+        """Resolve an id without revealing records from another namespace."""
+        sl = self._slices.get(memory_id)
+        if sl is None or sl.session != session_id:
+            raise MemoryNotFound(
+                f"Memory {memory_id!r} was not found in this session."
+            )
+        return sl
+
+    @staticmethod
+    def _check_expected_version(sl: Slice, expected_version: int) -> None:
+        """Enforce compare-and-swap semantics for one memory."""
+        actual = _memory_version(sl)
+        if (
+            isinstance(expected_version, bool)
+            or not isinstance(expected_version, int)
+            or expected_version < 1
+            or expected_version != actual
+        ):
+            raise MemoryConflict(
+                f"Memory version conflict: expected {expected_version!r}, current is {actual}."
+            )
+
+    @staticmethod
+    def _encode_memory_cursor(
+        session_id: str, memory_type: str | None, offset: int
+    ) -> str:
+        payload = json.dumps(
+            [session_id, memory_type, offset], separators=(",", ":"), ensure_ascii=False
+        ).encode("utf-8")
+        return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+    @staticmethod
+    def _decode_memory_cursor(
+        cursor: str, session_id: str, memory_type: str | None
+    ) -> int:
+        try:
+            if not isinstance(cursor, str) or not cursor:
+                raise ValueError("empty cursor")
+            padded = cursor + ("=" * (-len(cursor) % 4))
+            raw = base64.b64decode(
+                padded.encode("ascii"), altchars=b"-_", validate=True
+            )
+            payload = json.loads(raw.decode("utf-8"))
+            if (
+                not isinstance(payload, list)
+                or len(payload) != 3
+                or payload[0] != session_id
+                or payload[1] != memory_type
+                or isinstance(payload[2], bool)
+                or not isinstance(payload[2], int)
+                or payload[2] < 0
+            ):
+                raise ValueError("cursor scope or offset mismatch")
+            return payload[2]
+        except (UnicodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            raise MemoryCursorError("Invalid memory-page cursor.") from exc
+
+    @_synchronized
+    def memory_page(
+        self,
+        session_id: str,
+        *,
+        limit: int = 50,
+        cursor: str | None = None,
+        memory_type: str | None = None,
+    ) -> MemoryPage:
+        """Return a bounded, session-scoped page without vectors or namespace data."""
+        if (
+            isinstance(limit, bool)
+            or not isinstance(limit, int)
+            or not 1 <= limit <= _MAX_MEMORY_PAGE
+        ):
+            raise AetherContextError(
+                f"memory page limit must be between 1 and {_MAX_MEMORY_PAGE}, got {limit!r}.",
+                hint=f"Pass an integer limit in the range 1..{_MAX_MEMORY_PAGE}.",
+            )
+        matching = [
+            sid
+            for sid in self._order
+            if self._slices[sid].session == session_id
+            and (
+                memory_type is None
+                or self._slices[sid].meta.get("kind") == memory_type
+            )
+        ]
+        offset = (
+            self._decode_memory_cursor(cursor, session_id, memory_type)
+            if cursor is not None
+            else 0
+        )
+        if offset > len(matching):
+            raise MemoryCursorError(
+                "Memory-page cursor is stale after the scoped inventory changed."
+            )
+        end = min(offset + limit, len(matching))
+        items = tuple(
+            self._memory_record(self._slices[sid])
+            for sid in matching[offset:end]
+        )
+        next_cursor = (
+            self._encode_memory_cursor(session_id, memory_type, end)
+            if end < len(matching)
+            else None
+        )
+        return MemoryPage(items=items, next_cursor=next_cursor, total=len(matching))
+
+    @_synchronized
+    def memory_get(self, session_id: str, memory_id: str) -> MemoryRecord:
+        """Get one vector-free memory snapshot in ``session_id``."""
+        return self._memory_record(self._scoped_memory(session_id, memory_id))
+
+    @_synchronized
+    def memory_replace(
+        self,
+        session_id: str,
+        memory_id: str,
+        *,
+        text: str,
+        vector: np.ndarray,
+        tokens: int,
+        expected_version: int,
+        meta_patch: dict[str, Any] | None = None,
+        durable: bool = True,
+    ) -> MemoryRecord:
+        """Atomically replace text/vector when ``expected_version`` still matches."""
+        current = self._scoped_memory(session_id, memory_id)
+        self._check_expected_version(current, expected_version)
+        clean_text = text.strip() if isinstance(text, str) else ""
+        if not clean_text:
+            raise AetherContextError(
+                "Replacement memory text must be a non-empty string.",
+                hint="Pass non-whitespace text to memory_replace().",
+            )
+        if meta_patch is not None and not isinstance(meta_patch, dict):
+            raise AetherContextError(
+                "meta_patch must be a dictionary when provided.",
+                hint="Pass a JSON-serializable dict, or omit meta_patch.",
+            )
+        patch = meta_patch or {}
+        invalid_keys = [
+            key
+            for key in patch
+            if not isinstance(key, str) or key == "source" or key.startswith("_")
+        ]
+        if invalid_keys:
+            raise AetherContextError(
+                "meta_patch cannot change provenance or reserved metadata keys.",
+                hint="Patch application metadata only; source/version/timestamps are immutable.",
+            )
+        now = _utc_now()
+        meta = copy.deepcopy(current.meta)
+        meta.update(copy.deepcopy(patch))
+        meta[_MEMORY_VERSION_KEY] = _memory_version(current) + 1
+        meta.setdefault(_MEMORY_CREATED_KEY, now)
+        meta[_MEMORY_UPDATED_KEY] = now
+        updated = Slice(
+            id=current.id,
+            session=current.session,
+            vector=np.asarray(vector, dtype=np.float32),
+            text=clean_text,
+            tokens=int(tokens),
+            meta=meta,
+            score=float(current.score),
+        )
+        self.add(updated)
+        if durable:
+            self.flush()
+        return self._memory_record(self._slices[memory_id])
+
+    @_synchronized
+    def memory_delete(
+        self,
+        session_id: str,
+        memory_id: str,
+        *,
+        expected_version: int,
+        durable: bool = True,
+    ) -> MemoryRecord:
+        """Delete exactly one scoped memory using compare-and-swap semantics."""
+        current = self._scoped_memory(session_id, memory_id)
+        self._check_expected_version(current, expected_version)
+        deleted = self._memory_record(current)
+        old_count = len(self._order)
+        self._remove(memory_id)
+        self._compact_rows(old_count=old_count)
+        self._dirty = True
+        self._index_rebuild = True
+        if durable:
+            self.flush()
+        return deleted
+
+    @_synchronized
+    def memory_clear(
+        self,
+        session_id: str,
+        *,
+        expected_count: int,
+        durable: bool = True,
+    ) -> int:
+        """Clear one namespace only when its current count matches ``expected_count``."""
+        scoped_ids = [
+            sid for sid in self._order if self._slices[sid].session == session_id
+        ]
+        actual = len(scoped_ids)
+        if (
+            isinstance(expected_count, bool)
+            or not isinstance(expected_count, int)
+            or expected_count < 0
+            or expected_count != actual
+        ):
+            raise MemoryConflict(
+                f"Memory count conflict: expected {expected_count!r}, current is {actual}."
+            )
+        if scoped_ids:
+            old_count = len(self._order)
+            for sid in scoped_ids:
+                self._remove(sid)
+            self._compact_rows(old_count=old_count)
+            self._dirty = True
+            self._index_rebuild = True
+        if durable:
+            self.flush()
+        return actual
 
     # -- governor --------------------------------------------------------------
+    @_synchronized
     def evict_to_budget(self) -> list[str]:
         """Evict the lowest-retention slices until the pool fits under its byte ceiling.
 
@@ -480,10 +841,11 @@ class ContextPool:
         full_order = unranked + order
         n_evict = len(self._order) - max_slices
         evict_ids = full_order[:n_evict]
+        old_count = len(self._order)
         for sid in evict_ids:
             self._remove(sid)
         if evict_ids:
-            self._compact_rows()
+            self._compact_rows(old_count=old_count)
             self._dirty = True
             self._index_rebuild = True  # rows renumbered by compaction -> full graph rebuild
             logger.debug(
@@ -492,6 +854,7 @@ class ContextPool:
             )
         return evict_ids
 
+    @_synchronized
     def clear_session(self, session_id: str | None) -> int:
         """Remove every live slice belonging to ``session_id`` and return the count removed.
 
@@ -512,9 +875,10 @@ class ContextPool:
             ]
         if not removed:
             return 0
+        old_count = len(self._order)
         for sid in removed:
             self._remove(sid)
-        self._compact_rows()
+        self._compact_rows(old_count=old_count)
         self._dirty = True
         self._index_rebuild = True  # rows renumbered by compaction -> full graph rebuild
         logger.debug(
@@ -533,7 +897,7 @@ class ContextPool:
         except ValueError:
             pass
 
-    def _compact_rows(self) -> None:
+    def _compact_rows(self, *, old_count: int) -> None:
         """Re-pack live slices into contiguous rows ``[0..len)`` after eviction.
 
         Keeps the mmap dense so ``_live_matrix`` is a simple prefix slice and row indices
@@ -543,26 +907,31 @@ class ContextPool:
         if self._mmap is None:
             return
         n = len(self._order)
-        if n == 0:
+        if n:
+            packed = np.empty((n, self._mcols), dtype=self._mdtype)
+            for new_row, sid in enumerate(self._order):
+                v = self._slices[sid].vector
+                if self._qbits:
+                    codes, scale = quantize(v[None], self._qbits)
+                    packed[new_row] = codes[0]
+                    self._scale_of[sid] = float(scale[0])
+                else:
+                    packed[new_row] = v
+                self._row_of[sid] = new_row
+            self._mmap[:n] = packed
+        else:
             self._row_of = {}
-            return
-        packed = np.empty((n, self._mcols), dtype=self._mdtype)
-        for new_row, sid in enumerate(self._order):
-            v = self._slices[sid].vector
-            if self._qbits:
-                codes, scale = quantize(v[None], self._qbits)
-                packed[new_row] = codes[0]
-                self._scale_of[sid] = float(scale[0])
-            else:
-                packed[new_row] = v
-            self._row_of[sid] = new_row
-        self._mmap[:n] = packed
+        freed_end = min(max(old_count, n), self._capacity)
+        if freed_end > n:
+            self._mmap[n:freed_end] = 0
 
     # -- accounting ------------------------------------------------------------
+    @_synchronized
     def bytes_used(self) -> int:
         """Total bytes the live slices occupy, by the same accounting the governor uses."""
         return len(self._slices) * slice_cost_bytes(self._dim)
 
+    @_synchronized
     def stats(self) -> dict[str, Any]:
         """A small dict snapshot: count, bytes, ceiling, dim, index kind, sessions."""
         return {
@@ -577,6 +946,7 @@ class ContextPool:
         }
 
     # -- persistence -----------------------------------------------------------
+    @_synchronized
     def close(self) -> None:
         """Flush vectors + sidecar to disk and release the mmap. Idempotent.
 
@@ -589,18 +959,25 @@ class ContextPool:
 
     def __del__(self) -> None:  # pragma: no cover - best-effort flush on GC
         try:
-            self._flush()
-            self._release_mmap()
+            lock = getattr(self, "_lock", None)
+            if lock is None:
+                return
+            with lock:
+                self._flush()
+                self._release_mmap()
         except Exception:  # noqa: BLE001 - never raise from a finalizer
             pass
 
+    @_synchronized
+    def flush(self) -> None:
+        """Durably flush changed vector rows and the atomic metadata sidecar."""
+        self._flush()
+
     def _flush(self) -> None:
-        """Write the mmap and sidecar metadata if anything changed since the last flush."""
+        """Write and fsync the mmap and sidecar if state changed."""
         if not self._dirty:
             return
         self._dir.mkdir(parents=True, exist_ok=True)
-        if self._mmap is not None:
-            self._mmap.flush()
         records = [
             {
                 "id": sid,
@@ -625,8 +1002,35 @@ class ContextPool:
             "slices": records,
         }
         tmp = self._metadata_file().with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(header), encoding="utf-8")
-        os.replace(tmp, self._metadata_file())
+        try:
+            if self._mmap is not None:
+                self._mmap.flush()
+                with self._vectors_file().open("r+b", buffering=0) as vector_file:
+                    os.fsync(vector_file.fileno())
+            with tmp.open("w", encoding="utf-8", newline="") as metadata_file:
+                json.dump(
+                    header,
+                    metadata_file,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                metadata_file.flush()
+                os.fsync(metadata_file.fileno())
+            os.replace(tmp, self._metadata_file())
+            with self._metadata_file().open("r+b", buffering=0) as metadata_file:
+                os.fsync(metadata_file.fileno())
+            if os.name != "nt":
+                directory_fd = os.open(
+                    self._dir, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+                )
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+        except (OSError, TypeError, ValueError) as exc:
+            raise PoolCorrupt(
+                f"could not durably flush pool metadata at {self._metadata_file()}: {exc}"
+            ) from exc
         self._dirty = False
 
     def _load(self) -> None:
@@ -811,6 +1215,8 @@ class ContextPool:
 __all__ = [
     "ContextPool",
     "Slice",
+    "MemoryRecord",
+    "MemoryPage",
     "slice_cost_bytes",
     "POOL_FORMAT_VERSION",
     "VECTORS_FILENAME",

--- a/aether_context/errors.py
+++ b/aether_context/errors.py
@@ -82,6 +82,28 @@ class PoolCorrupt(AetherContextError):
     )
 
 
+class MemoryNotFound(AetherContextError):
+    """A memory id is absent from the caller's session namespace."""
+
+    default_hint = (
+        "Refresh the session memory page and retry with an id returned for this session."
+    )
+
+
+class MemoryConflict(AetherContextError):
+    """An optimistic memory mutation was based on stale state."""
+
+    default_hint = (
+        "Refresh the memory record (or page), then retry with its current version/count."
+    )
+
+
+class MemoryCursorError(AetherContextError):
+    """A memory-page cursor is malformed or belongs to a different scope/filter."""
+
+    default_hint = "Start a fresh memory-page request without a cursor."
+
+
 __all__ = [
     "AetherContextError",
     "PoolBudgetError",
@@ -90,4 +112,7 @@ __all__ = [
     "BackendUnavailable",
     "EncoderError",
     "PoolCorrupt",
+    "MemoryNotFound",
+    "MemoryConflict",
+    "MemoryCursorError",
 ]

--- a/aether_context/session.py
+++ b/aether_context/session.py
@@ -47,7 +47,13 @@ import numpy as np
 
 from aether_context._log import get_logger
 from aether_context.config import PoolConfig, SessionConfig, reach_tokens
-from aether_context.context_pool import ContextPool, Slice, slice_cost_bytes
+from aether_context.context_pool import (
+    ContextPool,
+    MemoryPage,
+    MemoryRecord,
+    Slice,
+    slice_cost_bytes,
+)
 from aether_context.encoder import StaticEncoder
 from aether_context.errors import (
     AetherContextError,
@@ -168,6 +174,7 @@ class Session:
         **cfg: Any,
     ) -> None:
         self.id: str = session_id or f"sess-{uuid.uuid4().hex[:12]}"
+        self._memory_lock = threading.RLock()
         self._closed: bool = False
         self._resident_k: int = max(1, int(resident_k))
         # Pool sharing discipline. "separate" (default) keeps every search/encode scoped to
@@ -321,6 +328,105 @@ class Session:
         """
         return None if self.pool_mode == "shared" else self.id
 
+    def _ensure_memory_open(self) -> None:
+        """Reject memory management after the owning session has closed."""
+        if self._closed:
+            raise AetherContextError(
+                "Memory management called on a closed Session.",
+                hint="Open a Session with the same session_id and pool_dir to manage its memories.",
+            )
+
+    def memory_page(
+        self,
+        *,
+        limit: int = 50,
+        cursor: str | None = None,
+        memory_type: str | None = None,
+    ) -> MemoryPage:
+        """List a bounded page of this session's vector-free durable memories."""
+        with self._memory_lock:
+            self._ensure_memory_open()
+            return self.pool.memory_page(
+                self.id,
+                limit=limit,
+                cursor=cursor,
+                memory_type=memory_type,
+            )
+
+    def memory_get(self, memory_id: str) -> MemoryRecord:
+        """Return one vector-free memory owned by this session."""
+        with self._memory_lock:
+            self._ensure_memory_open()
+            return self.pool.memory_get(self.id, memory_id)
+
+    def memory_replace(
+        self,
+        memory_id: str,
+        *,
+        text: str,
+        expected_version: int,
+        meta_patch: dict[str, Any] | None = None,
+        durable: bool = True,
+    ) -> MemoryRecord:
+        """Replace one memory using optimistic versioning and refresh its embedding."""
+        with self._memory_lock:
+            self._ensure_memory_open()
+            clean_text = text.strip() if isinstance(text, str) else ""
+            if not clean_text:
+                raise AetherContextError(
+                    "Replacement memory text must be a non-empty string.",
+                    hint="Pass non-whitespace text to memory_replace().",
+                )
+            vector = self.encoder.encode(clean_text)
+            record = self.pool.memory_replace(
+                self.id,
+                memory_id,
+                text=clean_text,
+                vector=np.asarray(vector, dtype=np.float32),
+                tokens=int(self._count_tokens(clean_text)),
+                expected_version=expected_version,
+                meta_patch=meta_patch,
+                durable=durable,
+            )
+            self.pager.reset()
+            return record
+
+    def memory_delete(
+        self,
+        memory_id: str,
+        *,
+        expected_version: int,
+        durable: bool = True,
+    ) -> MemoryRecord:
+        """Delete one memory using optimistic versioning."""
+        with self._memory_lock:
+            self._ensure_memory_open()
+            record = self.pool.memory_delete(
+                self.id,
+                memory_id,
+                expected_version=expected_version,
+                durable=durable,
+            )
+            self.pager.reset()
+            return record
+
+    def memory_clear(
+        self,
+        *,
+        expected_count: int,
+        durable: bool = True,
+    ) -> int:
+        """Atomically clear only this session's memories when the count still matches."""
+        with self._memory_lock:
+            self._ensure_memory_open()
+            removed = self.pool.memory_clear(
+                self.id,
+                expected_count=expected_count,
+                durable=durable,
+            )
+            self.pager.reset()
+            return removed
+
     def _cold_retrieve(self, key: SliceKey, query_vec: np.ndarray, k: int) -> list[Slice]:
         """Pager cold path honoring the session's pool mode (shared -> global search).
 
@@ -356,7 +462,7 @@ class Session:
 
     # -- plant / recover a fact -----------------------------------------------
     def remember(self, text: str, *, tags: dict[str, Any] | None = None,
-                 source: str = MEMORY_SOURCE_USER) -> Slice | None:
+                 source: str = MEMORY_SOURCE_USER, durable: bool = True) -> Slice | None:
         """Encode ``text`` as a high-salience slice into the pool (a load-bearing fact).
 
         This is how a durable constraint is established before a long run so it survives the
@@ -364,9 +470,29 @@ class Session:
         is tagged ``meta["source"]`` (default :data:`MEMORY_SOURCE_USER` — high authority) so a
         caller can later recall trusted memory only. Returns the stored :class:`Slice` (or
         ``None`` if encoding fails — fail-soft).
+
+        Caller tags cannot override provenance or storage-owned metadata. Explicit memories are
+        durably flushed by default; pass ``durable=False`` only when a later close/flush is
+        guaranteed.
         """
-        meta = {"source": source, **(tags or {})}
-        return self._encode_slice(text, salience=_REMEMBER_SALIENCE, tags=meta)
+        with self._memory_lock:
+            self._ensure_memory_open()
+            meta = {
+                key: value
+                for key, value in (tags or {}).items()
+                if isinstance(key, str) and not key.startswith("_") and key != "source"
+            }
+            meta["source"] = source
+            sl = self._encode_slice(text, salience=_REMEMBER_SALIENCE, tags=meta)
+            if sl is not None and durable:
+                try:
+                    self.pool.flush()
+                except AetherContextError as exc:
+                    logger.warning(
+                        "remember durable flush failed (%s); reporting the write as failed", exc
+                    )
+                    return None
+            return sl
 
     def recall(self, query: str, k: int = DEFAULT_RESIDENT_K, *,
                sources: set[str] | None = None) -> list[Slice]:
@@ -387,20 +513,22 @@ class Session:
             logger.warning("recall encode failed (%s); returning no local hits", exc)
             return []
         try:
-            scoped = self.pool.search(qvec, k, session=self._scope(), sources=sources)
-            if scoped:
-                return scoped
-            # Reopen case: a fresh Session over an existing pool dir has a new session id, so
-            # the prior run's slices live under a different namespace. Fall back to a global
-            # search so a disk-resident fact is still recoverable after a close + reopen.
-            # (In shared mode the scoped search is already global, so this is a harmless re-run.)
-            return self.pool.search(qvec, k, session=None, sources=sources)
+            return self.pool.search(qvec, k, session=self._scope(), sources=sources)
         except AetherContextError as exc:
             logger.warning("recall pool search failed (%s); returning no local hits", exc)
             return []
 
     # -- encode-on-spill ------------------------------------------------------
     def _encode_slice(
+        self, text: str, *, salience: float, tags: dict[str, Any]
+    ) -> Slice | None:
+        """Serialize id/sequence generation and writes through the session memory lock."""
+        with self._memory_lock:
+            return self._encode_slice_locked(
+                text, salience=salience, tags=tags
+            )
+
+    def _encode_slice_locked(
         self, text: str, *, salience: float, tags: dict[str, Any]
     ) -> Slice | None:
         """Encode ``text`` into a pool slice and add it (fail-soft).
@@ -418,7 +546,7 @@ class Session:
             logger.warning("encode-on-spill failed (%s); slice dropped, run continues", exc)
             return None
         self._spill_seq += 1
-        sid = f"{self.id}:slice:{self._spill_seq}"
+        sid = str(uuid.uuid4())
         tokens = self._count_tokens(text)
         score = self._salience(text, salience)
         # Chain coordinate component for this slice (monotonic per encode).
@@ -766,5 +894,7 @@ __all__ = [
     "Session",
     "RunResult",
     "HarvestCandidate",
+    "MemoryRecord",
+    "MemoryPage",
     "DEFAULT_RESIDENT_K",
 ]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -156,13 +156,20 @@ def test_full_open_to_close_holds_budget_and_runs_clean(tmp_pool_dir):
 def test_pool_survives_reopen_and_fact_still_recoverable(tmp_pool_dir):
     """The encoded fact is disk-resident: closing and reopening the same pool dir restores
     it, and it is still recoverable (mmap persistence carries the load-bearing fact)."""
-    s = _tiny_window_session(tmp_pool_dir)
+    session_id = "persistent-e2e-session"
+    s = _tiny_window_session(tmp_pool_dir, session_id=session_id)
     s.remember(PLANTED_FACT, tags={"kind": "constraint"})
     s.run("a long build")
     s.close()  # flush to disk
 
-    # reopen a fresh session over the SAME pool dir
-    s2 = Session(model="mock", pool_gb=5, pool_dir=tmp_pool_dir)
+    # Reopen the same explicit namespace over the SAME pool dir. Separate mode must never
+    # recover persistence by leaking through a global-search fallback.
+    s2 = Session(
+        model="mock",
+        pool_gb=5,
+        pool_dir=tmp_pool_dir,
+        session_id=session_id,
+    )
     try:
         hits = s2.recall(RECOVERY_QUERY, k=5)
         joined = " ".join(h.text.lower() for h in hits)

--- a/tests/test_memory_management.py
+++ b/tests/test_memory_management.py
@@ -1,0 +1,452 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the public, session-scoped memory management surface.
+
+The management API intentionally exposes text metadata rather than retrieval vectors. Every
+mutation is optimistic and session-scoped, and durable mutations must be visible on disk before
+they return. These tests stay hermetic under pytest's temporary directory.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import fields
+import json
+from pathlib import Path
+import threading
+from uuid import UUID
+
+import numpy as np
+import pytest
+
+from aether_context import MemoryPage, MemoryRecord, Session
+from aether_context.config import PoolConfig
+from aether_context.context_pool import ContextPool, Slice
+from aether_context.errors import AetherContextError, MemoryConflict, MemoryNotFound
+from aether_context.session import MEMORY_SOURCE_MODEL, MEMORY_SOURCE_USER
+
+
+def _session(pool_dir: Path, session_id: str = "memory-test", **kwargs: object) -> Session:
+    """Open a deterministic named session over an isolated pool directory."""
+    return Session(
+        "mock",
+        pool_gb=5,
+        pool_dir=pool_dir,
+        pool_mode="separate",
+        session_id=session_id,
+        **kwargs,
+    )
+
+
+def _remember(session: Session, text: str, **kwargs: object):
+    """Remember a fact and make the fail-soft return concrete for the tests below."""
+    stored = session.remember(text, **kwargs)
+    assert stored is not None
+    return stored
+
+
+def test_memory_page_get_and_type_filter_expose_vector_free_records(tmp_pool_dir: Path) -> None:
+    session = _session(tmp_pool_dir)
+    try:
+        stored = [
+            _remember(session, "first constraint", tags={"kind": "constraint"}),
+            _remember(session, "implementation note", tags={"kind": "note"}),
+            _remember(session, "second constraint", tags={"kind": "constraint"}),
+        ]
+
+        first = session.memory_page(limit=2)
+        assert isinstance(first, MemoryPage)
+        assert first.total == 3
+        assert len(first.items) == 2
+        assert first.next_cursor
+
+        second = session.memory_page(limit=2, cursor=first.next_cursor)
+        assert second.total == 3
+        assert len(second.items) == 1
+        assert second.next_cursor is None
+
+        records = [*first.items, *second.items]
+        assert {record.id for record in records} == {item.id for item in stored}
+        assert len({record.id for record in records}) == 3
+        public_fields = {field.name for field in fields(MemoryRecord)}
+        assert {
+            "id",
+            "text",
+            "tokens",
+            "meta",
+            "score",
+            "version",
+            "created_at",
+            "updated_at",
+        } <= public_fields
+        assert public_fields.isdisjoint({"vector", "session"})
+        assert all(isinstance(record, MemoryRecord) for record in records)
+
+        fetched = session.memory_get(stored[1].id)
+        assert fetched.id == stored[1].id
+        assert fetched.text == "implementation note"
+
+        constraints = session.memory_page(limit=10, memory_type="constraint")
+        assert constraints.total == 2
+        assert {record.meta["kind"] for record in constraints.items} == {"constraint"}
+        assert {record.id for record in constraints.items} == {stored[0].id, stored[2].id}
+    finally:
+        session.close()
+
+
+def test_memory_replace_increments_version_and_rejects_a_stale_writer(
+    tmp_pool_dir: Path,
+) -> None:
+    session = _session(tmp_pool_dir)
+    try:
+        stored = _remember(
+            session,
+            "deploy to staging",
+            source=MEMORY_SOURCE_USER,
+            tags={"kind": "constraint", "owner": "ops"},
+        )
+        before = session.memory_get(stored.id)
+
+        with pytest.raises(AetherContextError):
+            session.memory_replace(
+                stored.id,
+                text="attempted provenance rewrite",
+                expected_version=before.version,
+                meta_patch={"source": MEMORY_SOURCE_MODEL, "_version": 99},
+            )
+        assert session.memory_get(stored.id) == before
+
+        updated = session.memory_replace(
+            stored.id,
+            text="deploy to production after approval",
+            expected_version=before.version,
+            meta_patch={"kind": "decision", "owner": "release"},
+        )
+
+        assert updated.id == before.id
+        assert updated.text == "deploy to production after approval"
+        assert updated.version == before.version + 1
+        assert updated.created_at == before.created_at
+        assert updated.updated_at >= before.updated_at
+        assert updated.meta["kind"] == "decision"
+        assert updated.meta["owner"] == "release"
+        assert updated.meta["source"] == MEMORY_SOURCE_USER
+
+        sidecar = json.loads(session.pool.metadata_path.read_text(encoding="utf-8"))
+        persisted = next(
+            item for item in sidecar["slices"] if item["id"] == stored.id
+        )
+        assert persisted["text"] == updated.text
+        assert persisted["meta"]["_version"] == updated.version
+        with pytest.raises(MemoryConflict) as caught:
+            session.memory_replace(
+                stored.id,
+                text="stale overwrite",
+                expected_version=before.version,
+            )
+        assert caught.value.hint
+        assert session.memory_get(stored.id).text == updated.text
+    finally:
+        session.close()
+
+
+def test_memory_delete_is_durable_before_return_and_survives_reopen(
+    tmp_pool_dir: Path,
+) -> None:
+    session_id = "durable-delete"
+    session = _session(tmp_pool_dir, session_id)
+    doomed = _remember(session, "delete me", tags={"kind": "note"})
+    survivor = _remember(session, "keep me", tags={"kind": "constraint"})
+    current = session.memory_get(doomed.id)
+
+    deleted = session.memory_delete(
+        doomed.id,
+        expected_version=current.version,
+        durable=True,
+    )
+
+    assert deleted.id == doomed.id
+    assert deleted.version == current.version
+    with pytest.raises(MemoryNotFound):
+        session.memory_get(doomed.id)
+    sidecar = json.loads(session.pool.metadata_path.read_text(encoding="utf-8"))
+    assert {record["id"] for record in sidecar["slices"]} == {survivor.id}
+    session.close()
+
+    reopened = _session(tmp_pool_dir, session_id)
+    try:
+        with pytest.raises(MemoryNotFound):
+            reopened.memory_get(doomed.id)
+        assert reopened.memory_get(survivor.id).text == "keep me"
+    finally:
+        reopened.close()
+
+
+def test_memory_clear_expected_count_is_atomic_and_durable(tmp_pool_dir: Path) -> None:
+    session_id = "durable-clear"
+    session = _session(tmp_pool_dir, session_id)
+    first = _remember(session, "one")
+    second = _remember(session, "two")
+
+    with pytest.raises(MemoryConflict) as caught:
+        session.memory_clear(expected_count=1, durable=True)
+    assert caught.value.hint
+    assert {record.id for record in session.memory_page(limit=10).items} == {
+        first.id,
+        second.id,
+    }
+
+    assert session.memory_clear(expected_count=2, durable=True) == 2
+    assert session.memory_page(limit=10).total == 0
+    sidecar = json.loads(session.pool.metadata_path.read_text(encoding="utf-8"))
+    assert sidecar["count"] == 0
+    assert sidecar["slices"] == []
+    session.close()
+
+    reopened = _session(tmp_pool_dir, session_id)
+    try:
+        assert reopened.memory_page(limit=10).total == 0
+    finally:
+        reopened.close()
+
+
+def test_memory_management_never_crosses_session_scope_even_in_shared_mode(
+    tmp_pool_dir: Path,
+) -> None:
+    session_a = Session(
+        "mock",
+        pool_gb=5,
+        pool_dir=tmp_pool_dir,
+        pool_mode="shared",
+        session_id="owner-A",
+    )
+    owned_a = _remember(session_a, "A private managed record")
+    session_a.close()
+
+    session_b = Session(
+        "mock",
+        pool_gb=5,
+        pool_dir=tmp_pool_dir,
+        pool_mode="shared",
+        session_id="owner-B",
+    )
+    try:
+        assert session_b.memory_page(limit=10).total == 0
+        with pytest.raises(MemoryNotFound):
+            session_b.memory_get(owned_a.id)
+        with pytest.raises(MemoryNotFound):
+            session_b.memory_replace(owned_a.id, text="hijacked", expected_version=1)
+        with pytest.raises(MemoryNotFound):
+            session_b.memory_delete(owned_a.id, expected_version=1)
+        assert session_b.memory_clear(expected_count=0) == 0
+
+        owned_b = _remember(session_b, "B private managed record")
+        assert {item.id for item in session_b.memory_page(limit=10).items} == {owned_b.id}
+    finally:
+        session_b.close()
+
+    reopened_a = Session(
+        "mock",
+        pool_gb=5,
+        pool_dir=tmp_pool_dir,
+        pool_mode="shared",
+        session_id="owner-A",
+    )
+    try:
+        assert reopened_a.memory_get(owned_a.id).text == "A private managed record"
+        assert {item.id for item in reopened_a.memory_page(limit=10).items} == {owned_a.id}
+        with pytest.raises(MemoryNotFound):
+            reopened_a.memory_get(owned_b.id)
+    finally:
+        reopened_a.close()
+
+
+def test_separate_mode_recall_does_not_fall_back_to_global_pool(tmp_pool_dir: Path) -> None:
+    owner = _session(tmp_pool_dir, "recall-owner")
+    _remember(owner, "OMEGA private deployment secret")
+    owner.close()
+
+    stranger = _session(tmp_pool_dir, "recall-stranger")
+    try:
+        assert stranger.recall("OMEGA private deployment secret", k=4) == []
+    finally:
+        stranger.close()
+
+
+def test_same_named_session_uses_uuid_ids_without_overwriting_after_restart(
+    tmp_pool_dir: Path,
+) -> None:
+    session_id = "stable-session"
+    first_session = _session(tmp_pool_dir, session_id)
+    first = _remember(first_session, "fact from the first process")
+    first_session.close()
+
+    second_session = _session(tmp_pool_dir, session_id)
+    second = _remember(second_session, "fact from the second process")
+    try:
+        assert first.id != second.id
+        UUID(first.id.rsplit(":", 1)[-1])
+        UUID(second.id.rsplit(":", 1)[-1])
+        page = second_session.memory_page(limit=10)
+        assert page.total == 2
+        assert {item.text for item in page.items} == {
+            "fact from the first process",
+            "fact from the second process",
+        }
+    finally:
+        second_session.close()
+
+
+def test_remember_tags_cannot_spoof_provenance_or_version(tmp_pool_dir: Path) -> None:
+    session = _session(tmp_pool_dir, "provenance")
+    try:
+        stored = _remember(
+            session,
+            "model-authored production claim",
+            source=MEMORY_SOURCE_MODEL,
+            tags={
+                "kind": "constraint",
+                "source": MEMORY_SOURCE_USER,
+                "_version": 500,
+                "_created_at": "attacker-controlled",
+                "_updated_at": "attacker-controlled",
+            },
+        )
+        record = session.memory_get(stored.id)
+
+        assert stored.meta["source"] == MEMORY_SOURCE_MODEL
+        assert record.meta["source"] == MEMORY_SOURCE_MODEL
+        assert record.version == 1
+        assert record.created_at != "attacker-controlled"
+        assert record.updated_at != "attacker-controlled"
+        assert {
+            item.id
+            for item in session.recall(
+                "model-authored production claim",
+                k=4,
+                sources={MEMORY_SOURCE_USER},
+            )
+        } == set()
+        assert {
+            item.id
+            for item in session.recall(
+                "model-authored production claim",
+                k=4,
+                sources={MEMORY_SOURCE_MODEL},
+            )
+        } == {stored.id}
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("quantize_bits", [0, 4, 8])
+def test_delete_and_clear_zero_every_freed_mmap_row(
+    tmp_path: Path,
+    quantize_bits: int,
+) -> None:
+    session = _session(
+        tmp_path / f"q{quantize_bits}",
+        f"zero-q{quantize_bits}",
+        pool_quantize=quantize_bits,
+    )
+    try:
+        records = [_remember(session, f"nonzero vector {index}") for index in range(3)]
+        old_count = len(session.pool)
+        assert old_count == 3
+
+        middle = session.memory_get(records[1].id)
+        session.memory_delete(
+            middle.id,
+            expected_version=middle.version,
+            durable=True,
+        )
+        assert session.pool._mmap is not None
+        assert np.count_nonzero(np.asarray(session.pool._mmap[len(session.pool):old_count])) == 0
+
+        assert session.memory_clear(expected_count=2, durable=True) == 2
+        assert np.count_nonzero(np.asarray(session.pool._mmap[:old_count])) == 0
+    finally:
+        session.close()
+
+    disk_dtype = np.uint8 if quantize_bits else np.float32
+    raw_rows = np.fromfile(session.pool.vectors_path, dtype=disk_dtype)
+    assert np.count_nonzero(raw_rows) == 0
+
+
+def test_two_concurrent_replacements_have_exactly_one_winner(tmp_pool_dir: Path) -> None:
+    session = _session(tmp_pool_dir, "optimistic-race")
+    stored = _remember(session, "original")
+    version = session.memory_get(stored.id).version
+    barrier = threading.Barrier(3)
+
+    def replace(text: str) -> tuple[str, object]:
+        barrier.wait(timeout=5)
+        try:
+            return (
+                "updated",
+                session.memory_replace(stored.id, text=text, expected_version=version),
+            )
+        except MemoryConflict as exc:
+            return "conflict", exc
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(replace, text) for text in ("writer one", "writer two")]
+            barrier.wait(timeout=5)
+            outcomes = [future.result(timeout=10) for future in futures]
+
+        assert [status for status, _ in outcomes].count("updated") == 1
+        assert [status for status, _ in outcomes].count("conflict") == 1
+        winner = next(value for status, value in outcomes if status == "updated")
+        assert isinstance(winner, MemoryRecord)
+        assert winner.version == version + 1
+        assert session.memory_get(stored.id).text == winner.text
+    finally:
+        session.close()
+
+
+def test_pool_add_and_search_are_safe_under_basic_concurrency(tmp_path: Path) -> None:
+    dim = 256
+    pool = ContextPool(PoolConfig(pool_gb=5, dim=dim, index="flat", dir=tmp_path / "pool"))
+    barrier = threading.Barrier(5)
+
+    def writer(offset: int) -> None:
+        barrier.wait(timeout=5)
+        for index in range(20):
+            vector = np.zeros(dim, dtype=np.float32)
+            vector[(offset + index) % dim] = 1.0
+            pool.add(
+                Slice(
+                    id=f"slice-{offset + index}",
+                    session="concurrent",
+                    vector=vector,
+                    text=f"text {offset + index}",
+                    tokens=2,
+                    meta={"source": MEMORY_SOURCE_USER},
+                    score=0.8,
+                )
+            )
+
+    def reader(axis: int) -> None:
+        query = np.zeros(dim, dtype=np.float32)
+        query[axis] = 1.0
+        barrier.wait(timeout=5)
+        for _ in range(50):
+            for hit in pool.search(query, k=5, session="concurrent"):
+                assert hit.session == "concurrent"
+                assert hit.vector.shape == (dim,)
+
+    try:
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [
+                executor.submit(writer, 0),
+                executor.submit(writer, 20),
+                executor.submit(reader, 0),
+                executor.submit(reader, 20),
+            ]
+            barrier.wait(timeout=5)
+            for future in futures:
+                future.result(timeout=15)
+        assert len(pool) == 40
+    finally:
+        pool.close()


### PR DESCRIPTION
## Summary

- add public vector-free `MemoryRecord` / `MemoryPage` DTOs and session-scoped page/get/replace/delete/clear methods
- enforce optimistic versions, immutable provenance, UUID memory IDs, and strict namespace isolation (including removing separate-mode global recall fallback)
- serialize pool access through one re-entrant lock, durably fsync successful mutations, and zero reclaimed mmap rows for float32/q4/q8 pools
- preserve legacy retrieval metadata by returning detached search snapshots

## Security and durability

- foreign memory IDs resolve as scoped not-found errors
- caller tags and metadata patches cannot spoof `source`, versions, timestamps, or private chain coordinates
- clear is atomic on `expected_count`; replace/delete use compare-and-swap `expected_version`
- durable mutations flush vector data and atomically replace/fsync the sidecar before returning

## Validation

- `py -3.11 -m pytest -q`: **563 passed, 5 skipped**
- focused memory/storage suite: **40 passed, 3 skipped**
- `compileall` and `git diff --check`: passed

All tests use isolated pytest directories; no live pool data was touched.