### PR TITLE
docs: name the TypeScript terminal aether-agents, not aether-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ aether-context run "..." --no-mpo-chain                      # disable for one r
 The same install ships a second command — **`aether`** — an open-source agentic **coding terminal**
 running on the Unlimited Context engine. It's **local-first**: turns run on your local **[Ollama](https://ollama.com)**
 by default (no account, no network); sign in and they switch to the **Aether cloud API**. It's the
-Python-native twin of [`aether-code`](https://github.com/AetherAI3/aether-agent) (the TypeScript terminal)
-— same commands, same backend, same tools.
+Python-native twin of [Aether Agent](https://github.com/AetherAI3/aether-agent) — the TypeScript terminal,
+published on npm as [`aether-agents`](https://www.npmjs.com/package/aether-agents) — same commands, same backend, same tools.
 
 | Command | What it does |
 |---|---|


### PR DESCRIPTION
The README introduced Aether Agent as `aether-code` in code formatting. That
reads as a package name, and `aether-code` on npm is an unrelated third
party's package (maintainer `rivendaddy`, repo `dannyphantomx64/aether-code`),
not ours. A reader who typed what the code span showed would install a
stranger's agent.

Aether's terminal is published as `aether-agents` (npm maintainer
`ather-ai-llc`, the same package the aether-agent README installs). Name it by
its product name, link the repository, and state the npm package explicitly so
there is one unambiguous thing to install.

`aether-code` remains as an internal codename in source comments and older
plan documents — that is repository history, not a public install instruction,
and is out of scope here.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)