### PR TITLE
fix(ci): repair the three failures keeping main red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        numpy: ["1.24.*", "1.26.*", "2.*"]
+        # Pair each numpy with an interpreter it actually ships wheels for. numpy 1.24
+        # (our declared floor) stops at cp311 — on 3.12 pip finds no distribution and
+        # falls back to a source build that fails.
+        include:
+          - numpy: "1.24.*"
+            python-version: "3.11"
+          - numpy: "1.26.*"
+            python-version: "3.12"
+          - numpy: "2.*"
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
       - run: python -m pip install -e ".[dev]" "numpy==${{ matrix.numpy }}"
       - run: python -m pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,9 @@ target-version = "py310"
 select = ["E4", "E7", "E9", "F"]
 
 [tool.mypy]
-python_version = "3.10"
+# No pinned python_version: mypy analyses under the interpreter running it, which is what
+# the CI matrix already varies. Pinning it to the floor made mypy parse the *installed*
+# numpy stubs under 3.10 syntax rules, so numpy >= 2.5 (whose stubs use PEP 695 `type`
+# statements) failed to parse on every 3.12/3.13 job. The 3.10 matrix leg still enforces
+# 3.10 compatibility.
 ignore_missing_imports = true

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,6 +19,7 @@ Style mirrors the package's own ``test_slice_loader.py``.
 """
 from __future__ import annotations
 
+import threading
 import time
 from pathlib import Path
 
@@ -206,16 +207,29 @@ def test_run_uses_background_prefetch_when_streaming(tmp_pool_dir):
     """When the model streams (>1 chunk), the session prefetches on a side thread *while*
     the model generates — the prefetch overlaps generation rather than serializing after it.
 
-    We prove overlap with a slow-generating mock and a slow prefetch: wall-clock for the run
-    is close to max(generation, prefetch), not their sum."""
+    Overlap is asserted structurally, not by wall-clock: a prefetch must run off the main
+    thread, and must *start* before generation emits its last chunk. A serialised design
+    fails both regardless of how fast or slow the machine is. (The previous
+    ``elapsed < 0.30`` bound was flaky on shared CI runners — and since a serial run costs
+    generation + 5 prefetches ≈ 200ms, a 300ms bound could not actually tell the two
+    designs apart.)"""
+
+    gen_ticks: list[float] = []
+    prefetches: list[tuple[str, float]] = []
 
     class SlowMock:
         name = "slow-mock"
-        context_window = 4096
+        # small window on purpose: the background prefetch only launches once `pending`
+        # crosses int(window * TRIGGER_FRACTION) * 4 chars. At the old 4096 that trigger was
+        # 12288 chars while this mock emits ~285 in total, so the branch never ran and the
+        # test passed without ever exercising the thing it claims to prove. 16 -> 48 chars,
+        # which each ~57-char chunk clears.
+        context_window = 16
 
         def generate(self, prompt, *, system=None, stop=None, max_tokens=None):
             for _ in range(5):
-                time.sleep(0.02)  # 5 * 20ms = 100ms of "generation"
+                time.sleep(0.02)  # 5 * 20ms of "generation" — room for a prefetch to start
+                gen_ticks.append(time.perf_counter())
                 yield "slice token plan build module function class test verify "
 
         def count_tokens(self, text):
@@ -223,22 +237,30 @@ def test_run_uses_background_prefetch_when_streaming(tmp_pool_dir):
 
     s = Session(model=SlowMock(), pool_gb=5, pool_dir=tmp_pool_dir)
 
-    # make a prefetch noticeably slow so a *serial* design would clearly add its cost
+    # record which thread each prefetch lands on, and when it starts
     original = s.pager.prefetch_from
 
     def _slow_prefetch(*a, **k):
+        prefetches.append((threading.current_thread().name, time.perf_counter()))
         time.sleep(0.02)
         return original(*a, **k)
 
     s.pager.prefetch_from = _slow_prefetch  # type: ignore[method-assign]
     try:
-        t0 = time.perf_counter()
         result = s.run("overlap test")
-        elapsed = time.perf_counter() - t0
         assert result.text
