### PR TITLE
docs: canonicalize AetherAI3 public links

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default code owner — routes review on any change.
 # Note: this may change after a future transfer to the aether-ai org.
-* @DBarr3
+* @AetherAI3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,5 +64,5 @@ pool — local-first, numpy-only core.
   completion), hermetic via `MockLLM`.
 - Docs (`how-it-works`, `local-models`), examples, CI, Apache-2.0 license.
 
-[Unreleased]: https://github.com/DBarr3/Unlimited-Context-LLM/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/DBarr3/Unlimited-Context-LLM/releases/tag/v0.1.0
+[Unreleased]: https://github.com/AetherAI3/Unlimited-Context-LLM/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/AetherAI3/Unlimited-Context-LLM/releases/tag/v0.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ authors:
     given-names: "Brandon"
     affiliation: "Aether AI"
   - name: "Aether AI"
-version: "0.1.0"
-date-released: 2026-06-02
+version: "0.2.0"
+date-released: 2026-08-13
 license: Apache-2.0
-url: "https://github.com/DBarr3/Unlimited-Context-LLM"
-repository-code: "https://github.com/DBarr3/Unlimited-Context-LLM"
+url: "https://github.com/AetherAI3/Unlimited-Context-LLM"
+repository-code: "https://github.com/AetherAI3/Unlimited-Context-LLM"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 You need **Python 3.10–3.13** and `git`. That's it. No GPU, no API key, no model download.
 
 ```bash
-git clone https://github.com/DBarr3/Unlimited-Context-LLM.git
+git clone https://github.com/AetherAI3/Unlimited-Context-LLM.git
 cd Unlimited-Context-LLM
 python -m venv .venv
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 aether-context is licensed under the Apache License, Version 2.0,
 © 2026 Aether AI. See the `LICENSE` file for the full text.
-Created by Brandon Barrante (https://github.com/DBarr3), founder of Aether AI.
+Created by Brandon Barrante (https://github.com/AetherAI3), founder of Aether AI.
 
 ## Third-Party Dependencies
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Built by Aether](https://img.shields.io/badge/Built_by-Aether-7c3aed?style=flat-square)](https://aethersystems.net)
 [![Local-first](https://img.shields.io/badge/Local--first-100%25_offline-0ea5e9?style=flat-square)](#what-you-get)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square)](CONTRIBUTING.md)
-[![Stars](https://img.shields.io/github/stars/DBarr3/Unlimited-Context-LLM?style=flat-square&logo=github&color=eab308)](https://github.com/DBarr3/Unlimited-Context-LLM/stargazers)
+[![Stars](https://img.shields.io/github/stars/AetherAI3/Unlimited-Context-LLM?style=flat-square&logo=github&color=eab308)](https://github.com/AetherAI3/Unlimited-Context-LLM/stargazers)
 
 **An open project from [Aether](https://aethersystems.net)** · Apache-2.0 · [Install](#quickstart)
 
@@ -268,7 +268,7 @@ aether-context run "..." --no-mpo-chain                      # disable for one r
 The same install ships a second command — **`aether`** — an open-source agentic **coding terminal**
 running on the Unlimited Context engine. It's **local-first**: turns run on your local **[Ollama](https://ollama.com)**
 by default (no account, no network); sign in and they switch to the **Aether cloud API**. It's the
-Python-native twin of [`aether-code`](https://github.com/DBarr3/aether-agent) (the TypeScript terminal)
+Python-native twin of [`aether-code`](https://github.com/AetherAI3/aether-agent) (the TypeScript terminal)
 — same commands, same backend, same tools.
 
 | Command | What it does |
@@ -293,7 +293,7 @@ Python-native twin of [`aether-code`](https://github.com/DBarr3/aether-agent) (t
 
 ```bash
 # Install straight from GitHub — works today, always the latest:
-pip install git+https://github.com/DBarr3/Unlimited-Context-LLM.git
+pip install git+https://github.com/AetherAI3/Unlimited-Context-LLM.git
 
 # From PyPI, once published — the package name is "aether-context"
 # (note: `pip install unlimited-context` is NOT the package name):
@@ -324,7 +324,7 @@ If Unlimited Context helps your work, please cite it. Built and maintained by **
   author       = {Barrante, Brandon},
   organization = {Aether AI},
   year         = {2026},
