### PR TITLE
feat(witness): permanently retained slices

### DIFF
--- a/aether_context/session.py
+++ b/aether_context/session.py
@@ -355,6 +355,18 @@ class Session:
         return (float(sl.meta.get("_ct", 0.0)), float(sl.tokens) / (2.0 if sl.id in warm else 1.0))
 
     # -- plant / recover a fact -----------------------------------------------
+    def pin(self, text: str, *, tags: dict[str, Any] | None = None,
+            source: str = MEMORY_SOURCE_USER) -> Slice | None:
+        """Encode ``text`` as a **permanently retained** slice.
+
+        Equivalent to :meth:`remember` with ``pinned=True``: the slice never
+        fades and is never evicted, at any pool pressure, for the life of the
+        session. Use it for what the session must not lose -- an operating
+        contract, a hard constraint, an identity -- not for merely important
+        content, which ordinary salience already handles.
+        """
+        return self.remember(text, tags={**(tags or {}), "pinned": True}, source=source)
+
     def remember(self, text: str, *, tags: dict[str, Any] | None = None,
                  source: str = MEMORY_SOURCE_USER) -> Slice | None:
         """Encode ``text`` as a high-salience slice into the pool (a load-bearing fact).
@@ -435,6 +447,12 @@ class Session:
             return None
         self._clock += 1.0
         self.witness.touch(sid, salience=score, now=self._clock)
+        # A caller marks load-bearing content with ``pinned``: an agent's
+        # doctrine, its skills, its grounding. Salience cannot express that --
+        # a slice nothing queries decays exactly like one nothing needs -- so
+        # the tag is honoured here as permanence rather than as a hint.
+        if meta.get("pinned") is True:
+            self.witness.pin(sid)
         # Every encoded durable artifact (planted fact or spill) is a run artifact:
         # text + its 256-dim retrieval vector + tags, retained locally.
         self._harvest.append(

--- a/aether_context/witness.py
+++ b/aether_context/witness.py
@@ -153,6 +153,11 @@ class Witness:
         self._pin_periods: float = max(0.0, float(pin_periods))
         self._pin_bonus: float = max(0.0, float(pin_bonus))
         self._entries: dict[str, _Entry] = {}
+        # Permanently retained ids. Distinct from the temporal lock-in above,
+        # which only holds a *recently touched* slice back against comparable
+        # churn and expires. A permanent slice never fades and is never
+        # evicted, at any pressure, until it is explicitly released.
+        self._permanent: set[str] = set()
 
     # -- harden / re-harden ----------------------------------------------------
     def touch(self, slice_id: str, salience: float, now: float = 0.0) -> float:
@@ -173,6 +178,35 @@ class Witness:
         self._entries[slice_id] = _Entry(base=s, last_touch=float(now))
         return s
 
+    # -- permanence ------------------------------------------------------------
+    def pin(self, slice_id: str) -> None:
+        """Retain ``slice_id`` permanently: never faded, never evicted.
+
+        For the load-bearing content an agent must not lose no matter how long
+        it runs -- its operating doctrine, its skills, its grounding. Those are
+        resident because of *what they are*, not because they happened to
+        embed near the current query, and salience ranking cannot express that:
+        a slice that is never queried decays exactly like one that is
+        irrelevant.
+
+        Pinning an id the witness has not seen is allowed and remembered, so
+        callers may pin before or after the first touch without ordering care.
+        """
+        self._permanent.add(str(slice_id))
+
+    def unpin(self, slice_id: str) -> None:
+        """Release ``slice_id`` back to ordinary fade and eviction."""
+        self._permanent.discard(str(slice_id))
+
+    def is_permanent(self, slice_id: str) -> bool:
+        """True when ``slice_id`` is permanently retained."""
+        return str(slice_id) in self._permanent
+
+    @property
+    def permanent_ids(self) -> frozenset[str]:
+        """The permanently retained ids (a snapshot)."""
+        return frozenset(self._permanent)
+
     # -- fade ------------------------------------------------------------------
     def decay(self, now: float) -> None:
         """**Fade** every slice: collapse each live (decayed) score into its base at ``now``.
