### PR TITLE
fix(ci): publish-npm.yml was not valid YAML

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -115,8 +115,11 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: test -n "$NODE_AUTH_TOKEN" || {
-          echo "NPM_TOKEN is not set in the npm-production environment"; exit 1; }
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN is not set in the npm-production environment" >&2
+            exit 1
+          fi
 
       - name: Publish to npm
         if: ${{ !inputs.dry_run }}
@@ -126,4 +129,5 @@ jobs:
 
       - name: Dry run summary
         if: ${{ inputs.dry_run }}
-        run: echo "dry run: packed ${{ steps.pack.outputs.tarball }} without publishing"
+        run: |
+          echo "dry run - packed ${{ steps.pack.outputs.tarball }} without publishing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ llamacpp = ["llama-cpp-python>=0.2"]
 hf       = ["transformers>=4.40", "torch>=2.2"]
 fast     = ["hnswlib>=0.8"]                # faster ANN; flat numpy index is the fallback
 all      = ["aether-context[llamacpp,hf,fast]"]
-dev      = ["pytest>=8", "pytest-cov", "ruff>=0.5", "mypy>=1.10"]
+dev      = ["pytest>=8", "pytest-cov", "ruff>=0.5", "mypy>=1.10", "pyyaml>=6"]
 
 [project.scripts]
 aether-context = "aether_context.cli:main"

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -1,0 +1,85 @@
+# aether-context (Unlimited Context)
+# Copyright (c) 2026 Aether AI
+# SPDX-License-Identifier: Apache-2.0
+"""Every workflow file must be parseable YAML that still declares its triggers.
+
+This exists because of a real escape. `publish-npm.yml` merged to `main` containing
+
+    run: echo "dry run: packed ... without publishing"
+
+which is **not valid YAML** — a plain scalar cannot contain ``": "``, and the quotes there
+belong to the shell string, not to YAML. GitHub could not read the file's `on:` block, so
+dispatching it failed with the thoroughly misleading
+``Workflow does not have 'workflow_dispatch' trigger`` while the trigger was sitting right
+there in the source. Nothing in CI parsed workflow YAML, so nothing caught it.
+
+The trigger assertion is the half that matters: a syntactically valid file whose `on:` block
+got swallowed by a mis-indented key is silently un-runnable, which is exactly the failure that
+a publish workflow cannot afford — you find out at release time.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml  # dev-only dependency; declared in the `dev` extra, never at runtime
+
+WORKFLOW_DIR = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+
+
+def _workflow_files() -> list[Path]:
+    return sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml"))
+
+
+def test_there_are_workflows_to_check() -> None:
+    """Guard the guard: a glob that matches nothing would make every test below vacuous."""
+    # Assert
+    assert _workflow_files(), f"no workflow files found under {WORKFLOW_DIR}"
+
+
+@pytest.mark.parametrize("path", _workflow_files(), ids=lambda p: p.name)
+def test_workflow_is_valid_yaml(path: Path) -> None:
+    """The file parses. An unparseable workflow is invisible to GitHub, not merely broken."""
+    # Act / Assert
+    try:
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - only on a regression
+        pytest.fail(f"{path.name} is not valid YAML: {exc}")
+
+    assert isinstance(document, dict), f"{path.name} did not parse to a mapping"
+
+
+@pytest.mark.parametrize("path", _workflow_files(), ids=lambda p: p.name)
+def test_workflow_declares_triggers(path: Path) -> None:
+    """`on:` survives the parse with at least one trigger.
+
+    YAML 1.1 reads a bare ``on`` as the boolean ``True``, which is why the key is looked up
+    both ways — GitHub accepts the file either way, so the test must too.
+    """
+    # Act
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    triggers = document.get("on", document.get(True))
+
+    # Assert
+    assert triggers, f"{path.name} declares no triggers; GitHub can never run it"
+    if isinstance(triggers, dict):
+        assert list(triggers.keys()), f"{path.name} has an empty `on:` mapping"
+
+
+def test_publish_workflows_are_dispatchable() -> None:
+    """Both publish workflows must be manually dispatchable — that is how releases are cut.
+
+    Pinned explicitly because the failure is asymmetric: losing this trigger does not break
+    any test or any push, it just makes the release button disappear until someone needs it.
+    """
+    # Arrange
+    expected = {"publish.yml", "publish-npm.yml"}
+
+    # Act / Assert
+    for name in expected:
+        path = WORKFLOW_DIR / name
+        assert path.is_file(), f"{name} is missing"
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        triggers = document.get("on", document.get(True))
+        assert isinstance(triggers, dict), f"{name} has no trigger mapping"
+        assert "workflow_dispatch" in triggers, f"{name} is not manually dispatchable"


### PR DESCRIPTION
The npm publish workflow could not be dispatched. GitHub reported:

```
Workflow does not have 'workflow_dispatch' trigger
```

…while the trigger is plainly in the file. The real cause is that **the file does not parse**:

```yaml
run: echo "dry run: packed ... without publishing"
```

A YAML plain scalar cannot contain `": "`, and the quotes there belong to the shell string, not to YAML — so the line reads as a nested mapping and the parse dies at that column. GitHub could not see the `on:` block at all, which is why the error named the trigger rather than the syntax.

## Fix

Both `run:` steps become block scalars, so the shell is the only thing parsing shell. The credential guard was the same fragility in another shape — a folded plain scalar carrying `|| { …; }` across two lines — and is now a plain `if` block.

## Why it merged

Nothing in CI parsed workflow YAML. `tests/test_workflow_yaml.py` now asserts that every workflow file parses **and** still declares at least one trigger, with `publish.yml` and `publish-npm.yml` pinned as dispatchable.

The trigger half is the part that matters longer term: a syntactically valid workflow whose `on:` block got swallowed by a mis-indented key is silently un-runnable, and for a publish workflow you discover that at release time.

Verified the test is real, not decorative:

- Reintroducing the original defect makes it fail — `publish-npm.yml is not valid YAML: mapping values are not allowed here`.
- It is not vacuous: `test_there_are_workflows_to_check` fails if the glob ever matches nothing.

`pyyaml` joins the `dev` extra for that test (a hard import, not an `importorskip`, so a missing dep fails loudly instead of skipping silently). The runtime dependency set is unchanged — numpy and nothing else.

## Context

PyPI publishing already succeeded: [`aether-context` 0.3.0](https://pypi.org/project/aether-context/) is live and verified installable. This is the last thing blocking the npm half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)