-  url          = {https://github.com/DBarr3/Unlimited-Context-LLM},
+  url          = {https://github.com/AetherAI3/Unlimited-Context-LLM},
   license      = {Apache-2.0}
 }
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ when a version tag is pushed. The release is built and uploaded by
 [`.github/workflows/publish.yml`](.github/workflows/publish.yml) using **PyPI OIDC Trusted
 Publishing** — there is **no API token** stored in the repo or in GitHub secrets.
 
-Source of truth for the repo: <https://github.com/DBarr3/Unlimited-Context-LLM>
+Source of truth for the repo: <https://github.com/AetherAI3/Unlimited-Context-LLM>
 
 ---
 
@@ -22,7 +22,7 @@ pushing the very first tag, or the publish job fails.
    **Manage → Publishing → Add a new publisher**.
 3. Enter exactly:
    - **PyPI project name:** `aether-context`
-   - **Owner:** the GitHub org/user that owns the repo **at publish time** (currently `DBarr3`)
+   - **Owner:** the GitHub org/user that owns the repo **at publish time** (currently `AetherAI3`)
    - **Repository name:** `Unlimited-Context-LLM` (the repo's exact current name — OIDC matches
      this literally and does **not** follow GitHub's rename redirect, so it must be exact)
    - **Workflow name:** `publish.yml`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ issue for a suspected vulnerability. aetherai@aethersystems.net
 Use GitHub's private vulnerability reporting via the repository's **Security**
 tab ("Report a vulnerability"):
 
-https://github.com/DBarr3/Unlimited-Context-LLM/security/advisories/new
+https://github.com/AetherAI3/Unlimited-Context-LLM/security/advisories/new
 
 We aim to acknowledge new reports within a few days (best effort). We will work
 with you to validate the issue, and fixes are coordinated and prepared before

--- a/aether_agent/install.ps1
+++ b/aether_agent/install.ps1
@@ -1,6 +1,6 @@
 # Aether Coding Agent — 1-command install (Windows, PowerShell).
 #
-#   irm https://raw.githubusercontent.com/DBarr3/Unlimited-Context/main/aether_agent/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/AetherAI3/Unlimited-Context-LLM/main/aether_agent/install.ps1 | iex
 #
 # Installs the engine + agent (pip), checks Ollama, and pulls the default model.
 $ErrorActionPreference = "Stop"
@@ -13,7 +13,10 @@ if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
 }
 
 Write-Host "Installing aether-context (Unlimited Context engine + Aether agent)..."
-python -m pip install --upgrade aether-context
+# `aether-context` is not on PyPI yet (see RELEASING.md); install from the
+# canonical repository. Switch back to `aether-context` once the first PyPI
+# release is published.
+python -m pip install --upgrade "git+https://github.com/AetherAI3/Unlimited-Context-LLM.git"
 
 if (-not (Get-Command ollama -ErrorAction SilentlyContinue)) {
   Write-Host "Install Ollama from https://ollama.com/download, then re-run this."

--- a/aether_agent/install.sh
+++ b/aether_agent/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Aether Coding Agent — 1-command install (macOS / Linux / WSL).
 #
-#   curl -fsSL https://raw.githubusercontent.com/DBarr3/Unlimited-Context/main/aether_agent/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/AetherAI3/Unlimited-Context-LLM/main/aether_agent/install.sh | sh
 #
 # Installs the engine + agent (pip), Ollama, and pulls the default coding model.
 set -e
@@ -11,7 +11,10 @@ MODEL="${AETHER_MODEL:-qwen3-coder:30b}"
 command -v python3 >/dev/null 2>&1 || { echo "Aether Code needs Python 3.10+ — install from https://python.org"; exit 1; }
 
 echo "Installing aether-context (Unlimited Context engine + Aether agent)…"
-python3 -m pip install --upgrade aether-context
+# `aether-context` is not on PyPI yet (see RELEASING.md); install from the
+# canonical repository. Switch back to `aether-context` once the first PyPI
+# release is published.
+python3 -m pip install --upgrade "git+https://github.com/AetherAI3/Unlimited-Context-LLM.git"
 
 if ! command -v ollama >/dev/null 2>&1; then
   echo "Installing Ollama (runs the model locally)…"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ classifiers = [
 dependencies = ["numpy>=1.24,<3.0"]       # CORE = numpy only. Works offline with MockLLM.
 
 [project.urls]
-Homepage = "https://github.com/DBarr3/Unlimited-Context"
-Repository = "https://github.com/DBarr3/Unlimited-Context.git"
-Documentation = "https://github.com/DBarr3/Unlimited-Context#readme"
-Issues = "https://github.com/DBarr3/Unlimited-Context/issues"
-Changelog = "https://github.com/DBarr3/Unlimited-Context/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/AetherAI3/Unlimited-Context-LLM"
+Repository = "https://github.com/AetherAI3/Unlimited-Context-LLM.git"
+Documentation = "https://github.com/AetherAI3/Unlimited-Context-LLM#readme"
+Issues = "https://github.com/AetherAI3/Unlimited-Context-LLM/issues"
+Changelog = "https://github.com/AetherAI3/Unlimited-Context-LLM/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 ollama   = []                              # primary path uses stdlib urllib — no extra dep needed


### PR DESCRIPTION
Every public reference in this repo pointed at the DBarr3 namespace. That
account no longer exists — github.com/DBarr3 returns 404 and only
per-repository transfer redirects still resolve — so these links depended on a
redirect GitHub is free to drop.

Two of them were pointing at the wrong repository name on top of that:
pyproject.toml's five `[project.urls]` entries and both installer headers used
`Unlimited-Context`, not `Unlimited-Context-LLM`. Those URLs are what PyPI
renders on the project sidebar once a release is published.

Fixed here:
- README stars badge and stargazers link, the aether-agent cross-link, the
  git install command, and the BibTeX url.
- CONTRIBUTING clone command; SECURITY advisory link; NOTICE byline;
  RELEASING source-of-truth URL and the trusted-publisher owner (which must be
  literal — OIDC does not follow the rename redirect).
- CODEOWNERS default owner.
- pyproject `[project.urls]` — namespace and repository name.
- Installer headers in aether_agent/install.{sh,ps1}.

Also corrected two things the link sweep surfaced:
- CHANGELOG's link definitions referenced `v0.1.0`, a tag that does not exist;
  both were 404. The released tag is `v0.2.0`, which is the version the
  changelog's newest section documents.
- CITATION.cff still declared version 0.1.0 dated 2026-06-02. The published
  release is 0.2.0, dated 2026-08-13 per the changelog. GitHub's "Cite this
  repository" button reads this file directly.
- Both installers ran `pip install --upgrade aether-context`, which cannot
  succeed: there is no `aether-context` project on PyPI (verified 404 on the
  PyPI JSON API), so the advertised one-command install was a no-op that left
  the user without the tool. They now install from the canonical repository,
  with a comment to switch back after the first PyPI release.

Verified after the change: both changelog links, the advisory link, the raw
installer URLs, and the stars badge all resolve. `sh -n` passes on install.sh.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