@@ -182,6 +216,11 @@ class Witness:
         never negative. Calling repeatedly with non-decreasing ``now`` keeps fading.
         """
         for slice_id, entry in self._entries.items():
+            if slice_id in self._permanent:
+                # Re-anchor without fading: a permanent slice is as fresh at
+                # hour ten as at minute one.
+                self._entries[slice_id] = _Entry(base=entry.base, last_touch=float(now))
+                continue
             faded = self._decayed_score(entry, now)
             self._entries[slice_id] = _Entry(base=faded, last_touch=float(now))
 
@@ -252,10 +291,18 @@ class Witness:
         Ties break on insertion order for determinism. With ``now=None`` (or the lock-in
         disabled) this is simply ascending salience.
         """
-        scored = [(sid, self._eviction_score(e, now)) for sid, e in self._entries.items()]
+        scored = [
+            (sid, self._eviction_score(e, now))
+            for sid, e in self._entries.items()
+            if sid not in self._permanent
+        ]
         # stable ascending sort; ties keep dict insertion order (most-evictable first)
         scored.sort(key=lambda pair: pair[1])
-        return [sid for sid, _ in scored]
+        # Permanent ids rank last unconditionally: they are not candidates at
+        # any score, so no amount of pressure can order them forward.
+        return [sid for sid, _ in scored] + [
+            sid for sid in self._entries if sid in self._permanent
+        ]
 
     # -- budget eviction -------------------------------------------------------
     def budget_evict(
@@ -280,6 +327,14 @@ class Witness:
             return []
         # drop the most-evictable prefix; keep the `max_slices` most-retained survivors
         evicted = order[: len(order) - max_slices]
+        # A permanent slice is not evictable at any pressure. Without this the
+        # prefix would reach the permanent tail once the ceiling fell below the
+        # permanent count -- exactly the moment the guarantee matters most, and
+        # the pool would silently drop the agent's doctrine to make room for
+        # whatever it happened to be reading.
+        evicted = [sid for sid in evicted if sid not in self._permanent]
+        if not evicted:
+            return []
         for sid in evicted:
             del self._entries[sid]
         _log.debug(

--- a/tests/test_witness.py
+++ b/tests/test_witness.py
@@ -245,3 +245,88 @@ def test_eviction_order_without_now_is_ascending_score():
     w.touch("lo", salience=0.1, now=0.0)
     w.touch("mid", salience=0.5, now=0.0)
     assert w.eviction_order() == ["lo", "mid", "hi"]
+
+
+# -- permanence ---------------------------------------------------------------
+
+
+def test_a_pinned_slice_never_fades() -> None:
+    """Salience cannot express 'keep this because of what it is'.
+
+    A slice nothing queries decays exactly like one nothing needs, so an
+    agent's doctrine fades out of reach precisely because it is background.
+    """
+    w = Witness(decay_rate=0.5)
+    w.touch("doctrine", salience=0.9, now=0.0)
+    w.touch("chatter", salience=0.9, now=0.0)
+    w.pin("doctrine")
+
+    for tick in range(1, 60):
+        w.decay(float(tick))
+
+    assert w.score("doctrine") == 0.9, "a pinned base must be preserved exactly"
+    assert w.score("chatter") < 0.01
+    assert w.is_permanent("doctrine")
+    assert not w.is_permanent("chatter")
+
+
+def test_a_pinned_slice_is_never_evictable() -> None:
+    w = Witness()
+    w.touch("doctrine", salience=0.01, now=0.0)   # deliberately the weakest
+    for i in range(10):
+        w.touch(f"loud-{i}", salience=1.0, now=0.0)
+    w.pin("doctrine")
+
+    order = w.eviction_order()
+    assert order[-1] == "doctrine", "the weakest slice must still rank last once pinned"
+    assert order.index("doctrine") == len(order) - 1
+
+
+def test_budget_eviction_cannot_reach_a_pinned_slice_at_any_pressure() -> None:
+    """The guarantee has to hold at the moment it matters most.
+
+    Ranking pinned slices last is not enough: once the ceiling falls below the
+    pinned count the evictable prefix reaches them anyway, and the pool drops
+    the agent's doctrine to make room for whatever it was reading.
+    """
+    w = Witness()
+    for name in ("doctrine", "skills", "grounding"):
+        w.touch(name, salience=0.05, now=0.0)
+        w.pin(name)
+    for i in range(20):
+        w.touch(f"spill-{i}", salience=0.99, now=0.0)
+
+    # A ceiling of one slice, with three pinned. Nothing pinned may go.
+    evicted = w.budget_evict(ceiling_bytes=1, bytes_per_slice=1, now=1.0)
+
+    assert "doctrine" not in evicted
+    assert "skills" not in evicted
+    assert "grounding" not in evicted
+    for name in ("doctrine", "skills", "grounding"):
+        assert w.score(name) > 0.0, f"{name} was dropped from the witness"
+
+
+def test_unpin_returns_a_slice_to_ordinary_decay() -> None:
+    w = Witness(decay_rate=0.5)
+    w.touch("temp", salience=0.9, now=0.0)
+    w.pin("temp")
+    for tick in range(1, 20):
+        w.decay(float(tick))
+    assert w.score("temp") == 0.9
+
+    w.unpin("temp")
+    assert not w.is_permanent("temp")
+    for tick in range(20, 80):
+        w.decay(float(tick))
+    assert w.score("temp") < 0.01
+
+
+def test_pinning_an_unseen_id_is_remembered() -> None:
+    """Callers should not have to order pin and touch."""
+    w = Witness()
+    w.pin("later")
+    assert w.is_permanent("later")
+    w.touch("later", salience=0.5, now=0.0)
+    for tick in range(1, 40):
+        w.decay(float(tick))
+    assert w.score("later") == 0.5


### PR DESCRIPTION
Replaces #52, which sat on a base made unrelated by a history rewrite. Same change, rebuilt on current `main`; TurboVec's `pool_quantize` plumbing is preserved.

## The gap

Salience cannot express *"keep this because of what it is."* A slice nothing queries decays exactly like a slice nothing needs — so the content an agent must never lose (doctrine, skills, grounding) fades out of reach **precisely because** it sits in the background while the session works.

## Measured on a real agent bucket, before this change

Doctrine, 11 skills and 73 grounding facts injected at spawn:

```
"you are ATS"                               -> doctrine at rank 1
"abstain when evidence is thin"             -> doctrine at rank 2
"what am I and how do I behave"             -> SKILL chart_reader, SKILL risk
"system prompt doctrine operating contract" -> nothing
"scalping system"                           -> nothing
"ATS2 operating contract mode stance"       -> nothing
```

Four of six identity probes missed it. **The agent could not reliably recall what it was.**

## The change

- `decay()` re-anchors a permanent slice instead of fading it
- `eviction_order()` excludes permanent ids, appends them last
- `budget_evict()` filters them out of the evictable prefix

**The third guard is the one that matters.** Ranking last is not enough: once the ceiling falls below the permanent count the prefix reaches them anyway — exactly when the guarantee matters most. The test squeezes three pinned slices against a **one-slice ceiling** and asserts none move.

`Session` honours a `pinned` tag and grows `Session.pin()`.

```
after 200 fades   doctrine 0.5295 -> 0.5295
                  noise    0.4701 -> 0.0000
1-slice ceiling   doctrine survived: True   noise survived: False
```

**555 passed, 5 skipped.** Permanence is opt-in; an unpinned session is unchanged.

## Consumer

ATSv2 #122 pins doctrine, skills and Atlas grounding into a per-agent 5 GB bucket. It already writes the `pinned` tag; until this lands that tag is an inert label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)