### PR TITLE
chore: point CITATION.cff at v0.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,8 +6,8 @@ authors:
     given-names: "Brandon"
     affiliation: "Aether AI"
   - name: "Aether AI"
-version: "0.2.0"
-date-released: 2026-08-13
+version: "0.3.0"
+date-released: 2026-09-04
 license: Apache-2.0
 url: "https://github.com/AetherAI3/Unlimited-Context-LLM"
 repository-code: "https://github.com/AetherAI3/Unlimited-Context-LLM"


### PR DESCRIPTION
`CITATION.cff` still pointed at 0.2.0 and its August release date, so anyone citing the project from the GitHub "Cite this repository" button got the wrong version.

Bumped to 0.3.0 / 2026-09-04 to match the v0.3.0 release and `aether_context.__version__`. Nothing else in the repo referenced 0.2.0.