-        # generation alone is ~100ms; a fully-serial prefetch-after-each-chunk would add a
-        # lot more. Overlap keeps us well under generation + (5 * prefetch) = ~200ms.
-        assert elapsed < 0.30
+        assert len(gen_ticks) == 5, "the mock should have streamed five chunks"
+        assert prefetches, "expected at least one prefetch during the run"
+
+        # 1. backgrounded — Session._launch_prefetch names its threads "prefetch-<id>".
+        #    The final synchronous _page_working_set call runs on MainThread; ignore it.
+        backgrounded = [p for p in prefetches if p[0].startswith("prefetch-")]
+        assert backgrounded, f"no prefetch ran on a background thread: {prefetches}"
+
+        # 2. genuinely overlapping — it started before generation had finished.
+        assert backgrounded[0][1] < gen_ticks[-1], (
+            "prefetch started only after the last chunk — serialised, not overlapped"
+        )
     finally:
         s.close()
 


### PR DESCRIPTION
`main` is red on **9 of 16** check runs. Three unrelated root causes; each is fixed and verified separately.

### 1. mypy fails on every py3.12 / py3.13 job — 6 runs

`[tool.mypy] python_version = "3.10"` forced mypy to parse the *installed* numpy stubs under 3.10 syntax rules. numpy ≥ 2.5 uses PEP 695 `type` statements in `numpy/__init__.pyi`, so parsing aborted before any of our code was reached:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

This is why only 3.12/3.13 broke — 3.10/3.11 resolve an older numpy whose stubs predate PEP 695.

Dropping the pin lets mypy analyse under the interpreter running it, which the CI matrix already varies. The 3.10 leg still enforces 3.10 compatibility.

Reproduced against CI's exact versions (numpy 2.5.2 + mypy 2.3.0):

| | result |
|---|---|
| `--python-version 3.10` (old) | fails, `numpy/__init__.pyi:737` |
| interpreter default (new) | `Success: no issues found in 14 source files` |

### 2. `numpy 1.24.*` leg cannot install — 1 run

All three numpy legs pinned `python-version: "3.12"`, but numpy 1.24 — our declared floor in `dependencies` — ships no cp312 wheels. pip fell through to a source build and exited 2 (`ERROR: Exception:`).

Confirmed directly: `pip download "numpy==1.24.*" --python-version 3.12 --only-binary=:all:` → `No matching distribution found`.

Each numpy is now paired with an interpreter it has wheels for; 1.24 runs on 3.11. Testing the declared floor is kept, not dropped.

### 3. `test_run_uses_background_prefetch_when_streaming` is flaky — 2 runs

It asserted `elapsed < 0.30` on shared runners; macOS produced `assert 0.39159508299999857 < 0.3`. It also reproduced locally (1 in 5 on a fast machine).

While fixing it I found **the test was vacuous**. The background prefetch only launches once `pending` crosses `int(window * TRIGGER_FRACTION) * 4` chars. At `context_window = 4096` that is **12288 chars**, and the mock emits **~285 in total** — so `_launch_prefetch` was never called, and a fully serialised implementation would have passed identically. The only prefetch observed was the final synchronous one on `MainThread`.

Two changes:

- `context_window = 16` → trigger 48 chars, cleared by each ~57-char chunk, so the path is genuinely exercised (5 background launches).
- Overlap is now asserted **structurally** rather than by wall-clock: a prefetch must run off the main thread (`Session._launch_prefetch` names its threads `prefetch-<id>`), and must start before the last generated chunk. Both are ordering/identity facts, immune to runner speed.

Worth noting the old bound could not have discriminated anyway — a serial run costs generation + 5 prefetches ≈ 200ms, comfortably under the 300ms bound.

## Verification

Local, Python 3.13.5:

- `pytest -q` → **557 passed, 4 skipped**
- `ruff check aether_context tests` → All checks passed
- `python -m mypy aether_context` → Success, 14 source files
- rewritten overlap test run repeatedly: passes with wall-clock varying 0.69s–2.88s, which is the point

## Not included

No production code is touched — the diff is CI config, mypy config, and one test. The `numpy 1.24` floor stays tested rather than being dropped.