### PR TITLE
feat(release): publish aether-context to PyPI and npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,27 @@ jobs:
       - name: Bench smoke (hermetic mock model)
         run: python bench/drift_vs_window.py --model mock --quick
 
+  npm-launcher:
+    name: npm launcher
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/npm-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # The launcher ships as plain CommonJS with no build step, so `node --check` is the whole
+      # compile stage: a syntax error here would otherwise only surface on a user's first run.
+      - name: Syntax check
+        run: node --check bin/aether-context.js
+      # Proves `files` and `bin` agree with what is on disk before the tarball ever reaches npm.
+      - name: Pack and list the tarball
+        run: |
+          npm pack --silent
+          tar -tzf aether-context-*.tgz
+
   numpy-matrix:
     name: numpy ${{ matrix.numpy }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,129 @@
+name: publish (npm)
+
+# Publish the `aether-context` npm launcher (packages/npm-cli) to the npm registry.
+#
+# The launcher is a thin Node shim: it finds a Python interpreter, builds a private virtualenv,
+# and installs the matching `aether-context` release from PyPI. So it is only publishable *after*
+# that PyPI release exists — the preflight below refuses to ship a launcher whose pin points at
+# a version nobody can install.
+#
+# One-time setup, done by a maintainer:
+#   1. Create the `npm-production` environment in this repo's settings.
+#   2. Add an npm automation token as the `NPM_TOKEN` secret in that environment
+#      (npmjs.com -> Access Tokens -> Generate -> Automation).
+#   3. Run this workflow from the Actions tab.
+#
+# `--provenance` publishes a signed attestation linking the tarball to this workflow run, which
+# needs `id-token: write` and a `repository` field in package.json matching this repo.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag (or branch) to publish, e.g. v0.3.0"
+        required: true
+        default: main
+      dry_run:
+        description: "Pack and verify without publishing"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: pack + publish to npm
+    runs-on: ubuntu-latest
+    environment: npm-production
+    permissions:
+      id-token: write # provenance attestation
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/npm-cli
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Syntax-check the launcher
+        run: node --check bin/aether-context.js
+
+      # The launcher's version IS the version it installs from PyPI, so a drift between the two
+      # is the one defect that breaks every first run. Checked here as well as in the test suite
+      # because this job can be dispatched against any ref.
+      - name: Assert version parity with the Python package
+        working-directory: .
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+
+          npm = json.loads(pathlib.Path("packages/npm-cli/package.json").read_text())["version"]
+          init = pathlib.Path("aether_context/__init__.py").read_text()
+          py = re.search(r'__version__ = "([^"]+)"', init).group(1)
+          if npm != py:
+              sys.exit(f"version drift: npm {npm} != aether_context {py}")
+          print(f"version parity: {npm}")
+          PY
+
+      # A launcher pinned to a release that is not on PyPI installs nothing on first run. Publish
+      # the Python package first; this step is what stops the two registries drifting apart.
+      - name: Require the pinned PyPI release to exist
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+          import sys
+          import urllib.error
+          import urllib.request
+
+          version = json.loads(pathlib.Path("package.json").read_text())["version"]
+          url = f"https://pypi.org/pypi/aether-context/{version}/json"
+          try:
+              with urllib.request.urlopen(url, timeout=30) as response:
+                  json.load(response)
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  sys.exit(
+                      f"aether-context {version} is not on PyPI yet. Run the `publish (pypi)` "
+                      "workflow first — this launcher pins that exact version."
+                  )
+              raise
+          print(f"aether-context {version} is on PyPI")
+          PY
+
+      - name: Pack the tarball
+        id: pack
+        run: |
+          tarball="$(npm pack --silent)"
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+          tar -tzf "$tarball"
+
+      - name: Require an npm publishing credential
+        if: ${{ !inputs.dry_run }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: test -n "$NODE_AUTH_TOKEN" || {
+          echo "NPM_TOKEN is not set in the npm-production environment"; exit 1; }
+
+      - name: Publish to npm
+        if: ${{ !inputs.dry_run }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: echo "dry run: packed ${{ steps.pack.outputs.tarball }} without publishing"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,30 @@
-name: publish
+name: publish (pypi)
 
-# Publish to PyPI via OIDC Trusted Publishing (no API token stored in the repo).
+# Publish `aether-context` to PyPI via OIDC Trusted Publishing (no API token in the repo).
 #
-# DORMANT — run this manually, on purpose, and only once a PyPI trusted publisher
-# exists for this repository. There is currently no `aether-context` project on
-# PyPI and no publisher configured, so this job cannot succeed: it fails at the
-# OIDC exchange with `invalid-publisher`.
+# Manual on purpose. Tagging and publishing are separate decisions: a release tag that fails to
+# publish used to leave a red X on an otherwise green repo while nothing shipped.
 #
-# It used to run on `push: tags: v*`, which meant every release tag produced a
-# red X on an otherwise green repo while nothing was ever published. Tagging and
-# publishing are now separate decisions, so cutting a release no longer pretends
-# to ship a package.
+# One-time setup, done by a maintainer on PyPI (https://pypi.org/manage/account/publishing/):
+#   Add a *pending* publisher (the project does not exist there yet) with
+#     owner        AetherAI3
+#     repository   Unlimited-Context-LLM
+#     workflow     publish.yml
+#     environment  pypi-production
+#   All four are matched literally. OIDC does not follow the DBarr3 -> AetherAI3 transfer
+#   redirect, and the environment below must match the registered one exactly — the same
+#   `pypi-production` the sibling `aether-agent` and `agent-browser` repos already use.
 #
-# To enable publishing later:
-#   1. On PyPI add a *pending* publisher (the project does not exist yet) with
-#      owner `AetherAI3`, repository `Unlimited-Context-LLM`, workflow
-#      `publish.yml`, environment `pypi`. All four are matched literally — OIDC
-#      does not follow the DBarr3 -> AetherAI3 transfer redirect.
-#   2. Run this workflow from the Actions tab against the release tag.
-#   3. Once it succeeds, restoring the `push: tags: v*` trigger is safe.
+# Then create the `pypi-production` environment in this repo's settings and run this workflow
+# from the Actions tab against the release tag. Publish PyPI BEFORE npm: the npm launcher pins
+# `aether-context==<its own version>` and its first run fails until that version exists here.
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Tag to build and publish, e.g. v0.2.0"
+        description: "Tag (or branch) to build and publish, e.g. v0.3.0"
         required: true
+        default: main
 
 permissions:
   contents: read
@@ -33,21 +33,47 @@ jobs:
   publish:
     name: build + publish to PyPI
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: pypi-production
     permissions:
       id-token: write # OIDC token for Trusted Publishing
       contents: read
     steps:
       - uses: actions/checkout@v4
         with:
-          # Build the tag that was asked for, not the default branch.
+          # Build the ref that was asked for, not the default branch.
           ref: ${{ inputs.ref }}
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
       - name: Install build backend
-        run: python -m pip install build
+        run: python -m pip install build twine
+
       - name: Build sdist + wheel
         run: python -m build
+
+      # The collision this guard exists for: PyPI's `aether-agent` distribution already owns the
+      # `aether_agent` import path and the `aether` console script. `aether_agent/` still lives
+      # in this repo, so a packaging change that put it back into `packages` would ship a second
+      # copy that silently overwrites the other package's files wherever both are installed.
+      - name: Assert the wheel ships only aether_context
+        run: |
+          python - <<'PY'
+          import glob
+          import sys
+          import zipfile
+
+          wheel = glob.glob("dist/*.whl")[0]
+          names = zipfile.ZipFile(wheel).namelist()
+          intruders = sorted(n for n in names if n.startswith("aether_agent"))
+          if intruders:
+              sys.exit(f"{wheel} must not contain aether_agent files: {intruders[:5]}")
+          print(f"{wheel}: clean ({len(names)} files, aether_context only)")
+          PY
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*
+
       - name: Publish to PyPI (OIDC Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ pool_on_chain/
 # throwaway live-run wrapper (handles local TLS proxy; reads key from env)
 _run_eval_live.py
 runs/
+
+# Node (npm launcher)
+node_modules/
+*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ All notable changes to `aether-context` are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-09-03
+
+First release published to a package registry: PyPI as `aether-context`, npm as `aether-context`.
+
+### Added
+- **`aether-context setup`** — the guided first run, in three steps: size the pool, check for a
+  local model, then verify the engine with a real encode/retrieve round trip. The verification
+  runs against the mock model in a throwaway directory, so it passes with no daemon, no network
+  and no model pulled, and leaves the pool you just configured empty. `--pool N --yes` makes the
+  whole command non-interactive, so it is safe in a Dockerfile or a CI step.
+- **npm launcher** (`packages/npm-cli`, published as `aether-context`). `npx aether-context`
+  finds a Python 3.10+ interpreter, builds a private virtualenv under the OS cache directory,
+  installs the matching PyPI release into it, and forwards every argument through. Nothing is
+  written to global `site-packages` and nothing needs `sudo`. Zero npm dependencies.
+- `aether_context.ui` — the CLI's presentation seam (stdlib only; the core stays numpy-only).
+  Color is emitted only to a real tty and obeys `NO_COLOR`/`FORCE_COLOR`/`TERM=dumb`; VT100 mode
+  is enabled explicitly on Windows and styling is dropped if that fails. Box-drawing and glyphs
+  degrade to ASCII — prose included — when the stream's encoding cannot represent them, so a
+  `cp1252` console gets readable text instead of `?` characters or a `UnicodeEncodeError`.
+- `publish (npm)` workflow, and a preflight that refuses to publish a launcher whose pinned
+  release is not yet on PyPI.
+
+### Changed
+- **The distribution now ships `aether_context` only.** `aether_agent/` stays in the repo and in
+  the test suite, but is no longer packaged, and the `aether` / `aether-smoke` console scripts
+  are gone from this distribution. PyPI's `aether-agent` already owns that import path and the
+  `aether` command; pip does not detect file conflicts across distributions, so shipping a second
+  copy would have silently overwritten the other package's files wherever both were installed.
+  Install the terminal from its own package: `pip install aether-agent` or
+  `npm install -g aether-agents`.
+- The version is declared once, in `aether_context.__version__`, and read dynamically by the
+  build. A release-parity test pins the npm launcher's version to it.
+- `init`, `doctor` and `status` render through the new presentation seam. The `status` column
+  layout and the doctor's `[ok]`/`[warn]`/`[fail]`/`[skip]` bracket text are unchanged — both are
+  scraped by scripts — and the slice meter is appended after the counts rather than replacing them.
+- `publish (pypi)` builds an sdist and a wheel, asserts the wheel contains no `aether_agent`
+  files, and runs `twine check` before uploading. Its environment is now `pypi-production`,
+  matching the sibling `aether-agent` and `agent-browser` repos.
+- README: corrected the install instructions, and the claim that this package ships the `aether`
+  command.
+
 ## [0.2.0] — 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ aether-context run "..." --no-mpo-chain                      # disable for one r
 
 | Command | What it's for |
 |---|---|
+| `aether-context setup` | **Start here.** Guided first run: size the pool, check your model, verify the engine. |
 | `aether-context init` | Pick your pool size — the on-disk storage slider — on first run. |
 | `aether-context run "<task>" --no-mpo-chain` | Run with the MPO context chain disabled (plain cosine). |
 | `aether-context run "<task>"` | One-shot a task with full reach, then print the result. |
@@ -265,11 +266,21 @@ aether-context run "..." --no-mpo-chain                      # disable for one r
 
 ## The `aether` coding terminal
 
-The same install ships a second command — **`aether`** — an open-source agentic **coding terminal**
-running on the Unlimited Context engine. It's **local-first**: turns run on your local **[Ollama](https://ollama.com)**
-by default (no account, no network); sign in and they switch to the **Aether cloud API**. It's the
-Python-native twin of [Aether Agent](https://github.com/AetherAI3/aether-agent) — the TypeScript terminal,
-published on npm as [`aether-agents`](https://www.npmjs.com/package/aether-agents) — same commands, same backend, same tools.
+**`aether`** is an open-source agentic **coding terminal** that runs on the Unlimited Context
+engine. It's **local-first**: turns run on your local **[Ollama](https://ollama.com)** by default
+(no account, no network); sign in and they switch to the **Aether cloud API**.
+
+It ships as its own package, not as part of `aether-context`:
+
+```bash
+pip install aether-agent      # or: npm install -g aether-agents
+```
+
+Source lives at [AetherAI3/aether-agent](https://github.com/AetherAI3/aether-agent). The
+`aether_agent/` directory in *this* repo is the Python-native twin — same commands, same backend,
+same tools — kept here for development, and deliberately **not** published from this package:
+PyPI's `aether-agent` already owns that import path and the `aether` command, so shipping a
+second copy would silently overwrite it wherever both are installed.
 
 | Command | What it does |
 |---|---|
@@ -287,18 +298,39 @@ published on npm as [`aether-agents`](https://www.npmjs.com/package/aether-agent
 
 **Backend** — `local` (the default) runs every turn on your own Ollama; nothing leaves your machine and no account is needed. Opt into the hosted Aether API with `aether config set backend auto|cloud` (or `AETHER_BACKEND=auto`) plus `aether auth login` — `auto` uses the cloud only when you're signed in and falls back to local otherwise. The hosted API is the maintainer's own instance, so a fresh clone never calls it.
 
-**Smoke test** — with Ollama up, `python -m aether_agent.smoke` (or `aether-smoke`) runs the SSRF guard, a real local turn, a web search + fetch, and the cloud path (when signed in), printing `PASS`/`SKIP`/`FAIL` (exit non-zero only on a real failure — missing Ollama/network/sign-in are skips).
+**Smoke test** — from a clone of this repo, with Ollama up, `python -m aether_agent.smoke` runs the SSRF guard, a real local turn, a web search + fetch, and the cloud path (when signed in), printing `PASS`/`SKIP`/`FAIL` (exit non-zero only on a real failure — missing Ollama/network/sign-in are skips).
 
 ## Quickstart
 
 ```bash
-# Install straight from GitHub — works today, always the latest:
+pip install aether-context
+aether-context setup
+```
+
+Prefer npm? Same software, same release — the npm package is a launcher that installs the
+Python engine into a private virtualenv for you (it needs Python 3.10+ on your PATH):
+
+```bash
+npx aether-context setup
+```
+
+`setup` sizes the pool, checks for a local model, and verifies the engine end to end. It works
+with no daemon, no network and no model pulled — the check runs against the built-in mock model.
+
+<details>
+<summary>Other install routes</summary>
+
+```bash
+# Straight from source, always the latest main:
 pip install git+https://github.com/AetherAI3/Unlimited-Context-LLM.git
 
-# From PyPI, once published — the package name is "aether-context"
-# (note: `pip install unlimited-context` is NOT the package name):
-pip install aether-context
+# Isolated, if you only want the CLI:
+pipx install aether-context
 ```
+
+The distribution name is **`aether-context`** — `pip install unlimited-context` is not this
+package.
+</details>
 
 ```python
 from aether_context import Session

--- a/aether_context/__init__.py
+++ b/aether_context/__init__.py
@@ -24,6 +24,6 @@ Public surface (intentionally tiny):
 from aether_context.local_llm import load_model
 from aether_context.session import Session
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = ["Session", "load_model", "__version__"]

--- a/aether_context/cli.py
+++ b/aether_context/cli.py
@@ -9,6 +9,11 @@ contains engine logic; it wires argparse to :mod:`aether_context.config`, the Ol
 
 Commands
 --------
+``aether-context setup [--pool N] [--model M] [--dir D] [--yes]``
+    The guided first run: size the pool, check the local model, and verify the engine end to
+    end in a throwaway directory. Same non-tty discipline as ``init`` — with ``--pool``/``--yes``
+    it is a single non-interactive command, so it is safe in a Dockerfile or a CI step.
+
 ``aether-context init [--pool N] [--dir D]``
     Initialize / re-initialize the pool config. **Non-tty safe** (build plan §12 CRITICAL):
     the interactive slider only runs when stdin is a real tty; otherwise the size comes from
@@ -55,6 +60,7 @@ from aether_context.config import (
 )
 from aether_context.errors import AetherContextError, PoolBudgetError
 from aether_context.session import Session
+from aether_context.ui import Console
 
 #: Environment variable read for the pool size when no ``--pool`` flag is given (non-tty).
 _ENV_POOL_GB = "AETHER_POOL_GB"
@@ -68,6 +74,18 @@ _DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 _INDEX_MB_PER_GB = 29
 #: Short timeout (s) for the doctor's reachability probe — fail fast, stay offline-friendly.
 _PROBE_TIMEOUT = 2.0
+#: Suggested first model for `setup` — small enough to pull on a laptop, good enough to be useful.
+_SUGGESTED_MODEL = "qwen2.5"
+
+
+def _ui(stream: Any = None) -> Console:
+    """A :class:`Console` bound to the *current* ``sys.stdout`` (or ``stream``).
+
+    Built per call rather than once at import because the stream is swapped underneath us —
+    by pytest's ``capsys``, by a shell pipe, by a redirect — and the color/unicode decision has
+    to describe where the text is actually going.
+    """
+    return Console(stream if stream is not None else sys.stdout)
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +117,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     subparsers = parser.add_subparsers(dest="command")
+
+    p_setup = subparsers.add_parser(
+        "setup", help="guided first run: size the pool, check the model, verify the engine."
+    )
+    p_setup.add_argument("--pool", type=int, default=None, metavar="N", help="pool size in GB (>=5).")
+    p_setup.add_argument("--dir", type=str, default=None, metavar="D", help="pool directory.")
+    p_setup.add_argument(
+        "--model", type=str, default=None, metavar="M",
+        help=f"local model to check for (default: {_SUGGESTED_MODEL}).",
+    )
+    p_setup.add_argument(
+        "--yes", action="store_true",
+        help="take the defaults without prompting (for scripts, Dockerfiles, CI).",
+    )
+    p_setup.add_argument("--host", type=str, default=None, metavar="URL", help="Ollama host.")
 
     p_init = subparsers.add_parser(
         "init", help="initialize the pool (interactive slider on a tty; else --pool/env/5GB)."
@@ -198,6 +231,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        if args.command == "setup":
+            return _cmd_setup(args)
         if args.command == "init":
             return _cmd_init(args)
         if args.command == "doctor":
@@ -215,13 +250,124 @@ def main(argv: Sequence[str] | None = None) -> int:
         # no subcommand: a top-level --pool is a resize; otherwise show help.
         if args.pool is not None:
             return _cmd_resize(args)
+        ui = _ui()
+        ui.banner("Unlimited Context", f"aether-context {__version__}")
+        ui.line()
+        ui.line("  New here? One command sets everything up:")
+        ui.command("aether-context setup")
+        ui.line()
         parser.print_help()
         return 0
     except AetherContextError as exc:
         # typed, hinted failure: render it cleanly (never a traceback to the user).
-        print(f"error: {exc.message}", file=sys.stderr)
-        print(f"  fix: {exc.hint}", file=sys.stderr)
+        err = _ui(sys.stderr)
+        err.line(f"{err.glyph('fail')} {err.style('error:', 'bold', 'red')} {exc.message}")
+        err.line(f"  {err.style('fix:', 'dim')} {err.style(exc.hint, 'bold')}")
         return 1
+
+
+# ---------------------------------------------------------------------------
+# setup — the guided first run.
+# ---------------------------------------------------------------------------
+def _cmd_setup(args: argparse.Namespace) -> int:
+    """Walk a new install through pool sizing, the model check, and an end-to-end verify.
+
+    Three steps, in the order things actually go wrong:
+
+    1. **Pool** — the one number the user has to choose. Same resolution order as ``init``
+       (flag → tty slider → ``$AETHER_POOL_GB`` → floor), so ``--pool``/``--yes`` makes this
+       whole command non-interactive and it never blocks on a pipe.
+    2. **Model** — reachability of the local daemon, reported but *not* fatal: the engine runs
+       offline against the mock model, and saying otherwise would be a lie that sends people
+       hunting for a daemon they do not need yet.
+    3. **Verify** — a real encode/retrieve round trip. Run against a throwaway directory, not
+       the pool just configured, so a successful setup leaves a genuinely empty pool behind.
+
+    Returns 0 when the pool is configured and the engine verified; 1 if either failed. A
+    missing local model is a warning and does not change the exit code.
+    """
+    ui = _ui()
+    pool_dir = _resolve_dir(args.dir)
+
+    ui.banner("Unlimited Context", f"aether-context {__version__}")
+    ui.line()
+    ui.note("Virtual memory for an LLM's attention — local-first, numpy-only core.")
+    ui.note(f"Pool directory: {pool_dir}")
+
+    # --- 1. pool ---------------------------------------------------------------------
+    ui.step(1, 3, "Pool size")
+    ui.note("The pool is local DISK reserved for context reach. Resize any time.")
+    pool_gb = _resolve_pool_gb(getattr(args, "pool", None), pool_dir, assume_yes=args.yes)
+    _check_disk_for_pool(pool_gb, pool_dir)
+    cfg = _write_config(pool_dir, pool_gb)
+    reach = reach_tokens(cfg.pool_gb)
+    ui.check("ok", f"pool configured at {cfg.dir}")
+    ui.field("size:", f"{cfg.pool_gb} GB")
+    ui.field("reach:", f"~{reach / 1e9:.2f}B tokens")
+    ui.field("index:", f"{cfg.index}   dim {cfg.dim}   slice {cfg.slice_tokens} tok")
+    free = free_disk_bytes(pool_dir)
+    if free is not None:
+        # Just the number: a pool is typically a low single-digit percentage of a modern disk,
+        # so a meter here would sit at zero bars and read as broken rather than as reassuring.
+        ui.field("disk:", f"{free / BYTES_PER_GB:.1f} GB free")
+
+    # --- 2. model --------------------------------------------------------------------
+    ui.step(2, 3, "Local model")
+    host = _resolve_host(args.host)
+    model = args.model or _SUGGESTED_MODEL
+    reachable = _probe_ollama(host)
+    if not reachable:
+        ui.check(
+            "warn", f"no Ollama daemon at {host}",
+            "install from https://ollama.com, then `ollama serve`",
+        )
+        ui.note("Not a blocker — everything below runs offline against the mock model.")
+    elif _model_is_pulled(host, model):
+        ui.check("ok", f"model '{model}' is pulled and ready at {host}")
+    else:
+        ui.check("warn", f"model '{model}' is not pulled", f"ollama pull {model}")
+
+    # --- 3. verify -------------------------------------------------------------------
+    ui.step(3, 3, "Verify the engine")
+    ok = _verify_engine(ui)
+
+    # --- next steps ------------------------------------------------------------------
+    ui.heading("You're ready")
+    if reachable:
+        ui.command(f"aether-context chat --model ollama/{model}", "talk to your local model")
+    else:
+        ui.command("aether-context chat --model mock", "works offline, right now")
+    ui.command("aether-context run \"summarize this repo\"", "one-shot task")
+    ui.command("aether-context status", "pool, reach, hit rate")
+    ui.command("aether-context doctor", "diagnose anything that breaks")
+    ui.line()
+    return 0 if ok else 1
+
+
+def _verify_engine(ui: Console) -> bool:
+    """Prove the install works: one real run through a Session in a throwaway pool.
+
+    Deliberately uses the mock model and a temporary directory — this has to pass with no
+    daemon, no network and no model pulled, and it must not leave slices in the pool the user
+    just sized. A failure here is the one thing in ``setup`` that is genuinely broken, so it
+    reports the exception message rather than a cheerful guess.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="aether-verify-") as tmp:
+        session = None
+        try:
+            session = Session(model=_DEFAULT_MODEL, pool_gb=POOL_GB_FLOOR, pool_dir=Path(tmp))
+            session.run("verify the aether-context install")
+            used = int(session.status_dict()["slices_used"])
+        except Exception as exc:  # noqa: BLE001 - report any breakage, never traceback at the user
+            ui.check("fail", f"engine check failed: {exc}", "aether-context doctor")
+            return False
+        finally:
+            if session is not None:
+                session.close()
+    ui.check("ok", f"engine round trip passed ({used} slice(s) encoded and retrieved)")
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -238,25 +384,28 @@ def _cmd_init(args: argparse.Namespace) -> int:
     _check_disk_for_pool(pool_gb, pool_dir)  # reject a pool that won't fit on disk
     cfg = _write_config(pool_dir, pool_gb)  # raises PoolBudgetError if < floor
     reach = reach_tokens(cfg.pool_gb)
-    print(f"initialized pool at {cfg.dir}")
-    print(f"  pool size: {cfg.pool_gb} GB  (reach ~= {reach / 1e9:.2f}B tokens)")
-    print(f"  index: {cfg.index}   dim: {cfg.dim}   slice: {cfg.slice_tokens} tok")
+    ui = _ui()
+    ui.check("ok", f"initialized pool at {cfg.dir}")
+    ui.field("pool size:", f"{cfg.pool_gb} GB  (reach ~= {reach / 1e9:.2f}B tokens)")
+    ui.field("index:", f"{cfg.index}   dim: {cfg.dim}   slice: {cfg.slice_tokens} tok")
     free = free_disk_bytes(pool_dir)
     if free is not None:
-        print(f"  disk: {free / BYTES_PER_GB:.1f} GB free at {pool_dir}")
+        ui.field("disk:", f"{free / BYTES_PER_GB:.1f} GB free at {pool_dir}")
+    ui.line()
+    ui.note("Next: `aether-context setup` to check your model and verify the engine.")
     return 0
 
 
-def _resolve_pool_gb(flag: int | None, pool_dir: Path) -> int:
+def _resolve_pool_gb(flag: int | None, pool_dir: Path, *, assume_yes: bool = False) -> int:
     """Resolve the pool size without ever blocking on a non-tty stdin.
 
-    ``flag`` (``--pool``) wins. Else, only if stdin is an interactive tty do we run the slider
-    (which shows free disk and rejects a size that won't fit). Else ``$AETHER_POOL_GB`` if set
-    and numeric. Else the 5 GB default.
+    ``flag`` (``--pool``) wins. Else, only if stdin is an interactive tty — and the caller did
+    not pass ``--yes`` — do we run the slider (which shows free disk and rejects a size that
+    won't fit). Else ``$AETHER_POOL_GB`` if set and numeric. Else the 5 GB default.
     """
     if flag is not None:
         return int(flag)
-    if sys.stdin is not None and sys.stdin.isatty():
+    if not assume_yes and sys.stdin is not None and sys.stdin.isatty():
         return _prompt_pool_gb(pool_dir)
     env = os.environ.get(_ENV_POOL_GB)
     if env is not None and env.strip().isdigit():
@@ -272,30 +421,34 @@ def _prompt_pool_gb(pool_dir: Path) -> int:
     but also when a pick exceeds free disk). Empty input takes the 5 GB default; EOF falls back
     to the default.
     """
+    ui = _ui()
     free = free_disk_bytes(pool_dir)
     free_gb = (free / BYTES_PER_GB) if free is not None else None
-    print("Choose a pool size — this is the local DISK reserved for context reach:")
+    ui.line()
+    ui.line("  Choose a pool size — the local DISK reserved for context reach:")
     if free_gb is not None:
-        print(f"  ({free_gb:.1f} GB free at {pool_dir})")
+        ui.note(f"{free_gb:.1f} GB free at {pool_dir}")
     for gb in (5, 10, 15, 20):
-        warn = "" if (free_gb is None or gb <= free_gb) else "   (won't fit — not enough free disk)"
-        print(f"  {gb:>2} GB  ->  reach ~= {reach_tokens(gb) / 1e9:.2f}B tokens{warn}")
+        fits = free_gb is None or gb <= free_gb
+        reach = f"reach ~= {reach_tokens(gb) / 1e9:.2f}B tokens"
+        label = f"  {ui.glyph('ok' if fits else 'fail')} {gb:>2} GB  {ui.style(reach, 'dim')}"
+        ui.line(label if fits else f"{label} {ui.style(chr(40) + 'not enough free disk)', 'dim')}")
     for _attempt in range(3):
         try:
-            raw = input(f"pool GB [default {POOL_GB_FLOOR}]: ").strip()
+            raw = input(f"  pool GB [{POOL_GB_FLOOR}]: ").strip()
         except EOFError:
             return POOL_GB_FLOOR
         if not raw:
             return POOL_GB_FLOOR
         if not raw.isdigit():
-            print("  enter a whole number of GB (e.g. 5, 10, 20).")
+            ui.note("enter a whole number of GB (e.g. 5, 10, 20).")
             continue
         value = int(raw)
         if value < POOL_GB_FLOOR:
-            print(f"  {value} GB is below the {POOL_GB_FLOOR} GB floor; pick at least {POOL_GB_FLOOR}.")
+            ui.note(f"{value} GB is below the {POOL_GB_FLOOR} GB floor; pick at least {POOL_GB_FLOOR}.")
             continue
         if free_gb is not None and value > free_gb:
-            print(f"  {value} GB won't fit — only {free_gb:.1f} GB free at {pool_dir}. Pick a smaller size.")
+            ui.note(f"{value} GB won't fit — only {free_gb:.1f} GB free at {pool_dir}. Pick smaller.")
             continue
         return value
     return POOL_GB_FLOOR
@@ -430,14 +583,17 @@ def _cmd_status(args: argparse.Namespace) -> int:
     slices, capacity = _pool_counts(cfg)
     reach = reach_tokens(cfg.pool_gb)
     resident_mb = cfg.pool_gb * _INDEX_MB_PER_GB
-    print("aether-context status")
-    print(f"  pool:        {cfg.pool_gb} GB  (reach ~= {reach / 1e9:.2f}B tokens)")
-    print(f"  slices:      {slices} / {capacity}")
-    print(f"  reach:       {reach:,} tokens")
-    print("  hit rate:    N/A (no live session)")
-    print(f"  resident RAM ~= {resident_mb} MB (estimate)")
-    print(f"  pool-mode:   {cfg.mode}")
-    print(f"  index:       {cfg.index}")
+    ui = _ui()
+    ui.heading("aether-context status")
+    fill = (slices / capacity) if capacity else 0.0
+    ui.field("pool:", f"{cfg.pool_gb} GB  (reach ~= {reach / 1e9:.2f}B tokens)")
+    ui.field("slices:", f"{slices} / {capacity}  {ui.bar(fill, slots=16)}")
+    ui.field("reach:", f"{reach:,} tokens")
+    ui.field("hit rate:", "N/A (no live session)")
+    ui.field("resident:", f"~{resident_mb} MB RAM (estimate)")
+    ui.field("pool-mode:", cfg.mode)
+    ui.field("index:", cfg.index)
+    ui.line()
     return 0
 
 
@@ -779,18 +935,22 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     host = _resolve_host(args.host)
     model = args.model
     pool_dir = _resolve_dir(args.dir)
-    print("aether-context doctor")
-    print(f"  ollama host: {host}")
+    ui = _ui()
+    ui.heading("aether-context doctor")
+    ui.note(f"ollama host: {host}")
 
     ok = True
     reachable = _probe_ollama(host)
-    ok = _report_ollama(reachable, host) and ok
-    ok = _report_model(reachable, host, model) and ok
-    ok = _report_disk_vs_pool(pool_dir) and ok
-    ok = _report_ram_vs_index(pool_dir) and ok
+    ok = _report_ollama(ui, reachable, host) and ok
+    ok = _report_model(ui, reachable, host, model) and ok
+    ok = _report_disk_vs_pool(ui, pool_dir) and ok
+    ok = _report_ram_vs_index(ui, pool_dir) and ok
 
-    print("")
-    print("  all good." if ok else "  some checks need attention (see fixes above).")
+    ui.line()
+    if ok:
+        ui.line(f"  {ui.glyph('ok')} {ui.style('all good.', 'bold', 'green')}")
+    else:
+        ui.line(f"  {ui.glyph('warn')} some checks need attention (see fixes above).")
     return 0 if ok else 1
 
 
@@ -814,35 +974,38 @@ def _probe_ollama(host: str) -> bool:
         return False
 
 
-def _report_ollama(reachable: bool, host: str) -> bool:
+def _report_ollama(ui: Console, reachable: bool, host: str) -> bool:
     """Print the Ollama reachability check + its fix command. Returns True iff reachable."""
     if reachable:
-        print(f"  [ok]   ollama daemon reachable at {host}")
+        ui.check("ok", f"ollama daemon reachable at {host}")
         return True
-    print(f"  [fail] ollama daemon not reachable at {host}")
-    print("         fix: start it with `ollama serve`")
+    ui.check("fail", f"ollama daemon not reachable at {host}", "ollama serve")
     return False
 
 
-def _report_model(reachable: bool, host: str, model: str | None) -> bool:
+def _report_model(ui: Console, reachable: bool, host: str, model: str | None) -> bool:
     """Check whether ``model`` is pulled (only meaningful if the daemon is up).
 
     Always prints the exact ``ollama pull <model>`` fix command when a model was named, so the
     user sees the remedy even fully offline.
     """
     if model is None:
-        print("  [skip] no --model given; pass --model qwen2.5 to check a specific model")
+        ui.check("skip", "no --model given; pass --model qwen2.5 to check a specific model")
         return True
     if not reachable:
-        print(f"  [fail] cannot check model '{model}' (daemon down)")
-        print(f"         fix: start ollama then `ollama pull {model}`")
+        ui.check(
+            "fail", f"cannot check model '{model}' (daemon down)",
+            f"start ollama then `ollama pull {model}`",
+        )
         return False
     pulled = _model_is_pulled(host, model)
     if pulled:
-        print(f"  [ok]   model '{model}' is pulled")
+        ui.check("ok", f"model '{model}' is pulled")
         return True
-    print(f"  [fail] model '{model}' is not pulled")
-    print(f"         fix: `ollama pull {model}`  (or Session(model='ollama/{model}', pull=True))")
+    ui.check(
+        "fail", f"model '{model}' is not pulled",
+        f"ollama pull {model}  (or Session(model='ollama/{model}', pull=True))",
+    )
     return False
 
 
@@ -860,24 +1023,26 @@ def _model_is_pulled(host: str, model: str) -> bool:
     return any(n == model or n.split(":", 1)[0] == base for n in names)
 
 
-def _report_disk_vs_pool(pool_dir: Path) -> bool:
+def _report_disk_vs_pool(ui: Console, pool_dir: Path) -> bool:
     """Check free disk against the configured pool size (the pool reserves that much disk)."""
     cfg = PoolConfig.load(pool_dir)
     free = free_disk_bytes(pool_dir)
     if free is None:
-        print(f"  [ok]   {cfg.pool_gb} GB pool — free disk unknown (could not probe)")
+        ui.check("ok", f"{cfg.pool_gb} GB pool — free disk unknown (could not probe)")
         return True
     free_gb = free / BYTES_PER_GB
     if free >= cfg.pool_gb * BYTES_PER_GB:
-        print(f"  [ok]   {cfg.pool_gb} GB pool fits ({free_gb:.1f} GB free at {pool_dir})")
+        ui.check("ok", f"{cfg.pool_gb} GB pool fits ({free_gb:.1f} GB free at {pool_dir})")
         return True
     fits = max(POOL_GB_FLOOR, int(free // BYTES_PER_GB))
-    print(f"  [warn] {cfg.pool_gb} GB pool vs only {free_gb:.1f} GB free at {pool_dir}")
-    print(f"         fix: free up disk, or `aether-context --pool {fits}`")
+    ui.check(
+        "warn", f"{cfg.pool_gb} GB pool vs only {free_gb:.1f} GB free at {pool_dir}",
+        f"free up disk, or `aether-context --pool {fits}`",
+    )
     return False
 
 
-def _report_ram_vs_index(pool_dir: Path) -> bool:
+def _report_ram_vs_index(ui: Console, pool_dir: Path) -> bool:
     """Estimate the index RAM for the configured pool and compare to free system RAM.
 
     Reads the persisted ``PoolConfig`` (or defaults), computes the index RAM from the pool
@@ -889,16 +1054,17 @@ def _report_ram_vs_index(pool_dir: Path) -> bool:
     index_mb = index_bytes / (1024 * 1024)
     free_bytes = _free_ram_bytes()
     if free_bytes is None:
-        print(f"  [ok]   index RAM estimate ~= {index_mb:.0f} MB "
-              f"(free RAM unknown; could not probe)")
+        ui.check("ok", f"index RAM estimate ~= {index_mb:.0f} MB (free RAM unknown; not probed)")
         return True
     free_mb = free_bytes / (1024 * 1024)
     # comfortable = index fits in well under half of free RAM.
     if index_bytes * 2 < free_bytes:
-        print(f"  [ok]   index RAM ~= {index_mb:.0f} MB fits in {free_mb:.0f} MB free")
+        ui.check("ok", f"index RAM ~= {index_mb:.0f} MB fits in {free_mb:.0f} MB free")
         return True
-    print(f"  [warn] index RAM ~= {index_mb:.0f} MB vs only {free_mb:.0f} MB free")
-    print("         fix: use a smaller --pool (a paged 'tiered' index is not built yet)")
+    ui.check(
+        "warn", f"index RAM ~= {index_mb:.0f} MB vs only {free_mb:.0f} MB free",
+        "use a smaller --pool (a paged 'tiered' index is not built yet)",
+    )
     return False
 
 

--- a/aether_context/ui.py
+++ b/aether_context/ui.py
@@ -1,0 +1,253 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Terminal presentation seam for the ``aether-context`` console script.
+
+Stdlib only — the core dependency contract is numpy and nothing else, so there is no
+``rich``/``colorama`` here. This module owns *how* CLI output looks; the commands in
+:mod:`aether_context.cli` own *what* it says.
+
+Three degradations, all decided once at import of the writer and never at each call site:
+
+``color``
+    ANSI is emitted only when the stream is a real tty and the environment does not veto it
+    (``NO_COLOR`` wins over everything, ``FORCE_COLOR`` turns it back on, ``TERM=dumb``
+    disables). On Windows the VT100 mode is switched on explicitly; if that call fails the
+    styling silently falls back to plain text rather than printing escape soup.
+
+``unicode``
+    Box-drawing and glyphs are only used when the stream's encoding can actually represent
+    them. A ``cp1252`` console (still the Windows default for a redirected pipe) gets the
+    ASCII table instead of a ``UnicodeEncodeError``.
+
+``width``
+    Rules and padding follow ``COLUMNS``/the real terminal size, clamped so output stays
+    readable in a 40-column pane and does not sprawl on an ultrawide one.
+
+Because color is off whenever stdout is not a tty, every command's output is plain text under
+pytest, in a pipe, and in CI — so tests assert on words, never on escape sequences.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from typing import IO, Final
+
+#: Rules and headers never render narrower/wider than this, whatever the terminal reports.
+_MIN_WIDTH: Final = 40
+_MAX_WIDTH: Final = 78
+
+# --- ANSI SGR codes ---------------------------------------------------------------------
+_RESET: Final = "\033[0m"
+_CODES: Final[dict[str, str]] = {
+    "bold": "\033[1m",
+    "dim": "\033[2m",
+    "cyan": "\033[36m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "red": "\033[31m",
+    "blue": "\033[34m",
+}
+
+#: Status markers. The bracket text is load-bearing: `doctor` has always reported `[ok]` /
+#: `[fail]` / `[skip]`, scripts grep for it, and the suite asserts on it — so color and glyphs
+#: decorate that text, they never replace it.
+_MARKS: Final[dict[str, tuple[str, str, str]]] = {
+    # key: (unicode glyph, ascii glyph, color)
+    "ok": ("✓", "+", "green"),
+    "warn": ("△", "!", "yellow"),
+    "fail": ("✗", "x", "red"),
+    "skip": ("·", "-", "dim"),
+}
+
+
+class Console:
+    """A styled writer bound to one stream, with its capabilities resolved once.
+
+    Construct with the stream you intend to write to (``sys.stdout`` for reports,
+    ``sys.stderr`` for errors) so the capability probe matches the destination: piping stdout
+    to a file must not strip color from an error still going to the terminal.
+    """
+
+    def __init__(self, stream: IO[str] | None = None) -> None:
+        self.stream: IO[str] = stream if stream is not None else sys.stdout
+        self.color: bool = _supports_color(self.stream)
+        self.unicode: bool = _supports_unicode(self.stream)
+        self.width: int = _terminal_width()
+
+    # --- primitives ---------------------------------------------------------------------
+    def style(self, text: str, *names: str) -> str:
+        """Wrap ``text`` in the named SGR styles, or return it unchanged when color is off."""
+        if not self.color or not names:
+            return text
+        codes = "".join(_CODES[n] for n in names if n in _CODES)
+        return f"{codes}{text}{_RESET}" if codes else text
+
+    def line(self, text: str = "") -> None:
+        """Write one line to the bound stream, folded to ASCII when the stream can't encode.
+
+        Every command's output funnels through here, so the fold covers prose too — not just
+        the box-drawing set. Without it a ``cp1252`` pipe turns each em dash in a sentence into
+        a ``?``, which looks like a bug in the tool rather than a limitation of the console.
+        """
+        print(_ascii_fold(text) if not self.unicode else text, file=self.stream)
+
+    def glyph(self, kind: str) -> str:
+        """The bare status glyph for ``kind`` (``ok``/``warn``/``fail``/``skip``)."""
+        uni, ascii_, color = _MARKS[kind]
+        return self.style(uni if self.unicode else ascii_, color)
+
+    # --- composed output ----------------------------------------------------------------
+    def banner(self, title: str, subtitle: str = "") -> None:
+        """The product wordmark: a boxed title with an optional subtitle beneath it."""
+        inner = min(self.width, _MAX_WIDTH) - 2
+        if self.unicode:
+            top, bottom, side = "╭" + "─" * inner + "╮", \
+                "╰" + "─" * inner + "╯", "│"
+        else:
+            top = bottom = "+" + "-" * inner + "+"
+            side = "|"
+        self.line(self.style(top, "cyan"))
+        self.line(
+            self.style(side, "cyan")
+            + self.style(title.center(inner), "bold", "cyan")
+            + self.style(side, "cyan")
+        )
+        if subtitle:
+            self.line(
+                self.style(side, "cyan")
+                + self.style(subtitle.center(inner), "dim")
+                + self.style(side, "cyan")
+            )
+        self.line(self.style(bottom, "cyan"))
+
+    def heading(self, text: str) -> None:
+        """A section header: a blank line, then the title, then a rule the same width."""
+        self.line()
+        self.line(self.style(text, "bold"))
+        char = "─" if self.unicode else "-"
+        self.line(self.style(char * min(len(text), self.width), "dim"))
+
+    def field(self, label: str, value: str, *, pad: int = 12) -> None:
+        """An indented ``label   value`` row, labels left-aligned to a common column."""
+        self.line(f"  {self.style(label.ljust(pad), 'dim')} {value}")
+
+    def check(self, kind: str, text: str, fix: str = "") -> None:
+        """One diagnostic row — ``glyph [kind] text`` — plus an optional indented fix line.
+
+        ``kind`` is one of ``ok``/``warn``/``fail``/``skip`` and is printed literally inside
+        the brackets, which is the contract the doctor's output has always had.
+        """
+        self.line(f"  {self.glyph(kind)} [{kind}] {text}")
+        if fix:
+            self.line(f"        {self.style('fix:', 'dim')} {self.style(fix, 'bold')}")
+
+    def step(self, index: int, total: int, text: str) -> None:
+        """A numbered wizard step header, e.g. ``[1/3] Pool size``."""
+        self.line()
+        self.line(f"{self.style(f'[{index}/{total}]', 'cyan')} {self.style(text, 'bold')}")
+
+    def note(self, text: str) -> None:
+        """A dimmed aside — context the user can skim past."""
+        self.line(self.style(f"  {text}", "dim"))
+
+    def command(self, text: str, comment: str = "") -> None:
+        """A copy-pasteable command line, optionally trailed by a dimmed comment."""
+        tail = f"   {self.style('# ' + comment, 'dim')}" if comment else ""
+        self.line(f"  {self.style(text, 'bold', 'cyan')}{tail}")
+
+    def bar(self, fraction: float, slots: int = 24) -> str:
+        """A fixed-width meter for ``fraction`` in [0, 1], as a string (never printed)."""
+        fraction = max(0.0, min(1.0, fraction))
+        filled = round(fraction * slots)
+        full, empty = ("█", "░") if self.unicode else ("#", ".")
+        return self.style(full * filled, "cyan") + self.style(empty * (slots - filled), "dim")
+
+
+# --- text folding ---------------------------------------------------------------------------
+#: Typographic characters used in CLI prose, mapped to their ASCII equivalents.
+_FOLD: Final[dict[int, str]] = str.maketrans({
+    "—": "-", "–": "-", "≈": "~", "→": "->", "·": "-", "…": "...",
+    "“": '"', "”": '"', "‘": "'", "’": "'", "×": "x",
+})
+
+
+def _ascii_fold(text: str) -> str:
+    """Replace typographic characters with ASCII, dropping anything still unrepresentable.
+
+    The translation table covers what the CLI's own prose uses; the final pass is a backstop
+    for interpolated values (a path, a model name, an exception message) that could carry
+    anything at all.
+    """
+    folded = text.translate(_FOLD)
+    return folded.encode("ascii", "replace").decode("ascii")
+
+
+# --- capability probes ----------------------------------------------------------------------
+def _supports_color(stream: IO[str]) -> bool:
+    """Decide whether to emit ANSI on ``stream``.
+
+    ``NO_COLOR`` (any value, per no-color.org) disables unconditionally; ``FORCE_COLOR``
+    re-enables it even off a tty, which is how CI logs keep their color. Otherwise color needs
+    a real tty, a terminal that is not ``dumb``, and — on Windows — a console that accepts the
+    VT100 mode switch.
+    """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    if os.environ.get("TERM") == "dumb":
+        return False
+    try:
+        if not stream.isatty():
+            return False
+    except (AttributeError, ValueError):  # detached/closed stream
+        return False
+    if sys.platform == "win32":
+        return _enable_windows_vt()
+    return True
+
+
+def _enable_windows_vt() -> bool:
+    """Turn on VT100 processing for the Windows console. False if it cannot be enabled.
+
+    Windows Terminal and conhost on Windows 10+ support ANSI once
+    ``ENABLE_VIRTUAL_TERMINAL_PROCESSING`` is set on the output handle. Older consoles reject
+    the flag, and we would rather print clean text than raw escape bytes.
+    """
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        mode = ctypes.c_uint32()
+        if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            return False
+        return bool(kernel32.SetConsoleMode(handle, mode.value | 0x0004))
+    except Exception:  # noqa: BLE001 - any failure here just means "no color"
+        return False
+
+
+def _supports_unicode(stream: IO[str]) -> bool:
+    """True when ``stream``'s encoding can represent the box-drawing/glyph set.
+
+    Probed by actually encoding the widest character we use. A Windows console still running
+    ``cp1252`` fails here and gets the ASCII table, instead of raising ``UnicodeEncodeError``
+    in the middle of a report.
+    """
+    encoding = getattr(stream, "encoding", None) or "ascii"
+    try:
+        "─╭✓█".encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
+def _terminal_width() -> int:
+    """The usable output width, clamped to a readable range."""
+    try:
+        columns = shutil.get_terminal_size().columns
+    except (OSError, ValueError):
+        columns = _MAX_WIDTH
+    return max(_MIN_WIDTH, min(columns, _MAX_WIDTH))

--- a/packages/npm-cli/LICENSE
+++ b/packages/npm-cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Aether
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/npm-cli/README.md
+++ b/packages/npm-cli/README.md
@@ -1,0 +1,68 @@
+# aether-context (npm)
+
+**Unlimited Context — virtual memory for an LLM's attention.** Local-first, numpy-only core.
+
+This is the npm launcher. The engine itself is Python; this package exists so that
+`npx aether-context` works without you thinking about `pip` first.
+
+```bash
+npx aether-context setup
+```
+
+That single command sizes the local pool, checks for a local model, and verifies the engine
+end to end. It works with no daemon, no network and no model pulled — the verification runs
+against the built-in mock model.
+
+## Install
+
+```bash
+npm install -g aether-context
+```
+
+Or run it without installing:
+
+```bash
+npx aether-context --help
+```
+
+## Requirements
+
+**Python 3.10 or newer** on your PATH. The launcher does not bundle an interpreter; it finds
+one, then creates a private virtualenv in your OS cache directory and installs the matching
+`aether-context` release from PyPI into it. Your global `site-packages` is never touched and
+nothing needs `sudo`.
+
+If Python is missing or too old, the launcher says so and points at the fix rather than failing
+with a stack trace.
+
+## Commands
+
+```bash
+aether-context setup                 # guided first run
+aether-context chat --model mock     # interactive REPL, works offline
+aether-context run "your task"       # one-shot
+aether-context status                # pool, reach, hit rate
+aether-context doctor                # diagnose Ollama / disk / RAM
+```
+
+## Environment
+
+| Variable | Effect |
+| --- | --- |
+| `AETHER_CONTEXT_PYTHON` | Interpreter to use, skipping the PATH search. |
+| `AETHER_CONTEXT_VERSION` | Release to install (`latest` for the newest). Defaults to this package's own version. |
+| `AETHER_CONTEXT_HOME` | Where the private virtualenv lives. |
+
+## Prefer pip?
+
+The Python package is the same software, published from the same commit:
+
+```bash
+pip install aether-context
+```
+
+## Links
+
+- Source: <https://github.com/AetherAI3/Unlimited-Context-LLM>
+- PyPI: <https://pypi.org/project/aether-context/>
+- License: Apache-2.0

--- a/packages/npm-cli/bin/aether-context.js
+++ b/packages/npm-cli/bin/aether-context.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// aether-context (Unlimited Context)
+// Copyright (c) 2026 Aether AI
+// SPDX-License-Identifier: Apache-2.0
+//
+// npm launcher for the `aether-context` Python package.
+//
+// The engine is Python (numpy-only core), so this package does not reimplement it — it makes
+// `npx aether-context` work for people whose muscle memory is npm. On first run it builds a
+// private virtualenv under the OS cache directory, installs the matching `aether-context`
+// release from PyPI into it, and from then on forwards straight through. Nothing is written to
+// the user's global site-packages and nothing needs sudo.
+//
+// Zero dependencies on purpose: a launcher that has to resolve a dependency tree before it can
+// tell you that Python is missing is a worse launcher.
+
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const PACKAGE_VERSION = require("../package.json").version;
+/** Minimum interpreter the Python package declares (`requires-python = ">=3.10"`). */
+const MIN_PYTHON = [3, 10];
+
+/**
+ * The `aether-context` release to install.
+ *
+ * Pinned to this launcher's own version: the two are cut from one commit in one repo, and a
+ * release-parity test fails the build if they ever drift. `AETHER_CONTEXT_VERSION` overrides it
+ * (use `latest` for the newest release) for anyone testing a pre-release.
+ */
+function targetVersion() {
+  const override = process.env.AETHER_CONTEXT_VERSION;
+  if (!override) return PACKAGE_VERSION;
+  return override.toLowerCase() === "latest" ? null : override;
+}
+
+function requirement() {
+  const version = targetVersion();
+  return version === null ? "aether-context" : `aether-context==${version}`;
+}
+
+// --- interpreter discovery -----------------------------------------------------------------
+
+/** Candidate interpreter commands, best first. `AETHER_CONTEXT_PYTHON` short-circuits the search. */
+function pythonCandidates() {
+  const explicit = process.env.AETHER_CONTEXT_PYTHON;
+  if (explicit) return [[explicit, []]];
+  const candidates = [
+    ["python3", []],
+    ["python", []],
+  ];
+  // The Windows launcher resolves a real interpreter even when `python` is the Store alias stub.
+  if (process.platform === "win32") candidates.unshift(["py", ["-3"]]);
+  return candidates;
+}
+
+/** `[major, minor]` for an interpreter, or null if it cannot run / is not a real Python. */
+function pythonVersion(command, args) {
+  const probe = spawnSync(
+    command,
+    [...args, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+    { encoding: "utf8", windowsHide: true },
+  );
+  if (probe.status !== 0 || !probe.stdout) return null;
+  const match = /^(\d+)\.(\d+)/.exec(probe.stdout.trim());
+  return match ? [Number(match[1]), Number(match[2])] : null;
+}
+
+function meetsMinimum(version) {
+  return (
+    version[0] > MIN_PYTHON[0] ||
+    (version[0] === MIN_PYTHON[0] && version[1] >= MIN_PYTHON[1])
+  );
+}
+
+/**
+ * The first interpreter on PATH new enough to run the package.
+ *
+ * Reports the two failure modes separately, because the fix differs: no Python at all versus a
+ * Python that is too old. On Windows the App Execution Alias makes `python` exist while failing
+ * to run, which the probe treats as "not a real Python" rather than crashing.
+ */
+function findPython() {
+  let bestFound = null;
+  for (const [command, args] of pythonCandidates()) {
+    const version = pythonVersion(command, args);
+    if (!version) continue;
+    if (meetsMinimum(version)) return { command, args, version };
+    if (!bestFound || version > bestFound.version) bestFound = { command, args, version };
+  }
+  if (bestFound) {
+    fail(
+      `found Python ${bestFound.version.join(".")}, but aether-context needs ` +
+        `${MIN_PYTHON.join(".")} or newer.`,
+      "install a newer Python from https://python.org, or point AETHER_CONTEXT_PYTHON at one",
+    );
+  }
+  fail(
+    "no Python interpreter found on PATH.",
+    "install Python " +
+      MIN_PYTHON.join(".") +
+      "+ from https://python.org, or set AETHER_CONTEXT_PYTHON=/path/to/python",
+  );
+}
+
+// --- managed environment --------------------------------------------------------------------
+
+/** Where the private virtualenv lives — per-user cache, never the repo or global site-packages. */
+function venvRoot() {
+  if (process.env.AETHER_CONTEXT_HOME) return process.env.AETHER_CONTEXT_HOME;
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    return path.join(process.env.LOCALAPPDATA || path.join(home, "AppData", "Local"), "aether-context", "npm-venv");
+  }
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Caches", "aether-context", "npm-venv");
+  }
+  const base = process.env.XDG_CACHE_HOME || path.join(home, ".cache");
+  return path.join(base, "aether-context", "npm-venv");
+}
+
+function venvPython(root) {
+  return process.platform === "win32"
+    ? path.join(root, "Scripts", "python.exe")
+    : path.join(root, "bin", "python");
+}
+
+/** The installed `aether_context.__version__` inside the venv, or null if it is not importable. */
+function installedVersion(python) {
+  if (!fs.existsSync(python)) return null;
+  const probe = spawnSync(
+    python,
+    ["-c", "import aether_context; print(aether_context.__version__)"],
+    { encoding: "utf8", windowsHide: true },
+  );
+  return probe.status === 0 && probe.stdout ? probe.stdout.trim() : null;
+}
+
+function run(command, args, label) {
+  const result = spawnSync(command, args, { stdio: "inherit", windowsHide: true });
+  if (result.error) fail(`${label} failed to start: ${result.error.message}`);
+  if (result.status !== 0) fail(`${label} failed (exit ${result.status}).`);
+}
+
+/**
+ * Ensure the managed venv exists with the right release installed, and return its interpreter.
+ *
+ * The fast path — already installed at the pinned version — does one short probe and no network
+ * access at all, so the launcher does not add a package-manager round trip to every invocation.
+ */
+function ensureEnvironment() {
+  const root = venvRoot();
+  const python = venvPython(root);
+  const wanted = targetVersion();
+  const have = installedVersion(python);
+
+  if (have !== null && (wanted === null || have === wanted)) return python;
+
+  const interpreter = findPython();
+  if (!fs.existsSync(python)) {
+    console.error(`aether-context: preparing a private Python environment in ${root}`);
+    fs.mkdirSync(path.dirname(root), { recursive: true });
+    run(interpreter.command, [...interpreter.args, "-m", "venv", root], "creating the virtualenv");
+  }
+  console.error(`aether-context: installing ${requirement()} from PyPI (first run only)`);
+  run(python, ["-m", "pip", "install", "--quiet", "--upgrade", "pip"], "upgrading pip");
+  run(python, ["-m", "pip", "install", "--quiet", requirement()], "installing aether-context");
+  return python;
+}
+
+// --- entry point -------------------------------------------------------------------------------
+
+function fail(message, hint) {
+  console.error(`aether-context: ${message}`);
+  if (hint) console.error(`  fix: ${hint}`);
+  process.exit(1);
+}
+
+function main() {
+  const python = ensureEnvironment();
+  // `-m` rather than the console script: the module path is stable across platforms and does not
+  // depend on where the venv put its Scripts/bin shims.
+  const result = spawnSync(python, ["-m", "aether_context.cli", ...process.argv.slice(2)], {
+    stdio: "inherit",
+    windowsHide: true,
+  });
+  if (result.error) fail(`could not run aether-context: ${result.error.message}`);
+  process.exit(result.status === null ? 1 : result.status);
+}
+
+main();

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "aether-context",
+  "version": "0.3.0",
+  "description": "Unlimited Context — virtual memory for an LLM's attention. Local-first, numpy-only core. npm launcher for the aether-context Python engine.",
+  "bin": {
+    "aether-context": "bin/aether-context.js"
+  },
+  "files": [
+    "bin/aether-context.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "check": "node --check bin/aether-context.js"
+  },
+  "keywords": [
+    "llm",
+    "context",
+    "retrieval",
+    "ollama",
+    "local",
+    "rag",
+    "agents",
+    "unlimited-context"
+  ],
+  "author": "Aether AI",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/AetherAI3/Unlimited-Context-LLM#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AetherAI3/Unlimited-Context-LLM.git",
+    "directory": "packages/npm-cli"
+  },
+  "bugs": {
+    "url": "https://github.com/AetherAI3/Unlimited-Context-LLM/issues"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aether-context"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Unlimited Context — virtual memory for an LLM's attention. Local-first, numpy-only core."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"
@@ -43,11 +43,17 @@ dev      = ["pytest>=8", "pytest-cov", "ruff>=0.5", "mypy>=1.10"]
 
 [project.scripts]
 aether-context = "aether_context.cli:main"
-aether = "aether_agent.cli:main"
-aether-smoke = "aether_agent.smoke:main"
+
+[tool.setuptools.dynamic]
+version = { attr = "aether_context.__version__" }
 
 [tool.setuptools]
-packages = ["aether_context", "aether_agent"]
+# Only `aether_context` is distributed. `aether_agent/` also lives in this repo, but the
+# `aether-agent` distribution on PyPI already owns that import path and the `aether` console
+# script; shipping a second copy here would silently overwrite the other package's files on
+# any machine that installed both. The agent stays in-repo (and importable in the test suite,
+# which runs `python -m pytest` from the repo root) but out of the wheel.
+packages = ["aether_context"]
 
 [tool.setuptools.package-data]
 aether_context = ["py.typed"]

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,0 +1,192 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``aether-context setup`` — the guided first run.
+
+Hermetic like the rest of the suite: the Ollama probe is monkeypatched (never a real socket),
+pool state lives under ``tmp_path``, and every invocation is non-interactive so nothing can
+block on ``input()``.
+
+The behaviours worth pinning are the ones a broken first run would silently violate: the pool
+gets written, the engine is really exercised, a missing daemon is a warning rather than a
+failure, and the verification does not leave slices behind in the pool it just configured.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aether_context import cli
+
+
+@pytest.fixture(autouse=True)
+def _no_daemon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to 'no Ollama daemon' — no test in this file touches the network."""
+    monkeypatch.setattr(cli, "_probe_ollama", lambda host: False)
+
+
+def _setup(tmp_pool_dir: Path, *extra: str) -> int:
+    """Run `setup` non-interactively against ``tmp_pool_dir``."""
+    return cli.main(["setup", "--pool", "5", "--yes", "--dir", str(tmp_pool_dir), *extra])
+
+
+# --- the happy path ----------------------------------------------------------
+def test_setup_writes_the_pool_config_and_exits_zero(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A clean setup configures the pool on disk and reports success."""
+    # Act
+    code = _setup(tmp_pool_dir)
+    out = capsys.readouterr().out
+
+    # Assert
+    assert code == 0
+    config = tmp_pool_dir / "config.json"
+    assert config.exists()
+    assert json.loads(config.read_text())["pool_gb"] == 5
+    assert "pool configured" in out
+
+
+def test_setup_runs_all_three_steps_and_verifies_the_engine(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """All three numbered steps report, and the engine round trip actually passes."""
+    # Act
+    _setup(tmp_pool_dir)
+    out = capsys.readouterr().out
+
+    # Assert
+    assert "[1/3]" in out and "[2/3]" in out and "[3/3]" in out
+    assert "engine round trip passed" in out
+
+
+def test_setup_ends_with_runnable_next_commands(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The last thing a new user sees is commands they can paste, not a wall of prose."""
+    # Act
+    _setup(tmp_pool_dir)
+    out = capsys.readouterr().out
+
+    # Assert
+    assert "aether-context chat" in out
+    assert "aether-context status" in out
+    assert "aether-context doctor" in out
+
+
+# --- offline is a first-class path -------------------------------------------
+def test_missing_daemon_warns_but_does_not_fail(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No Ollama is a warning: the engine runs offline, so setup must not report failure."""
+    # Act
+    code = _setup(tmp_pool_dir)
+    out = capsys.readouterr().out
+
+    # Assert
+    assert code == 0
+    assert "[warn]" in out
+    assert "no Ollama daemon" in out
+    assert "mock model" in out  # the offline route is named, not just implied
+
+
+def test_offline_setup_suggests_the_mock_model(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """With no daemon, the suggested next command is one that works right now."""
+    # Act
+    _setup(tmp_pool_dir)
+    out = capsys.readouterr().out
+
+    # Assert
+    assert "chat --model mock" in out
+
+
+def test_reachable_daemon_with_pulled_model_reports_ok(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reachable daemon holding the model reports [ok] and points chat at that model."""
+    # Arrange
+    monkeypatch.setattr(cli, "_probe_ollama", lambda host: True)
+    monkeypatch.setattr(cli, "_model_is_pulled", lambda host, model: True)
+
+    # Act
+    code = _setup(tmp_pool_dir, "--model", "qwen2.5")
+    out = capsys.readouterr().out
+
+    # Assert
+    assert code == 0
+    assert "'qwen2.5' is pulled" in out
+    assert "chat --model ollama/qwen2.5" in out
+
+
+def test_reachable_daemon_missing_model_prints_the_pull_command(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An un-pulled model is a warning carrying the exact `ollama pull` fix."""
+    # Arrange
+    monkeypatch.setattr(cli, "_probe_ollama", lambda host: True)
+    monkeypatch.setattr(cli, "_model_is_pulled", lambda host, model: False)
+
+    # Act
+    code = _setup(tmp_pool_dir, "--model", "qwen2.5")
+    out = capsys.readouterr().out
+
+    # Assert
+    assert code == 0
+    assert "ollama pull qwen2.5" in out
+
+
+# --- the verify must not pollute the pool it just sized ----------------------
+def test_verification_leaves_the_configured_pool_empty(tmp_pool_dir: Path) -> None:
+    """The engine check runs in a throwaway dir, so a fresh setup leaves 0 slices behind."""
+    # Act
+    _setup(tmp_pool_dir)
+
+    # Assert
+    from aether_context.config import PoolConfig
+
+    slices, _capacity = cli._pool_counts(PoolConfig.load(tmp_pool_dir))
+    assert slices == 0
+
+
+# --- non-interactive discipline ----------------------------------------------
+def test_setup_never_prompts_with_yes_even_on_a_tty(
+    tmp_pool_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--yes` must skip the slider even when stdin looks interactive (scripts, Dockerfiles)."""
+    # Arrange: a tty-looking stdin, and an input() that fails the test if it is ever reached.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+
+    def _explode(prompt: str = "") -> str:
+        raise AssertionError("setup --yes must not prompt")
+
+    monkeypatch.setattr("builtins.input", _explode)
+
+    # Act
+    code = cli.main(["setup", "--yes", "--dir", str(tmp_pool_dir)])
+
+    # Assert
+    assert code == 0
+
+
+def test_setup_reports_failure_when_the_engine_check_breaks(
+    tmp_pool_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A genuinely broken engine exits non-zero and names the breakage instead of a traceback."""
+    # Arrange
+    def _broken(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("numpy is on fire")
+
+    monkeypatch.setattr(cli, "Session", _broken)
+
+    # Act
+    code = _setup(tmp_pool_dir)
+    out = capsys.readouterr().out
+
+    # Assert
+    assert code == 1
+    assert "engine check failed" in out
+    assert "numpy is on fire" in out

--- a/tests/test_release_parity.py
+++ b/tests/test_release_parity.py
@@ -1,0 +1,138 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Release-parity checks across the two registries this repo publishes to.
+
+`aether-context` ships twice from one commit: the Python package on PyPI, and an npm launcher
+that installs *that exact release* into a private virtualenv. The launcher pins the version it
+installs to its own ``package.json`` version, so a drift between the two would mean
+``npx aether-context`` silently installing a different release than ``pip install`` gives you —
+or, once the pin points at a version that was never published, failing outright on first run.
+
+That is not a hypothetical: the sibling `aether-agent` launcher shipped pinned to a version its
+npm counterpart had moved past, and installed an older agent than the documented route did.
+These tests are the cheap detector.
+"""
+from __future__ import annotations
+
+import json
+import re
+from importlib.metadata import distribution
+from pathlib import Path
+
+import pytest
+
+import aether_context
+
+try:  # tomllib landed in 3.11; the package floor is 3.10, so this import is optional here.
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - only taken on the 3.10 leg of the matrix
+    tomllib = None  # type: ignore[assignment]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NPM_DIR = REPO_ROOT / "packages" / "npm-cli"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _npm_manifest() -> dict[str, object]:
+    return json.loads((NPM_DIR / "package.json").read_text(encoding="utf-8"))
+
+
+# --- version parity ----------------------------------------------------------
+def test_npm_launcher_version_matches_the_python_package() -> None:
+    """The npm launcher and the Python package are one release, so they carry one version."""
+    # Act
+    npm_version = _npm_manifest()["version"]
+
+    # Assert
+    assert npm_version == aether_context.__version__, (
+        "packages/npm-cli/package.json and aether_context.__version__ disagree; the launcher "
+        "would install a different release than `pip install aether-context` gives you"
+    )
+
+
+def test_pyproject_takes_its_version_from_the_package() -> None:
+    """`pyproject.toml` must stay dynamic, so the package attribute is the single source."""
+    # Act
+    text = PYPROJECT.read_text(encoding="utf-8")
+
+    # Assert
+    assert 'dynamic = ["version"]' in text
+    assert 'version = { attr = "aether_context.__version__" }' in text
+    assert not re.search(r'^version\s*=\s*"', text, re.M), "a literal version would drift"
+
+
+# --- what the wheel is allowed to contain ------------------------------------
+# Read from the build configuration and the installed metadata rather than by scanning the
+# TOML for a substring: the prose comment above the setting mentions `aether_agent` too, and a
+# test that a comment can satisfy is not a test.
+def test_the_installed_distribution_owns_only_aether_context() -> None:
+    """`aether_agent` must stay out of the wheel: PyPI's `aether-agent` owns that import path.
+
+    Both distributions installed together would write the same ``aether_agent/`` files, and pip
+    does not detect conflicts across distributions — the second install silently wins.
+    """
+    # Act
+    top_level = distribution("aether-context").read_text("top_level.txt")
+
+    # Assert
+    assert top_level is not None
+    assert top_level.split() == ["aether_context"]
+
+
+@pytest.mark.skipif(tomllib is None, reason="tomllib requires Python 3.11+")
+def test_the_build_configuration_declares_only_aether_context() -> None:
+    """The declared package list is the thing the wheel is actually built from."""
+    # Act
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+    # Assert
+    assert config["tool"]["setuptools"]["packages"] == ["aether_context"]
+    assert config["project"]["scripts"] == {"aether-context": "aether_context.cli:main"}
+
+
+def test_the_distribution_declares_only_its_own_console_script() -> None:
+    """`aether` and `aether-smoke` belong to the `aether-agent` distribution, not this one."""
+    # Act
+    installed = {entry.name: entry.value for entry in distribution("aether-context").entry_points}
+
+    # Assert
+    assert installed == {"aether-context": "aether_context.cli:main"}
+
+
+# --- the launcher's own contract ---------------------------------------------
+def test_launcher_bin_is_listed_and_present() -> None:
+    """The published tarball must actually contain the file `bin` points at."""
+    # Act
+    manifest = _npm_manifest()
+    bin_path = manifest["bin"]["aether-context"]  # type: ignore[index]
+
+    # Assert
+    assert (NPM_DIR / bin_path).is_file()
+    assert bin_path in manifest["files"]  # type: ignore[operator]
+
+
+def test_launcher_pins_the_matching_pypi_release() -> None:
+    """The launcher installs `aether-context==<its own version>`, not a floating range."""
+    # Act
+    source = (NPM_DIR / "bin" / "aether-context.js").read_text(encoding="utf-8")
+
+    # Assert
+    assert "aether-context==${version}" in source
+    assert "PACKAGE_VERSION" in source
+
+
+def test_launcher_minimum_python_matches_requires_python() -> None:
+    """A launcher that accepts an interpreter the package rejects fails after the install."""
+    # Arrange
+    floor = re.search(r'requires-python\s*=\s*">=(\d+)\.(\d+)', PYPROJECT.read_text(encoding="utf-8"))
+    assert floor is not None
+    expected = [int(floor.group(1)), int(floor.group(2))]
+
+    # Act
+    source = (NPM_DIR / "bin" / "aether-context.js").read_text(encoding="utf-8")
+    declared = re.search(r"MIN_PYTHON\s*=\s*\[(\d+),\s*(\d+)\]", source)
+
+    # Assert
+    assert declared is not None
+    assert [int(declared.group(1)), int(declared.group(2))] == expected

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,183 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the terminal presentation seam (:mod:`aether_context.ui`).
+
+Hermetic: no tty, no network, no subprocess. Streams are ``io.StringIO`` stand-ins whose
+``isatty``/``encoding`` we control, which is exactly what the capability probes read.
+
+The property that matters most here is the *degradation*: a console that cannot do color or
+cannot encode box-drawing must get readable ASCII, never escape soup and never a
+``UnicodeEncodeError`` mid-report.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aether_context.ui import Console, _ascii_fold
+
+
+class _Stream:
+    """A capture stream with controllable ``isatty()`` and ``encoding``.
+
+    Written from scratch rather than subclassing ``io.StringIO``, whose ``encoding`` attribute
+    is read-only — and ``encoding`` is exactly what the unicode probe reads. ``print()`` only
+    needs ``write``, so this is the whole contract.
+    """
+
+    def __init__(self, *, tty: bool = False, encoding: str = "utf-8") -> None:
+        self._chunks: list[str] = []
+        self._tty = tty
+        self.encoding = encoding
+
+    def write(self, text: str) -> int:
+        self._chunks.append(text)
+        return len(text)
+
+    def isatty(self) -> bool:
+        return self._tty
+
+    def getvalue(self) -> str:
+        return "".join(self._chunks)
+
+
+# --- color probe -------------------------------------------------------------
+def test_no_color_on_a_pipe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-tty stream gets no ANSI, so piped/captured output stays plain text."""
+    # Arrange
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    # Act
+    console = Console(_Stream(tty=False))
+
+    # Assert
+    assert console.color is False
+    assert console.style("hello", "bold", "cyan") == "hello"
+
+
+def test_no_color_env_beats_a_real_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`NO_COLOR` disables styling even on an interactive terminal (no-color.org)."""
+    # Arrange
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+
+    # Act / Assert
+    assert Console(_Stream(tty=True)).color is False
+
+
+def test_force_color_enables_styling_off_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`FORCE_COLOR` turns ANSI back on for a pipe — how CI logs keep their color."""
+    # Arrange
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+
+    # Act
+    console = Console(_Stream(tty=False))
+
+    # Assert
+    assert console.color is True
+    assert "\033[" in console.style("hello", "bold")
+
+
+def test_term_dumb_disables_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A `TERM=dumb` terminal cannot render SGR, so we do not send any."""
+    # Arrange
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "dumb")
+
+    # Act / Assert
+    assert Console(_Stream(tty=True)).color is False
+
+
+# --- unicode probe -----------------------------------------------------------
+def test_cp1252_stream_falls_back_to_ascii_glyphs() -> None:
+    """A cp1252 console cannot encode the box/glyph set, so it gets the ASCII table."""
+    # Arrange
+    console = Console(_Stream(encoding="cp1252"))
+
+    # Act / Assert
+    assert console.unicode is False
+    assert console.glyph("ok") == "+"
+    assert console.glyph("fail") == "x"
+
+
+def test_utf8_stream_keeps_the_glyphs() -> None:
+    """A UTF-8 stream renders the real check/cross glyphs."""
+    # Arrange / Act
+    console = Console(_Stream(encoding="utf-8"))
+
+    # Assert
+    assert console.unicode is True
+    assert console.glyph("ok") == "✓"
+
+
+def test_output_is_ascii_folded_for_a_non_unicode_stream() -> None:
+    """Prose is folded too, not just glyphs — an em dash must not surface as `?`."""
+    # Arrange
+    stream = _Stream(encoding="cp1252")
+    console = Console(stream)
+
+    # Act
+    console.line("local-first — numpy-only")
+
+    # Assert
+    written = stream.getvalue()
+    assert "—" not in written
+    assert "?" not in written
+    assert "local-first - numpy-only" in written
+
+
+def test_banner_encodes_cleanly_on_a_cp1252_stream() -> None:
+    """The whole banner survives a cp1252 encode — the crash this fallback exists to prevent."""
+    # Arrange
+    stream = _Stream(encoding="cp1252")
+    console = Console(stream)
+
+    # Act
+    console.banner("Unlimited Context", "aether-context 0.0.0")
+
+    # Assert: round-trips through the console's real encoding without raising.
+    stream.getvalue().encode("cp1252")
+
+
+def test_ascii_fold_replaces_unmappable_characters() -> None:
+    """Anything outside the table (an interpolated path, a model name) still degrades safely."""
+    # Act / Assert
+    assert _ascii_fold("≈ 5 GB → done") == "~ 5 GB -> done"
+    assert "?" in _ascii_fold("модель")  # unmappable: replaced, never raised
+
+
+# --- composed output ---------------------------------------------------------
+def test_check_prints_the_bracket_kind_and_its_fix() -> None:
+    """`[ok]`/`[fail]` bracket text is the doctor's long-standing contract; the fix rides along."""
+    # Arrange
+    stream = _Stream()
+    console = Console(stream)
+
+    # Act
+    console.check("fail", "ollama daemon not reachable", "ollama serve")
+
+    # Assert
+    out = stream.getvalue()
+    assert "[fail]" in out
+    assert "ollama daemon not reachable" in out
+    assert "ollama serve" in out
+
+
+@pytest.mark.parametrize(
+    ("fraction", "expected_filled"),
+    [(0.0, 0), (0.5, 8), (1.0, 16), (-3.0, 0), (99.0, 16)],
+)
+def test_bar_is_clamped_and_proportional(fraction: float, expected_filled: int) -> None:
+    """The meter fills proportionally and clamps, so an out-of-range ratio cannot corrupt it."""
+    # Arrange
+    console = Console(_Stream())
+
+    # Act
+    bar = console.bar(fraction, slots=16)
+
+    # Assert
+    assert len(bar) == 16
+    assert bar.count("█") == expected_filled


### PR DESCRIPTION
Makes this repo publishable to both registries, adds a guided first-run CLI, and fixes a packaging collision that would have corrupted installs.

## The blocker this fixes

The wheel packaged `aether_agent/` (35 files) and declared the `aether` and `aether-smoke` console scripts. But PyPI's `aether-agent` 0.3.2 already ships `aether_agent/__init__.py` and `aether_agent/cli.py` — verified by downloading the published wheel. pip does not detect file conflicts *across* distributions, so a machine with both installed would have had one package silently overwrite the other's files, and the `aether` command would belong to whichever installed last.

The distribution now ships `aether_context` only. `aether_agent/` stays in the repo and in the test suite — the suite runs `python -m pytest` from the repo root, so the import still resolves — it is simply not packaged. The terminal installs from its own package (`pip install aether-agent` / `npm install -g aether-agents`), which the README now says instead of claiming this install provides it.

Guarded three ways: a test on the installed distribution's `top_level.txt` and entry points, a test on the declared build config, and a step in the publish workflow that inspects the built wheel before upload.

## `aether-context setup`

Three steps — size the pool, check for a local model, verify the engine — ending in commands you can paste.

```
╭──────────────────────────────────────────────╮
│               Unlimited Context              │
│             aether-context 0.3.0             │
╰──────────────────────────────────────────────╯

[1/3] Pool size
  ✓ [ok] pool configured at ~/.aether-context
  size:        5 GB
  reach:       ~1.17B tokens

[2/3] Local model
  △ [warn] no Ollama daemon at http://localhost:11434
        fix: install from https://ollama.com, then `ollama serve`
  Not a blocker — everything below runs offline against the mock model.

[3/3] Verify the engine
  ✓ [ok] engine round trip passed (1 slice(s) encoded and retrieved)
```

The verification is a real encode/retrieve round trip against the mock model in a temporary directory: it passes with no daemon, no network and no model pulled, and leaves the pool you just configured empty. `--pool N --yes` makes the whole command non-interactive, so it is safe in a Dockerfile or a CI step.

## Presentation seam

New `aether_context/ui.py`, stdlib only — the core dependency contract stays numpy-and-nothing-else.

- Color requires a real tty and obeys `NO_COLOR` / `FORCE_COLOR` / `TERM=dumb`. VT100 is enabled explicitly on Windows; if that call fails, styling is dropped rather than printing escape bytes.
- Glyphs **and prose** fold to ASCII when the stream's encoding cannot represent them, so a `cp1252` console gets `+ [ok]` and `-` instead of `?` characters or a `UnicodeEncodeError` mid-report.
- Because color is off whenever stdout is not a tty, output is plain text under pytest, in a pipe, and in CI.

`init`, `doctor` and `status` render through it. The `status` column layout and the doctor's `[ok]`/`[warn]`/`[fail]`/`[skip]` bracket text are unchanged — both are scraped by scripts, and `test_cli_surface.py` caught the break when the slice meter first replaced the counts instead of following them.

## npm launcher

`packages/npm-cli`, published as `aether-context`. Zero dependencies: it finds a Python 3.10+ interpreter, builds a private virtualenv under the OS cache directory, installs the matching PyPI release into it, and forwards argv. Global `site-packages` is never touched and nothing needs `sudo`. The fast path (already installed at the pinned version) does one probe and no network access.

The launcher pins `aether-context==<its own version>`. That pin is exactly what shipped a stale `aether-agent` launcher, so it is guarded by a parity test against `aether_context.__version__` and by a workflow preflight that refuses to publish a launcher whose release is not on PyPI yet.

## Verification

In a clean venv, mirroring CI:

- **589 passed, 5 skipped** (556 before, +33 new). ruff and mypy green. Bench smoke green (`verdict: ON beats OFF`).
- Wheel contains 23 files, **0** from `aether_agent`; one console script; version 0.3.0 from the dynamic attr. Both distributions pass `twine check`.
- `import aether_agent` fails from a non-repo cwd (proving it is undistributed) while the suite still passes.
- The npm launcher was run end to end against the locally built wheel: cold start creates the venv, `setup` completes, `--version` returns `aether-context 0.3.0`. The missing-interpreter and unpublished-version paths both fail with a legible message and exit 1.

## Operator gates — publishing cannot run until these exist

1. **PyPI Trusted Publisher** (pending-publisher form, since the project does not exist yet): owner `AetherAI3`, repository `Unlimited-Context-LLM`, workflow `publish.yml`, environment `pypi-production`. All four match literally; OIDC does not follow the DBarr3 → AetherAI3 redirect.
2. **`pypi-production` environment** in this repo's settings.
3. **`npm-production` environment** with an npm automation token as the `NPM_TOKEN` secret.

Then run `publish (pypi)` **before** `publish (npm)` — the launcher's pin makes that ordering load-bearing, and the npm preflight enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
