### PR TITLE
docs: add the project landing page and enable Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ reaches it in slices, one small window at a time. Local-first, offline, free.
 [![Built by Aether](https://img.shields.io/badge/Built_by-Aether-7c3aed?style=flat-square)](https://aethersystems.net)
 [![Stars](https://img.shields.io/github/stars/AetherAI3/Unlimited-Context-LLM?style=flat-square&logo=github&color=eab308)](https://github.com/AetherAI3/Unlimited-Context-LLM/stargazers)
 
+[Site](https://aetherai3.github.io/Unlimited-Context-LLM/) ·
 [Install](https://github.com/AetherAI3/Unlimited-Context-LLM#install) ·
 [How it works](https://github.com/AetherAI3/Unlimited-Context-LLM#how-it-works) ·
 [The proof](https://github.com/AetherAI3/Unlimited-Context-LLM#the-proof) ·

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Unlimited Context — virtual memory for an LLM's attention</title>
+<meta name="description" content="Keep a billion-token pool on your own disk. Your local model reaches it in slices, one small window at a time. Apache-2.0, offline, free.">
+<link rel="canonical" href="https://aetherai3.github.io/Unlimited-Context-LLM/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Unlimited Context — virtual memory for an LLM's attention">
+<meta property="og:description" content="Keep a billion-token pool on your own disk. Your local model reaches it in slices, one small window at a time. Apache-2.0, offline, free.">
+<meta property="og:url" content="https://aetherai3.github.io/Unlimited-Context-LLM/">
+<meta property="og:image" content="https://raw.githubusercontent.com/AetherAI3/Unlimited-Context-LLM/main/assets/social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Unlimited Context — virtual memory for an LLM's attention">
+<meta name="twitter:description" content="Keep a billion-token pool on your own disk. Your local model reaches it in slices, one small window at a time.">
+<meta name="twitter:image" content="https://raw.githubusercontent.com/AetherAI3/Unlimited-Context-LLM/main/assets/social-preview.png">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ctext y='26' font-size='26'%3E%E2%9A%A1%3C/text%3E%3C/svg%3E">
+<style>
+  :root{
+    --bg:#0b0e13; --bg-2:#0d1117; --panel:#12161d; --line:#212936;
+    --fg:#e6edf3; --muted:#9aa4b2; --dim:#7d8590;
+    --cyan:#56d4dd; --green:#56d364; --amber:#e3b341; --violet:#b78bff;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+    --sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif;
+    --wrap:1080px;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{
+    margin:0;background:var(--bg);color:var(--fg);font-family:var(--sans);
+    font-size:16px;line-height:1.65;-webkit-font-smoothing:antialiased;
+  }
+  body::before{
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+    background:
+      radial-gradient(60rem 34rem at 50% -12rem, rgba(86,212,221,.10), transparent 70%),
+      radial-gradient(44rem 26rem at 88% 4rem, rgba(183,139,255,.07), transparent 70%);
+  }
+  .wrap{position:relative;z-index:1;max-width:var(--wrap);margin:0 auto;padding:0 24px}
+  a{color:var(--cyan);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code,kbd{font-family:var(--mono)}
+
+  /* nav */
+  nav{position:sticky;top:0;z-index:10;backdrop-filter:blur(10px);
+      background:rgba(11,14,19,.78);border-bottom:1px solid var(--line)}
+  .nav-in{display:flex;align-items:center;gap:20px;height:58px}
+  .brand{display:flex;align-items:center;gap:9px;font-weight:650;color:var(--fg);letter-spacing:-.01em}
+  .brand span.bolt{color:var(--cyan)}
+  .nav-links{margin-left:auto;display:flex;align-items:center;gap:22px;font-size:14.5px}
+  .nav-links a{color:var(--muted)}
+  .nav-links a:hover{color:var(--fg);text-decoration:none}
+  .ghbtn{border:1px solid var(--line);background:var(--panel);color:var(--fg)!important;
+         padding:6px 13px;border-radius:8px;font-size:14px;font-weight:550}
+  .ghbtn:hover{border-color:#33405a;text-decoration:none}
+  @media(max-width:720px){.nav-links a.hide-sm{display:none}}
+
+  /* hero */
+  header{padding:74px 0 8px;text-align:center}
+  .eyebrow{font-family:var(--mono);font-size:12.5px;letter-spacing:.16em;text-transform:uppercase;
+           color:var(--dim)}
+  h1{font-size:clamp(2.3rem,5.4vw,3.6rem);line-height:1.08;letter-spacing:-.032em;
+     margin:14px 0 0;font-weight:700}
+  h1 .grad{background:linear-gradient(96deg,var(--cyan),var(--violet));
+           -webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{max-width:660px;margin:20px auto 0;color:var(--muted);font-size:clamp(1.02rem,2vw,1.16rem)}
+  .sub strong{color:var(--fg);font-weight:600}
+
+  .cmds{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin:30px 0 6px}
+  .cmd{display:flex;align-items:center;gap:12px;background:var(--panel);border:1px solid var(--line);
+       border-radius:10px;padding:10px 12px 10px 15px;font-family:var(--mono);font-size:14.5px}
+  .cmd .dollar{color:var(--green)}
+  .copy{border:0;background:transparent;color:var(--dim);cursor:pointer;font:inherit;
+        font-size:12px;padding:3px 7px;border-radius:6px}
+  .copy:hover{background:#1b2230;color:var(--fg)}
+  .note{color:var(--dim);font-size:13.5px;margin-top:10px}
+
+  /* demo */
+  .demo{margin:40px auto 0;max-width:820px}
+  .demo img{width:100%;height:auto;display:block;border-radius:12px;
+            border:1px solid var(--line);box-shadow:0 24px 70px -30px rgba(0,0,0,.9)}
+  .demo figcaption{color:var(--dim);font-size:13px;margin-top:12px;text-align:center}
+
+  /* stats */
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin:56px 0 0}
+  @media(max-width:760px){.stats{grid-template-columns:repeat(2,1fr)}}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px 16px}
+  .stat b{display:block;font-family:var(--mono);font-size:clamp(1.25rem,3vw,1.6rem);
+          letter-spacing:-.02em;color:var(--cyan)}
+  .stat .g{color:var(--green)}
+  .stat .a{color:var(--amber)}
+  .stat small{display:block;color:var(--dim);font-size:12.5px;margin-top:5px;line-height:1.45}
+
+  /* sections */
+  section{padding:74px 0 0}
+  h2{font-size:clamp(1.5rem,3vw,1.95rem);letter-spacing:-.022em;margin:0 0 8px;font-weight:680}
+  .lede{color:var(--muted);max-width:720px;margin:0 0 26px}
+  .rule{height:1px;background:var(--line);margin:74px 0 0}
+
+  .grid{display:grid;grid-template-columns:repeat(2,1fr);gap:14px}
+  @media(max-width:760px){.grid{grid-template-columns:1fr}}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:20px}
+  .card h3{margin:0 0 6px;font-size:15.5px;letter-spacing:-.01em}
+  .card h3 .os{font-family:var(--mono);color:var(--violet);font-weight:600}
+  .card p{margin:0;color:var(--muted);font-size:14.5px}
+  .card p b{color:var(--fg);font-weight:600}
+
+  table{width:100%;border-collapse:collapse;font-size:14.5px;margin-top:6px}
+  th,td{padding:11px 12px;border-bottom:1px solid var(--line);text-align:left}
+  th{color:var(--dim);font-weight:550;font-size:12.5px;letter-spacing:.05em;text-transform:uppercase}
+  td.n,th.n{text-align:right;font-family:var(--mono)}
+  tbody tr:hover{background:#10151d}
+  .tablewrap{overflow-x:auto;border:1px solid var(--line);border-radius:12px;background:var(--panel)}
+  .tablewrap table tr:last-child td{border-bottom:0}
+
+  .proof-img{margin:22px 0 0}
+  .proof-img img{width:100%;height:auto;border-radius:12px;border:1px solid var(--line);background:#fff}
+  .caveat{margin-top:20px;border-left:2px solid #2b3547;padding:2px 0 2px 16px;
+          color:var(--dim);font-size:13.6px}
+  .caveat b{color:var(--muted);font-weight:600}
+
+  ul.plain{list-style:none;padding:0;margin:0;display:grid;gap:10px}
+  ul.plain li{color:var(--muted);font-size:15px;padding-left:24px;position:relative}
+  ul.plain li::before{content:"→";position:absolute;left:0;color:var(--cyan);font-family:var(--mono)}
+  ul.plain li b{color:var(--fg);font-weight:600}
+
+  .cta{text-align:center;padding:78px 0 0}
+  .cta .btns{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:22px}
+  .btn{display:inline-block;padding:11px 20px;border-radius:10px;font-weight:600;font-size:15px}
+  .btn.primary{background:var(--cyan);color:#06212a!important}
+  .btn.primary:hover{background:#7ee0e7;text-decoration:none}
+  .btn.ghost{border:1px solid var(--line);background:var(--panel);color:var(--fg)!important}
+  .btn.ghost:hover{border-color:#33405a;text-decoration:none}
+
+  footer{margin-top:78px;border-top:1px solid var(--line);padding:30px 0 56px;
+         color:var(--dim);font-size:13.5px}
+  .foot-in{display:flex;flex-wrap:wrap;gap:14px 26px;align-items:center}
+  .foot-in .sp{margin-left:auto}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="wrap nav-in">
+    <a class="brand" href="#top"><span class="bolt">⚡</span> Unlimited Context</a>
+    <div class="nav-links">
+      <a href="#how" class="hide-sm">How it works</a>
+      <a href="#proof" class="hide-sm">Proof</a>
+      <a href="#sizing" class="hide-sm">Sizing</a>
+      <a class="ghbtn" href="https://github.com/AetherAI3/Unlimited-Context-LLM">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<header id="top">
+  <div class="wrap">
+    <p class="eyebrow">Apache-2.0 · local-first · no account</p>
+    <h1>Virtual memory for an<br><span class="grad">LLM's attention</span></h1>
+    <p class="sub">Keep a <strong>billion-token pool</strong> on your own disk. Your local model
+      reaches it in slices, one small window at a time — so a long run stops quietly forgetting
+      what it decided an hour ago.</p>
+
+    <div class="cmds">
+      <div class="cmd"><span class="dollar">$</span><span id="c1">pip install aether-context</span>
+        <button class="copy" data-t="pip install aether-context">copy</button></div>
+      <div class="cmd"><span class="dollar">$</span><span id="c2">npx aether-context setup</span>
+        <button class="copy" data-t="npx aether-context setup">copy</button></div>
+    </div>
+    <p class="note">Runs with no daemon, no network and no model pulled — setup verifies against a built-in mock model.</p>
+
+    <figure class="demo">
+      <img src="https://raw.githubusercontent.com/AetherAI3/Unlimited-Context-LLM/main/assets/demo.gif"
+           alt="Terminal recording: npx aether-context setup sizes a 5 GB pool, doctor reports four green checks, status prints pool, reach and resident RAM."
+           width="716" height="538" loading="eager">
+      <figcaption>A real session, captured unedited: guided setup, a clean doctor check, pool status.</figcaption>
+    </figure>
+
+    <div class="stats">
+      <div class="stat"><b>~1.16B</b><small>tokens of reach from a 5 GB pool</small></div>
+      <div class="stat"><b class="g">0.15 → 1.00</b><small>recall of early facts, engine off vs on</small></div>
+      <div class="stat"><b class="a">−24%</b><small>session cost, same work</small></div>
+      <div class="stat"><b>100%</b><small>on your machine, offline</small></div>
+    </div>
+  </div>
+</header>
+
+<section id="problem">
+  <div class="wrap">
+    <h2>Long runs die the same way</h2>
+    <p class="lede">The model fills its window, starts compressing its own history, and silently
+      drops the one detail that mattered three steps ago. You get the runaway PR, the function
+      rewritten twice, the build that falls apart at hour two. A bigger window only delays it,
+      and a crammed one rots in the middle anyway.</p>
+    <p class="lede" style="margin-bottom:0">The fix isn't more window. It's to stop throwing the
+      overflow away — encode it to a pool on disk, and recover the exact slice when it's needed.</p>
+  </div>
+</section>
+
+<section id="how">
+  <div class="wrap">
+    <h2>It's virtual memory, for attention</h2>
+    <p class="lede">Map it onto an operating system and it clicks. The pager runs while the model
+      generates, so most of the fetch hides behind its own thinking.</p>
+    <div class="grid">
+      <div class="card"><h3><span class="os">RAM</span> → the resident window</h3>
+        <p>What the model can see <b>right now</b>. Small and fast, exactly as it always was.</p></div>
+      <div class="card"><h3><span class="os">Disk</span> → the context pool</h3>
+        <p>Your encoded memory. <b>~5 GB ≈ ~1B tokens</b>, sitting on your own drive.</p></div>
+      <div class="card"><h3><span class="os">Pager</span> → the slice loader</h3>
+        <p>Embeds what the model is reasoning about <b>this second</b> and prefetches the matching slices.</p></div>
+      <div class="card"><h3><span class="os">Page replacement</span> → retention</h3>
+        <p>Useful slices <b>stay</b>, stale ones fade, anything relevant again comes back.</p></div>
+    </div>
+    <ul class="plain" style="margin-top:22px">
+      <li><b>MPO context chain</b> — recall pulls the connected thread, not isolated nearest neighbours.</li>
+      <li><b>Any backend</b> — Ollama, llama.cpp, Hugging Face, or your own API-backed model.</li>
+      <li><b>numpy-only core</b> — vectors live on disk, mmap'd; only the index graph stays resident.</li>
+    </ul>
+  </div>
+</section>
+
+<section id="proof">
+  <div class="wrap">
+    <h2>Measured, not asserted</h2>
+    <p class="lede">One live, paid run: a reasoning model driven through a 40-turn agent session
+      that overflows its window — 2,000-token window, 60 real <code>microsoft/vscode</code> issues,
+      engine off vs on. $0.19, 14 June 2026. Raw artifacts are committed in the repo.</p>
+
+    <div class="tablewrap">
+      <table>
+        <thead><tr><th>Metric</th><th class="n">Off</th><th class="n">On</th><th class="n">Change</th></tr></thead>
+        <tbody>
+          <tr><td>Recall of early facts</td><td class="n">0.15</td><td class="n">1.00</td><td class="n">6.7×</td></tr>
+          <tr><td>Tasks done right</td><td class="n">3 / 20</td><td class="n">20 / 20</td><td class="n">3 → 20</td></tr>
+          <tr><td>Cost, full session</td><td class="n">$0.0711</td><td class="n">$0.0542</td><td class="n">−24%</td></tr>
+          <tr><td>Cost, recall phase</td><td class="n">$0.00117/t</td><td class="n">$0.00053/t</td><td class="n">−54%</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <figure class="proof-img">
+      <img src="https://raw.githubusercontent.com/AetherAI3/Unlimited-Context-LLM/main/docs/benchmarks/artifacts/2026-06-14-deepseek-v4-pro/api_eval_plot.png"
+           alt="Two charts: cumulative cost per turn and recall coherence per turn, engine off versus on.">
+    </figure>
+
+    <p class="caveat"><b>Scope, honestly.</b> That run used a hosted reasoning model, not a local
+      one — the mechanism is backend-agnostic, but the headline number is not a local number. The
+      2,000-token window is deliberately tiny to force overflow, so a realistic window shows a
+      smaller (still real) gain. N = 20 recall turns, single run. It measures the engine, not the
+      MPO chain: on this single-fact task the chain ties plain recall, and its multi-slice edge is
+      synthetic-only so far.
+      <a href="https://github.com/AetherAI3/Unlimited-Context-LLM/blob/main/docs/benchmarks/2026-06-14-deepseek-v4-pro-session-eval.md">Full write-up →</a></p>
+  </div>
+</section>
+
+<section id="sizing">
+  <div class="wrap">
+    <h2>Disk in, reach out</h2>
+    <p class="lede">One number to choose. Roughly 2.2 KB per 512-token slice works out to
+      ~233M tokens of reach per gigabyte, and RAM stays a formula rather than a mystery.</p>
+    <div class="tablewrap">
+      <table>
+        <thead><tr><th>Pool</th><th class="n">Slices</th><th class="n">Reach</th><th class="n">Index RAM</th><th class="n">Sessions on 8 GB</th></tr></thead>
+        <tbody>
+          <tr><td>5 GB <span style="color:var(--dim)">(floor)</span></td><td class="n">2.27M</td><td class="n">~1.16B</td><td class="n">~146 MB</td><td class="n">~13</td></tr>
+          <tr><td>10 GB</td><td class="n">4.55M</td><td class="n">~2.33B</td><td class="n">~291 MB</td><td class="n">~7</td></tr>
+          <tr><td>15 GB</td><td class="n">6.82M</td><td class="n">~3.49B</td><td class="n">~436 MB</td><td class="n">~4</td></tr>
+          <tr><td>20 GB</td><td class="n">9.09M</td><td class="n">~4.65B</td><td class="n">~582 MB</td><td class="n">~3</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="caveat" style="margin-top:18px">Session counts are for isolated pools, and roughly
+      double on a 16 GB machine. Share one pool instead and the index is paid once — dozens of
+      sessions fit, with CPU as the limit rather than memory, at the cost of isolation.
+      A bigger pool always buys reach, never more concurrent sessions.</p>
+  </div>
+</section>
+
+<section id="honest">
+  <div class="wrap">
+    <h2>Honest about the word "unlimited"</h2>
+    <p class="lede" style="margin-bottom:0">It means <strong style="color:var(--fg)">reach, not
+      attention</strong>. Your model keeps its native context window; the engine makes it reach a
+      billion-token pool in slices, through fast retrieval. The whole thing rides on hit rate —
+      when that's high the pool feels like one seamless context, and when it isn't, a miss looks
+      like forgetting. That's the trade, stated plainly.</p>
+  </div>
+</section>
+
+<div class="rule"></div>
+
+<div class="cta">
+  <div class="wrap">
+    <h2>Give the model you already run a longer memory</h2>
+    <p class="lede" style="margin:8px auto 0;text-align:center">Two commands, no account, nothing
+      leaves your machine.</p>
+    <div class="btns">
+      <a class="btn primary" href="https://github.com/AetherAI3/Unlimited-Context-LLM">Star on GitHub</a>
+      <a class="btn ghost" href="https://pypi.org/project/aether-context/">PyPI</a>
+      <a class="btn ghost" href="https://www.npmjs.com/package/aether-context">npm</a>
+      <a class="btn ghost" href="https://github.com/AetherAI3/Unlimited-Context-LLM/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">Good first issues</a>
+    </div>
+  </div>
+</div>
+
+<footer>
+  <div class="wrap foot-in">
+    <span>Built by <a href="https://aethersystems.net">Aether AI</a> · Apache-2.0</span>
+    <span class="sp">
+      <a href="https://github.com/AetherAI3/Unlimited-Context-LLM/blob/main/docs/how-it-works.md">How it works</a> ·
+      <a href="https://github.com/AetherAI3/Unlimited-Context-LLM/blob/main/SAFETY.md">Safety</a> ·
+      <a href="https://github.com/AetherAI3/Unlimited-Context-LLM/blob/main/USE_POLICY.md">Use policy</a> ·
+      <a href="https://github.com/AetherAI3/Unlimited-Context-LLM/blob/main/CITATION.cff">Cite</a>
+    </span>
+  </div>
+</footer>
+
+<script>
+document.querySelectorAll(".copy").forEach(function (b) {
+  b.addEventListener("click", function () {
+    var t = b.getAttribute("data-t");
+    var done = function () { b.textContent = "copied"; setTimeout(function () { b.textContent = "copy"; }, 1400); };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(t).then(done, done);
+    } else {
+      var ta = document.createElement("textarea");
+      ta.value = t; document.body.appendChild(ta); ta.select();
+      try { document.execCommand("copy"); } catch (e) {}
+      document.body.removeChild(ta); done();
+    }
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds the project's missing share/demo page and turns on GitHub Pages for it.

`docs/index.html` is a single self-contained file (18 KB, no build step, no external CSS or JS) served from `main` `/docs`. `docs/.nojekyll` keeps Pages from processing the folder, so the page ships exactly as written.

## What's on it

- Hero with the two install commands, each with a copy button, and the real terminal GIF from the README.
- A stat row: reach at the 5 GB floor, the 0.15 to 1.00 recall change, the cost change, and local-only.
- The problem, stated once and briefly.
- The OS mapping (RAM, disk, pager, page replacement) as four cards.
- The benchmark table and chart, with the same caveat paragraph the README carries: hosted model, tiny forced window, N=20, chain edge synthetic-only. The page does not make a claim the repo cannot back.
- The sizing table, the honest note about the word "unlimited", and a star CTA.

Dark theme matched to the terminal recording, one accent colour, no external font or script requests. Rendered and checked at 1280 and 390 wide - no horizontal scroll at either.

## Sharing

Full Open Graph and Twitter card tags with `assets/social-preview.png` as the image, so a pasted link unfurls properly in Slack, Discord, X and iMessage. That is the part that was missing: the repo had no site and no homepage set, so every link to this project was a bare GitHub URL.

## Also here

One line added to the README nav pointing at the site.

After merge, Pages is enabled on `main` `/docs` and the repo homepage is set to the published URL.