### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ All notable changes to `aether-context` are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-08-13
+
 ### Added
+- **Permanently retained slices.** `Session.pin(text, tags=...)` encodes a slice the witness
+  never fades and the byte governor never evicts, at any pool pressure (equivalent to
+  `remember(..., pinned=True)`). Permanent slices are **re-pinned from the pool when a session
+  opens**: permanence is re-derived from the slices' own tags, so a pinned fact survives a
+  restart instead of coming back as ordinary content and fading on the first long run. Use it
+  for the handful of load-bearing constraints a long-running agent must never lose.
 - **MPO context chain (on by default).** Links the session's slices into one connected
   structure and assists retrieval: when cosine pulls an entry slice, the MPO (Matrix Product
   Operator) chain pulls in the slices most coupled to it — widening the working set with the

--- a/aether_context/__init__.py
+++ b/aether_context/__init__.py
@@ -24,6 +24,6 @@ Public surface (intentionally tiny):
 from aether_context.local_llm import load_model
 from aether_context.session import Session
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["Session", "load_model", "__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aether-context"
-version = "0.1.0"
+version = "0.2.0"
 description = "Unlimited Context — virtual memory for an LLM's attention. Local-first, numpy-only core."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"


### PR DESCRIPTION
Release prep for **v0.2.0** — the first tagged release of `aether-context`. Version bump + changelog only; no behaviour changes.

## Version lives in two places

`RELEASING.md` documents only `pyproject.toml`, but `aether_context/__init__.py` carries its own `__version__`, and that is what `aether-context --version` prints (`cli.py:48` imports it, `cli.py:90` renders it). Bumping one without the other ships a CLI that reports the wrong version, so both are bumped here.

Worth folding that into `RELEASING.md` step 1 separately.

## Changelog

Moves the accumulated `[Unreleased]` entries into a dated `[0.2.0]`, and **adds the permanent-pins entry that was missing entirely** — PRs #53 and #55 landed `Session.pin()` and rehydration-on-open, but neither was recorded.

Headline items:

- **Permanently retained slices** — `Session.pin()`; never faded, never evicted, and re-pinned from the pool on open so a pinned fact survives a restart
- **MPO context chain**, on by default — connected-context recall@8 **0.15 → 0.78**
- **Witness temporal lock-in** — breaks the evict → cold-miss → re-page flap
- **Incremental HNSW inserts** — `O(new)` instead of rebuilding `O(N)` per search-after-add
- **`--index tiered` is no longer a silent capability claim** — it warns and runs flat, which is what it always did

## Claims check

The recall figure was **re-run before publishing** rather than trusted from the changelog:

```
threads=40 size=5 distractors=400 k=8
  cosine-only thread recall@8: 0.150
  + MPO chain   thread recall@8: 0.775
```

Reproduce with `python -m bench.chain_recall`.

One correction along the way: a draft of the pins entry referenced `Session.unpin()`, which **does not exist** — only `Witness.unpin()` does, and that is internal. Removed rather than shipped.

## Verification

- `pytest -q` → **557 passed, 4 skipped**
- `aether-context --version` → `0.2.0`; `pyproject.toml` → `0.2.0`

## ⚠️ Do not tag this `v*` without reading below

Merging this PR is safe. **Pushing a `v0.2.0` tag is not yet**, and that is a separate decision — see the release thread. `publish.yml` fires on `push: tags: v*` and publishes to PyPI via OIDC Trusted Publishing. `aether-context` does not exist on PyPI yet, so that would be a first-ever publish, and `RELEASING.md` warns the Trusted Publisher's **owner must match the repo's owner at publish time** — it documents `DBarr3`, but this repo is now under `AetherAI3`.