### PR TITLE
chore(release): close out the 0.3.0 dual-registry release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to `aether-context` are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+- `publish-npm.yml` was not valid YAML — `run: echo "dry run: packed ..."` put `": "` inside a
+  plain scalar, so the file did not parse and GitHub could not see its `on:` block. Dispatching
+  it failed with `Workflow does not have 'workflow_dispatch' trigger` while the trigger was
+  present in the source. Both `run:` steps are block scalars now.
+
+### Added
+- `tests/test_workflow_yaml.py` — every workflow file must parse *and* still declare at least
+  one trigger, with both publish workflows pinned as dispatchable. Nothing in CI parsed workflow
+  YAML before, which is how the above reached `main`. `pyyaml` joins the `dev` extra for it; the
+  runtime dependency set is unchanged (numpy only).
+- PyPI and npm version badges, now that both registries carry the package.
+
+### Changed
+- `RELEASING.md` rewritten. It had documented tag-triggered publishing (removed in #63), owner
+  `DBarr3` (a deleted account), environment `pypi` (the workflow uses `pypi-production`), and a
+  `version` literal in `pyproject.toml` (now dynamic) — and it now records the trap that failed
+  the first real publish: the pending publisher's *project name* field is the distribution name,
+  not the repository name. A mismatch passes the OIDC exchange and then fails the upload with
+  `400 Non-user identities cannot create new projects`.
+
 ## [0.3.0] — 2026-09-03
 
 First release published to a package registry: PyPI as `aether-context`, npm as `aether-context`.
@@ -105,5 +126,6 @@ pool — local-first, numpy-only core.
   completion), hermetic via `MockLLM`.
 - Docs (`how-it-works`, `local-models`), examples, CI, Apache-2.0 license.
 
-[Unreleased]: https://github.com/AetherAI3/Unlimited-Context-LLM/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/AetherAI3/Unlimited-Context-LLM/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/AetherAI3/Unlimited-Context-LLM/releases/tag/v0.3.0
 [0.2.0]: https://github.com/AetherAI3/Unlimited-Context-LLM/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 <img width="537" height="405" alt="Unlimited Context" src="https://github.com/user-attachments/assets/79758729-ead7-42ca-9784-831cae68ef06" />
 
+[![PyPI](https://img.shields.io/pypi/v/aether-context?style=flat-square&logo=pypi&logoColor=white&color=06b6d4)](https://pypi.org/project/aether-context/)
+[![npm](https://img.shields.io/npm/v/aether-context?style=flat-square&logo=npm&logoColor=white&color=cb3837)](https://www.npmjs.com/package/aether-context)
 [![License](https://img.shields.io/badge/License-Apache_2.0-06b6d4?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-14b8a6?style=flat-square&logo=python&logoColor=white)](https://www.python.org)
 [![Built by Aether](https://img.shields.io/badge/Built_by-Aether-7c3aed?style=flat-square)](https://aethersystems.net)

--- a/tests/test_release_parity.py
+++ b/tests/test_release_parity.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import re
-from importlib.metadata import distribution
+from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 
 import pytest
@@ -28,6 +28,15 @@ try:  # tomllib landed in 3.11; the package floor is 3.10, so this import is opt
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - only taken on the 3.10 leg of the matrix
     tomllib = None  # type: ignore[assignment]
+
+#: The installed distribution, or None when the tests run from a clone with nothing installed.
+#: The metadata assertions below need a real install to read; the build-configuration ones read
+#: `pyproject.toml` and do not, so the invariant stays covered either way (CI installs
+#: `-e ".[dev]"`, so both halves run there).
+try:
+    DIST = distribution("aether-context")
+except PackageNotFoundError:  # pragma: no cover - only when running uninstalled
+    DIST = None
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 NPM_DIR = REPO_ROOT / "packages" / "npm-cli"
@@ -66,6 +75,7 @@ def test_pyproject_takes_its_version_from_the_package() -> None:
 # Read from the build configuration and the installed metadata rather than by scanning the
 # TOML for a substring: the prose comment above the setting mentions `aether_agent` too, and a
 # test that a comment can satisfy is not a test.
+@pytest.mark.skipif(DIST is None, reason="aether-context is not installed in this environment")
 def test_the_installed_distribution_owns_only_aether_context() -> None:
     """`aether_agent` must stay out of the wheel: PyPI's `aether-agent` owns that import path.
 
@@ -73,7 +83,8 @@ def test_the_installed_distribution_owns_only_aether_context() -> None:
     does not detect conflicts across distributions — the second install silently wins.
     """
     # Act
-    top_level = distribution("aether-context").read_text("top_level.txt")
+    assert DIST is not None  # narrowed by the skipif above
+    top_level = DIST.read_text("top_level.txt")
 
     # Assert
     assert top_level is not None
@@ -91,10 +102,12 @@ def test_the_build_configuration_declares_only_aether_context() -> None:
     assert config["project"]["scripts"] == {"aether-context": "aether_context.cli:main"}
 
 
+@pytest.mark.skipif(DIST is None, reason="aether-context is not installed in this environment")
 def test_the_distribution_declares_only_its_own_console_script() -> None:
     """`aether` and `aether-smoke` belong to the `aether-agent` distribution, not this one."""
     # Act
-    installed = {entry.name: entry.value for entry in distribution("aether-context").entry_points}
+    assert DIST is not None  # narrowed by the skipif above
+    installed = {entry.name: entry.value for entry in DIST.entry_points}
 
     # Assert
     assert installed == {"aether-context": "aether_context.cli:main"}


### PR DESCRIPTION
Housekeeping after [`aether-context` 0.3.0](https://pypi.org/project/aether-context/) went live on PyPI and [npm](https://www.npmjs.com/package/aether-context).

## CHANGELOG

`[0.3.0]` had no link reference and `[Unreleased]` still compared from `v0.2.0`. Both fixed.

The repo changes that landed *after* the publish — the `publish-npm.yml` YAML fix, the workflow-YAML test, the RELEASING.md rewrite — go under **`[Unreleased]`**, deliberately not into `[0.3.0]`. Those artifacts are on PyPI and immutable; describing post-release commits as part of that release would be false.

## README

PyPI and npm version badges, now that both registries carry the package.

## Parity tests were brittle

The two metadata-based tests in `test_release_parity.py` read the *installed* distribution, so they crashed with `PackageNotFoundError` for anyone running `pytest` in a clone without installing first. CI installs `-e ".[dev]"`, so they always passed there — which is precisely how the sharp edge stayed hidden through 18 green checks. I only hit it running the suite in a fresh worktree.

They now skip with an explicit reason when nothing is installed. **That leaves no coverage gap:** `test_the_build_configuration_declares_only_aether_context` asserts the same invariant from `pyproject.toml` and needs no install, and in CI both halves run. Verified by installing into a throwaway venv — all 8 tests run, none skip — so the skip is a real environment guard, not a hole.

## Verification

599 passed, 5 skipped. ruff and mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)