### PR TITLE
chore(release): make the PyPI publish dormant instead of failing on every tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,30 @@
 name: publish
 
 # Publish to PyPI via OIDC Trusted Publishing (no API token stored in the repo).
-# Triggered by pushing a version tag, e.g. `git push origin v0.1.0`.
+#
+# DORMANT — run this manually, on purpose, and only once a PyPI trusted publisher
+# exists for this repository. There is currently no `aether-context` project on
+# PyPI and no publisher configured, so this job cannot succeed: it fails at the
+# OIDC exchange with `invalid-publisher`.
+#
+# It used to run on `push: tags: v*`, which meant every release tag produced a
+# red X on an otherwise green repo while nothing was ever published. Tagging and
+# publishing are now separate decisions, so cutting a release no longer pretends
+# to ship a package.
+#
+# To enable publishing later:
+#   1. On PyPI add a *pending* publisher (the project does not exist yet) with
+#      owner `AetherAI3`, repository `Unlimited-Context-LLM`, workflow
+#      `publish.yml`, environment `pypi`. All four are matched literally — OIDC
+#      does not follow the DBarr3 -> AetherAI3 transfer redirect.
+#   2. Run this workflow from the Actions tab against the release tag.
+#   3. Once it succeeds, restoring the `push: tags: v*` trigger is safe.
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag to build and publish, e.g. v0.2.0"
+        required: true
 
 permissions:
   contents: read
@@ -20,6 +39,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Build the tag that was asked for, not the default branch.
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,12 +42,22 @@ pushing the very first tag, or the publish job fails.
 
 ## Cutting a release
 
-1. **Bump the version** in [`pyproject.toml`](pyproject.toml):
+1. **Bump the version in BOTH places it lives.** They are separate strings and nothing keeps
+   them in sync:
 
    ```toml
+   # pyproject.toml
    [project]
    version = "X.Y.Z"
    ```
+
+   ```python
+   # aether_context/__init__.py
+   __version__ = "X.Y.Z"
+   ```
+
+   `cli.py` imports `__version__`, so the second one is what `aether-context --version`
+   prints. Bumping only `pyproject.toml` ships a CLI that reports the previous version.
 
 2. **Update [`CHANGELOG.md`](CHANGELOG.md):** move items out of `## [Unreleased]` into a new
    `## [X.Y.Z] — YYYY-MM-DD` section. The format follows
@@ -61,31 +71,46 @@ pushing the very first tag, or the publish job fails.
    git commit -m "release: vX.Y.Z"
    ```
 
-4. **Tag and push.** The tag (prefixed with `v`) is what triggers the publish workflow:
+4. **Tag, push, and cut the GitHub Release:**
 
    ```bash
    git tag -a vX.Y.Z -m "aether-context vX.Y.Z"
    git push origin vX.Y.Z
+   gh release create vX.Y.Z --title "vX.Y.Z — <one concrete capability>" --notes-file notes.md
    ```
 
-   Pushing the tag fires [`.github/workflows/publish.yml`](.github/workflows/publish.yml), which:
-   `actions/checkout@v4` → `actions/setup-python@v5` (3.12) → `pip install build` →
-   `python -m build` (sdist + wheel) → `pypa/gh-action-pypi-publish@release/v1` (OIDC, no token)
-   → upload to PyPI.
+   The tag **no longer triggers a publish**. `publish.yml` is dormant
+   (`workflow_dispatch` only) because there is no `aether-context` project on PyPI and no
+   trusted publisher configured — every tag used to produce a red X while nothing shipped.
+   Tagging and publishing are separate decisions now.
 
-5. **Verify.** Watch the **publish** run in the Actions tab, then confirm the new version at
-   <https://pypi.org/project/aether-context/> and:
+   Until PyPI is set up, the supported install is straight from GitHub:
 
    ```bash
-   pip install --upgrade aether-context==X.Y.Z
+   pip install git+https://github.com/AetherAI3/Unlimited-Context-LLM.git@vX.Y.Z
    ```
+
+   Say that in the release notes rather than `pip install aether-context`, which does not
+   work yet.
+
+5. **Verify.** Confirm the release renders correctly, then check the tag installs cleanly from
+   a throwaway environment:
+
+   ```bash
+   pip install git+https://github.com/AetherAI3/Unlimited-Context-LLM.git@vX.Y.Z
+   aether-context --version   # must print X.Y.Z, not the previous version
+   ```
+
+   Once PyPI is configured, additionally dispatch **publish** from the Actions tab against the
+   tag, then confirm at <https://pypi.org/project/aether-context/>.
 
 ---
 
 ## Notes & troubleshooting
 
-- **Tag format matters.** The workflow triggers on `v*` tags only. A bare `X.Y.Z` tag (no `v`)
-  will not publish.
+- **The tag no longer publishes anything.** `publish.yml` is `workflow_dispatch` only. It used
+  to fire on `v*` tags, but with no trusted publisher configured every tag just produced a red
+  X. Restore the `push: tags: v*` trigger once a manual dispatch has actually succeeded.
 - **Re-tagging.** PyPI files are immutable — you cannot re-upload the same version. If a release
   is broken, bump to a new patch version and tag again.
 - **Version mismatch.** The published version comes from `pyproject.toml`, not the tag string.


### PR DESCRIPTION
Follow-up to the v0.2.0 release. Docs and CI config only — no package code.

## Problem

`aether-context` is not on PyPI and there is no trusted publisher for this repo, so `publish.yml` **cannot succeed**. It fails at the OIDC exchange:

```
* `invalid-publisher`: valid token, but no corresponding publisher
  repository_owner: AetherAI3
  environment:      pypi
```

It was wired to `push: tags: v*`, so cutting `v0.2.0` put a red X on an otherwise fully green repo — and nothing shipped. Every future release tag would have done the same.

No version was consumed on PyPI, so nothing needs yanking.

## Changes

**`publish.yml` → dormant.** Now `workflow_dispatch` only, taking the tag to build as an input. Checkout honours that input rather than silently building the default branch — a manual dispatch that built `main` instead of the tag would be a worse failure than the one being fixed.

The job is kept intact so it can be dispatched the moment a publisher exists. The header records the four claims that must match, and that OIDC does **not** follow the `DBarr3` → `AetherAI3` transfer redirect.

**`RELEASING.md` — three places it was actively wrong:**

| Step | Was | Now |
|---|---|---|
| 1 | bump `pyproject.toml` | bump **both** — `__version__` in `aether_context/__init__.py` is a second unsynced string, and it's what `aether-context --version` prints |
| 4 | "the tag is what triggers the publish workflow" | it no longer does; tagging and publishing are separate decisions |
| 5 | verify at pypi.org | verify via git-tag install + `--version`, with the PyPI path documented as a later step |

Step 1 is the one that actually bit us: v0.2.0 would have shipped a CLI reporting `0.1.0` if only `pyproject.toml` had been bumped.

## Install, until PyPI exists

```bash
pip install git+https://github.com/AetherAI3/Unlimited-Context-LLM.git@v0.2.0
```

The v0.2.0 release notes have been corrected to say this — they previously said `pip install aether-context`, which does not work.

## Re-enabling later

1. On PyPI add a **pending** publisher (the project doesn't exist yet) — owner `AetherAI3`, repository `Unlimited-Context-LLM`, workflow `publish.yml`, environment `pypi`.
2. Dispatch **publish** from the Actions tab against the tag.
3. Once that succeeds, restoring `push: tags: v*` is safe.