### PR TITLE
Add durable context recovery and production gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PYTHONDONTWRITEBYTECODE: "1"
+
 jobs:
   test:
     name: test (py${{ matrix.python-version }} · ${{ matrix.os }})
@@ -54,6 +57,20 @@ jobs:
         run: |
           npm pack --silent
           tar -tzf aether-context-*.tgz
+
+  live-context-ipc:
+    name: live context IPC memory gate
+    runs-on: ubuntu-latest
+    env:
+      AETHER_LIVE_IPC_SCALE: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install -e ".[dev]"
+      - run: python -m pytest -q tests/test_retention_scale.py::test_live_unix_ipc_near_cap_memory_and_concurrency_gate
 
   numpy-matrix:
     name: numpy ${{ matrix.numpy }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ All notable changes to `aether-context` are documented here. Format follows
 ## [Unreleased]
 
 ### Added
+- Recovery startup now publishes its signed hydrate receipt through a required,
+  atomic, owner-only `--restore-result` file. Exact retries converge on the same
+  evidence, while conflicting or unsafe result paths fail before serving. The
+  private daemon IPC also accepts the same bounded hydrate inputs with
+  daemon-configured checkpoint trust roots for live Cloud recovery.
+- Gateway can release and revive an exact never-bound reservation after a signed
+  pre-dispatch authorization failure; revision CAS and stored receipts make lost
+  acknowledgements safe. Revisioned V2 reserve/bind commands prevent an original
+  reserve or delayed bind from attaching to a revived attempt.
+- Separate signed abort and no-dispatch expiry paths close dispatched and
+  never-dispatched reservations. V3 reserve/bind receipts carry the exact prior
+  expiry, terminal Cloud fence and revival lineage so stale generations cannot
+  bind or dispatch after same-key revival.
+- A signed per-cycle checkpoint durability registration distinguishes local,
+  ephemeral canary packs from remotely registered packs. Local packs cannot be
+  hydrated and expire without remote evidence; remote packs still require
+  deletion proof before managed-key destruction. New packs preserve the exact
+  registration proof across replacement, and V2 deletion evidence binds the
+  replacement host's reattestation.
 - Hosted V1 now has signed freeze manifests, exact checkpoint/hydrate receipts,
   revision-bound retention commands, independent remote-object and managed-KMS
   deletion evidence, and crash-safe durable cleanup receipts.
@@ -22,6 +41,14 @@ All notable changes to `aether-context` are documented here. Format follows
   hosted data-plane case generator required for scale qualification. The legacy
   deletion route now fails closed in favor of signed retention, including for
   legacy checkpoints.
+- Hosted health now has closed rolling-compatible V1 and extended V2 responses.
+  V2 reports the live package-tree and locked interpreter/dependency environment
+  committed by `ContextRuntimeBuildManifestV2`; source-only qualification rejects
+  bytecode and native import shadows and fails closed on live measurement errors.
+- Health V3 reports the guarded complete deployment-lock import closure, exact
+  protocol capabilities and the measured live IPC pack ceiling. The copy-based
+  daemon path bounds emitted packs at 13 MB and decrypted snapshots at 16 MB,
+  while preserving the original 64 MB V1 profile default for direct use.
 
 ## [0.3.1] — 2026-09-04
 

--- a/aether_context/contracts/__init__.py
+++ b/aether_context/contracts/__init__.py
@@ -10,7 +10,27 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 Ident = Annotated[str, Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$")]
 Digest = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+PrefixedDigest = Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")]
 Sha = Annotated[str, Field(pattern=r"^[0-9a-f]{40}$")]
+# The copy-heavy JSON/base64 IPC path is deliberately narrower than the V1
+# checkpoint profile. A canonical JSON snapshot may be up to 16 MB, but zlib's
+# entropy ceiling for JSON-safe text makes the largest emitted encrypted pack
+# about 13 MB. Advertising that reachable pack boundary keeps the measured
+# near-limit gate honest until the transport is streamed.
+LIVE_IPC_MAX_CHECKPOINT_BYTES = 13_000_000
+HOSTED_CONTEXT_CAPABILITIES = (
+    "reserve_v2",
+    "bind_v2",
+    "checkpoint_durability",
+    "release_reservation",
+    "abort_reservation",
+    "expire_aborted_reservation",
+    "expire_reservation",
+    "reserve_v3",
+    "bind_v3",
+    "hydrate_v2",
+    "deletion_v2",
+)
 
 
 def canonical(value: object) -> bytes:
@@ -68,6 +88,350 @@ class ContextRequestV1(Closed):
     retention_class: Literal["ephemeral", "audit"] = "ephemeral"
     resume_context_cycle_id: Ident | None = None
     promotion_mode: Literal["verified_only", "disabled"] = "verified_only"
+
+
+class SignedV1(Closed):
+    payload: dict
+    key_id: Ident
+    signature: str = Field(min_length=64, max_length=128)
+
+
+class ContextReservationReceiptV1(Closed):
+    """Rolling-compatible service evidence for one exact reservation."""
+
+    schema_version: Literal["ContextReservationReceiptV1"] = "ContextReservationReceiptV1"
+    context_cycle_id: Ident
+    context_bucket_id: Ident
+    request_digest: Digest
+    profile_digest: Digest
+
+
+class ContextReservationCommandV2(Closed):
+    """Revision-aware reservation and explicit post-release revival."""
+
+    schema_version: Literal["ContextReservationCommandV2"] = (
+        "ContextReservationCommandV2"
+    )
+    operation: Literal["reserve"] = "reserve"
+    owner_id: Ident
+    project_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    expires_at: int = Field(ge=0)
+    released_revision: int | None = Field(default=None, ge=2)
+
+
+class ContextReservationReceiptV2(Closed):
+    schema_version: Literal["ContextReservationReceiptV2"] = "ContextReservationReceiptV2"
+    context_cycle_id: Ident
+    context_bucket_id: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    revision: int = Field(ge=1)
+
+
+class ContextReservationReceiptV3(Closed):
+    schema_version: Literal["ContextReservationReceiptV3"] = "ContextReservationReceiptV3"
+    context_cycle_id: Ident
+    context_bucket_id: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    revision: int = Field(ge=3)
+    prior_expiry_receipt_digest: Digest
+    prior_expiry_revision: int = Field(ge=2)
+    invocation_no_dispatch_receipt_digest: Digest
+    revival_command_digest: Digest
+
+    @model_validator(mode="after")
+    def exact_revival_revision(self) -> "ContextReservationReceiptV3":
+        if self.revision != self.prior_expiry_revision + 1:
+            raise ValueError("reservation revival revision must follow expiry")
+        return self
+
+
+class ContextReservationCommandV3(Closed):
+    """Reservation revival authorized by an exact no-dispatch expiry receipt."""
+
+    schema_version: Literal["ContextReservationCommandV3"] = (
+        "ContextReservationCommandV3"
+    )
+    operation: Literal["reserve"] = "reserve"
+    owner_id: Ident
+    project_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    expires_at: int = Field(ge=0)
+    expired_reservation_receipt: SignedV1
+
+
+class ContextReservationReleaseCommandV1(Closed):
+    """Gateway proof that authorization failed before objective dispatch."""
+
+    schema_version: Literal["ContextReservationReleaseCommandV1"] = (
+        "ContextReservationReleaseCommandV1"
+    )
+    operation: Literal["release_reservation"] = "release_reservation"
+    context_cycle_id: Ident
+    owner_id: Ident
+    project_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    expected_revision: int = Field(ge=1)
+    reason_code: Literal["pre_dispatch_authorization_failed"]
+    dispatch_started: Literal[False]
+    authorization_failure_receipt_digest: Digest
+    issued_at: int = Field(ge=0)
+    expires_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def short_lived(self) -> "ContextReservationReleaseCommandV1":
+        if self.expires_at <= self.issued_at or self.expires_at - self.issued_at > 900:
+            raise ValueError("reservation release authority must be short-lived")
+        return self
+
+
+class ContextReservationReleaseReceiptV1(Closed):
+    schema_version: Literal["ContextReservationReleaseReceiptV1"] = (
+        "ContextReservationReleaseReceiptV1"
+    )
+    operation: Literal["release_reservation"] = "release_reservation"
+    context_cycle_id: Ident
+    owner_id: Ident
+    project_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    authorization_failure_receipt_digest: Digest
+    release_command_digest: Digest
+    final_state: Literal["EXPIRED"] = "EXPIRED"
+    released: Literal[True] = True
+    revision: int = Field(ge=2)
+
+
+class ContextReservationAbortCommandV1(Closed):
+    """Gateway proof that a dispatched objective stalled before context bind."""
+
+    schema_version: Literal["ContextReservationAbortCommandV1"] = (
+        "ContextReservationAbortCommandV1"
+    )
+    operation: Literal["abort_reservation"] = "abort_reservation"
+    context_cycle_id: Ident
+    owner_id: Ident
+    project_id: Ident
+    objective_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    expected_revision: int = Field(ge=1)
+    reason_code: Literal["timeout", "cancel", "reconciliation_failed"]
+    dispatch_started: Literal[True]
+    objective_dispatch_receipt_digest: Digest
+    reservation_receipt: SignedV1
+    issued_at: int = Field(ge=0)
+    expires_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def short_lived(self) -> "ContextReservationAbortCommandV1":
+        if self.expires_at <= self.issued_at or self.expires_at - self.issued_at > 900:
+            raise ValueError("reservation abort authority must be short-lived")
+        return self
+
+
+class ContextReservationAbortReceiptV1(Closed):
+    schema_version: Literal["ContextReservationAbortReceiptV1"] = (
+        "ContextReservationAbortReceiptV1"
+    )
+    operation: Literal["abort_reservation"] = "abort_reservation"
+    context_cycle_id: Ident
+    owner_id: Ident
+    project_id: Ident
+    objective_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    reason_code: Literal["timeout", "cancel", "reconciliation_failed"]
+    objective_dispatch_receipt_digest: Digest
+    reservation_receipt_digest: Digest
+    abort_command_digest: Digest
+    final_state: Literal["ABORTED"] = "ABORTED"
+    aborted: Literal[True] = True
+    aborted_at: int = Field(ge=0)
+    retention_expires_at: int = Field(ge=0)
+    revision: int = Field(ge=2)
+
+    @model_validator(mode="after")
+    def retention_follows_abort(self) -> "ContextReservationAbortReceiptV1":
+        if self.retention_expires_at <= self.aborted_at:
+            raise ValueError("reservation abort retention expiry must follow abort")
+        return self
+
+
+class ContextReservationAbortExpiryCommandV1(Closed):
+    """Authority to clean one terminal, never-bound reservation after retention."""
+
+    schema_version: Literal["ContextReservationAbortExpiryCommandV1"] = (
+        "ContextReservationAbortExpiryCommandV1"
+    )
+    operation: Literal["expire_aborted_reservation"] = (
+        "expire_aborted_reservation"
+    )
+    namespace: NamespaceV1
+    idempotency_key: Ident
+    expected_revision: int = Field(ge=2)
+    reason_code: Literal["policy_expiry", "operator_expiry"]
+    abort_receipt: SignedV1
+    issued_at: int = Field(ge=0)
+    expires_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def short_lived(self) -> "ContextReservationAbortExpiryCommandV1":
+        if self.expires_at <= self.issued_at or self.expires_at - self.issued_at > 900:
+            raise ValueError("reservation abort expiry authority must be short-lived")
+        return self
+
+
+class ContextInvocationNoDispatchSnapshotV1(Closed):
+    """Exact atomically locked Cloud dispatch-fence projection."""
+
+    owner_user_id: Ident
+    objective_id: Ident
+    idempotency_key: Ident
+    request_digest: PrefixedDigest
+    context_cycle_id: Ident
+    reservation_receipt_digest: Digest
+    reservation_revision: int = Field(ge=1)
+    state: Literal["closed_without_dispatch"]
+    revision: int = Field(ge=1)
+    canonical_result_state: Literal[
+        "absent", "planned", "blocked_without_authority"
+    ]
+    canonical_result_digest: Digest | None = None
+
+    @model_validator(mode="after")
+    def result_is_resolvable(self) -> "ContextInvocationNoDispatchSnapshotV1":
+        if (self.canonical_result_state == "absent") != (
+            self.canonical_result_digest is None
+        ):
+            raise ValueError("canonical result state and digest mismatch")
+        return self
+
+
+class ContextInvocationNoDispatchReceiptV1(Closed):
+    """Signed exact snapshot of a terminal Cloud dispatch fence."""
+
+    schema_version: Literal["ContextInvocationNoDispatchReceiptV1"] = (
+        "ContextInvocationNoDispatchReceiptV1"
+    )
+    operation: Literal["close_without_dispatch"] = "close_without_dispatch"
+    ledger_snapshot: ContextInvocationNoDispatchSnapshotV1
+    ledger_snapshot_digest: Digest
+    issued_at: int = Field(ge=0)
+    expires_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def short_lived(self) -> "ContextInvocationNoDispatchReceiptV1":
+        if self.expires_at <= self.issued_at or self.expires_at - self.issued_at > 900:
+            raise ValueError("no-dispatch closure proof must be short-lived")
+        if digest(self.ledger_snapshot) != self.ledger_snapshot_digest:
+            raise ValueError("ledger snapshot digest mismatch")
+        return self
+
+
+class ContextReservationExpiryCommandV1(Closed):
+    """Expire a clean reservation after canonical dispatch has been fenced out."""
+
+    schema_version: Literal["ContextReservationExpiryCommandV1"] = (
+        "ContextReservationExpiryCommandV1"
+    )
+    operation: Literal["expire_reservation"] = "expire_reservation"
+    context_cycle_id: Ident
+    context_bucket_id: Ident
+    objective_id: Ident
+    owner_id: Ident
+    project_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    expected_revision: int = Field(ge=1)
+    reason_code: Literal["reservation_timeout", "client_cancel", "reconciliation_failed"]
+    reservation_receipt: SignedV1
+    invocation_no_dispatch_receipt: SignedV1
+    invocation_no_dispatch_receipt_digest: Digest
+    issued_at: int = Field(ge=0)
+    expires_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def closed_short_lived_proof(self) -> "ContextReservationExpiryCommandV1":
+        if self.expires_at <= self.issued_at or self.expires_at - self.issued_at > 900:
+            raise ValueError("reservation expiry authority must be short-lived")
+        if digest(self.invocation_no_dispatch_receipt) != self.invocation_no_dispatch_receipt_digest:
+            raise ValueError("no-dispatch receipt digest mismatch")
+        return self
+
+
+class ContextReservationExpiryReceiptV1(Closed):
+    schema_version: Literal["ContextReservationExpiryReceiptV1"] = (
+        "ContextReservationExpiryReceiptV1"
+    )
+    operation: Literal["expire_reservation"] = "expire_reservation"
+    context_cycle_id: Ident
+    context_bucket_id: Ident
+    objective_id: Ident
+    owner_id: Ident
+    project_id: Ident
+    idempotency_key: Ident
+    request_digest: Digest
+    profile_digest: Digest
+    reason_code: Literal["reservation_timeout", "client_cancel", "reconciliation_failed"]
+    reservation_receipt_digest: Digest
+    invocation_no_dispatch_receipt_digest: Digest
+    expiry_command_digest: Digest
+    final_state: Literal["EXPIRED"] = "EXPIRED"
+    expired: Literal[True] = True
+    revivable: Literal[True] = True
+    expired_at: int = Field(ge=0)
+    revision: int = Field(ge=2)
+
+
+class ContextCheckpointDurabilityCommandV1(Closed):
+    """Immutable per-cycle choice between local-only and remote checkpoints."""
+
+    schema_version: Literal["ContextCheckpointDurabilityCommandV1"] = (
+        "ContextCheckpointDurabilityCommandV1"
+    )
+    operation: Literal["register_checkpoint_durability"] = (
+        "register_checkpoint_durability"
+    )
+    namespace: NamespaceV1
+    idempotency_key: Ident
+    expected_revision: int = Field(ge=1)
+    mode: Literal["local_ephemeral", "remote_registered"]
+    issued_at: int = Field(ge=0)
+    expires_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def short_lived(self) -> "ContextCheckpointDurabilityCommandV1":
+        if self.expires_at <= self.issued_at or self.expires_at - self.issued_at > 900:
+            raise ValueError("checkpoint durability authority must be short-lived")
+        return self
+
+
+class ContextCheckpointDurabilityReceiptV1(Closed):
+    schema_version: Literal["ContextCheckpointDurabilityReceiptV1"] = (
+        "ContextCheckpointDurabilityReceiptV1"
+    )
+    operation: Literal["register_checkpoint_durability"] = (
+        "register_checkpoint_durability"
+    )
+    namespace: NamespaceV1
+    idempotency_key: Ident
+    mode: Literal["local_ephemeral", "remote_registered"]
+    command_digest: Digest
+    effective_at: int = Field(ge=0)
+    revision: int = Field(ge=2)
 
 
 class ContextProfileV1(Closed):
@@ -162,10 +526,60 @@ class CapabilityV1(Closed):
     max_tokens: int = Field(ge=1, le=65536)
 
 
-class SignedV1(Closed):
-    payload: dict
-    key_id: Ident
-    signature: str = Field(min_length=64, max_length=128)
+class ContextCheckpointDurabilityReceiptV2(ContextCheckpointDurabilityReceiptV1):
+    """Replacement-host attestation over exact source registration evidence."""
+
+    schema_version: Literal["ContextCheckpointDurabilityReceiptV2"] = "ContextCheckpointDurabilityReceiptV2"  # type: ignore[assignment]
+    source_registration_receipt: SignedV1
+    source_registration_receipt_digest: Digest
+    reattested_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def source_receipt_digest_matches(self) -> "ContextCheckpointDurabilityReceiptV2":
+        if digest(self.source_registration_receipt) != self.source_registration_receipt_digest:
+            raise ValueError("source durability registration digest mismatch")
+        try:
+            source_claim = ContextCheckpointDurabilityReceiptV1.model_validate(
+                self.source_registration_receipt.payload
+            )
+        except ValueError as exc:
+            raise ValueError(
+                "source durability registration must be an exact V1 receipt"
+            ) from exc
+        source = source_claim.model_dump(mode="json")
+        if source != self.source_registration_receipt.payload:
+            raise ValueError("source durability registration must be closed")
+        expected = {
+            "namespace": self.namespace.model_dump(mode="json"),
+            "idempotency_key": self.idempotency_key,
+            "mode": self.mode,
+            "command_digest": self.command_digest,
+            "effective_at": self.effective_at,
+            "revision": self.revision,
+        }
+        if any(source.get(field) != value for field, value in expected.items()):
+            raise ValueError("source durability registration claim mismatch")
+        return self
+
+
+class ContextBindingCommandV2(Closed):
+    """Revision-CAS wrapper that keeps the persisted binding itself at V1."""
+
+    schema_version: Literal["ContextBindingCommandV2"] = "ContextBindingCommandV2"
+    operation: Literal["bind"] = "bind"
+    binding: ContextBindingV1
+    reservation_receipt: SignedV1
+    expected_reservation_revision: int = Field(ge=1)
+
+
+class ContextBindingCommandV3(Closed):
+    """Bind an expiry-revived reservation to its exact V3 lineage."""
+
+    schema_version: Literal["ContextBindingCommandV3"] = "ContextBindingCommandV3"
+    operation: Literal["bind"] = "bind"
+    binding: ContextBindingV1
+    reservation_receipt: SignedV1
+    expected_reservation_revision: int = Field(ge=3)
 
 
 class PromotionCandidateV1(Closed):
@@ -193,6 +607,113 @@ class ContextCheckpointReceiptV1(Closed):
     def key_reference_pair(self) -> "ContextCheckpointReceiptV1":
         if len({item is None for item in (self.key_ref, self.key_provider, self.key_version)}) != 1:
             raise ValueError("checkpoint key reference, provider and version must be paired")
+        return self
+
+
+class ContextHydrateCommandV2(Closed):
+    """Short-lived recovery authority for one checkpoint and runtime source."""
+
+    schema_version: Literal["ContextHydrateCommandV2"] = "ContextHydrateCommandV2"
+    operation: Literal["hydrate"] = "hydrate"
+    namespace: NamespaceV1
+    manifest_checksum: Digest
+    key_ref: Ident | None = None
+    key_provider: str | None = Field(default=None, min_length=1, max_length=100)
+    key_version: Ident | None = None
+    fence: int = Field(ge=1)
+    expected_source_revision: Sha
+    issued_at: int = Field(ge=0)
+    expires_at: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def bounded_recovery(self) -> "ContextHydrateCommandV2":
+        if len({item is None for item in (self.key_ref, self.key_provider, self.key_version)}) != 1:
+            raise ValueError("hydrate key reference, provider and version must be paired")
+        if self.expires_at <= self.issued_at or self.expires_at - self.issued_at > 900:
+            raise ValueError("hydrate authority must be short-lived")
+        return self
+
+
+class ContextHealthV1(Closed):
+    """Returned daemon health identity and measured readiness evidence."""
+
+    schema_version: Literal["ContextHealthV1"] = "ContextHealthV1"
+    ready: bool
+    profile_digest: Digest
+    index_implementation: str = Field(min_length=1, max_length=100)
+    index_version: str = Field(min_length=1, max_length=100)
+    disk_free_bytes: int = Field(ge=0)
+    resident_cache_limit_bytes: int = Field(ge=0)
+    resident_process_limit_bytes: int = Field(ge=0)
+    resident_process_observed_peak_bytes: int | None = Field(default=None, ge=0)
+    configured_max_records: int = Field(ge=1)
+    configured_max_indexed_bytes: int = Field(ge=1)
+    configured_reachable_tokens_upper_bound: int = Field(ge=0)
+    measured_indexed_records: int | None = Field(default=None, ge=0)
+    measured_indexed_bytes: int | None = Field(default=None, ge=0)
+    estimated_reachable_tokens: int | None = Field(default=None, ge=0)
+    reach_claim_enabled: bool
+    benchmark_failures: list[str]
+    benchmark_source_revision: Sha | None = None
+    benchmark_receipt_digest: Digest | None = None
+    benchmark_recall_dataset_digest: Digest | None = None
+    runtime_build_ready: bool
+    runtime_build_failures: list[str]
+    runtime_build_manifest_digest: Digest | None = None
+    runtime_source_revision: Sha | None = None
+    runtime_data_plane_case_generator_digest: Digest | None = None
+    cycle_key_provider: str | None = Field(default=None, min_length=1, max_length=100)
+    managed_cycle_keys_ready: bool
+    managed_cycle_key_failures: list[str]
+    managed_key_provider_receipt_digests: dict[str, Digest]
+    managed_key_provider_receipt_digest: Digest | None = None
+
+
+class ContextHealthV2(ContextHealthV1):
+    """Health V1 plus the measured executable runtime identity."""
+
+    schema_version: Literal["ContextHealthV2"] = "ContextHealthV2"  # type: ignore[assignment]
+    runtime_package_tree_digest: Digest | None = None
+    runtime_locked_environment_digest: Digest | None = None
+    runtime_python_implementation: str | None = Field(default=None, min_length=1, max_length=40)
+    runtime_python_version: str | None = Field(default=None, min_length=1, max_length=40)
+    runtime_python_abi: str | None = Field(default=None, min_length=1, max_length=200)
+    runtime_python_executable_digest: Digest | None = None
+    runtime_dependency_versions: dict[str, str]
+    runtime_dependency_artifact_digests: dict[str, Digest]
+    runtime_sqlite_version: str | None = Field(default=None, min_length=1, max_length=40)
+    runtime_package_import_root_digest: Digest | None = None
+    runtime_bytecode_policy: Literal["source-only/no-bytecode/v1"] | None = None
+
+
+class ContextHealthV3(ContextHealthV2):
+    """Health V2 plus the guarded complete dependency import closure."""
+
+    schema_version: Literal["ContextHealthV3"] = "ContextHealthV3"  # type: ignore[assignment]
+    runtime_dependency_import_closure: list[str] = Field(default_factory=list, max_length=32)
+    runtime_bytecode_policy: Literal["preimport-guard/source-only/v2"] | None = None  # type: ignore[assignment]
+    context_protocol_version: Literal[3] = 3
+    capabilities: list[
+        Literal[
+            "reserve_v2",
+            "bind_v2",
+            "checkpoint_durability",
+            "release_reservation",
+            "abort_reservation",
+            "expire_aborted_reservation",
+            "expire_reservation",
+            "reserve_v3",
+            "bind_v3",
+            "hydrate_v2",
+            "deletion_v2",
+        ]
+    ]
+    live_ipc_checkpoint_bytes: int = Field(ge=1024, le=LIVE_IPC_MAX_CHECKPOINT_BYTES)
+
+    @model_validator(mode="after")
+    def exact_capabilities(self) -> "ContextHealthV3":
+        if self.capabilities != list(HOSTED_CONTEXT_CAPABILITIES):
+            raise ValueError("hosted context capabilities must be exact and ordered")
         return self
 
 
@@ -372,6 +893,188 @@ class KeyDestructionReceiptV1(Closed):
         return self
 
 
+class ContextRetentionReceiptV1(Closed):
+    schema_version: Literal["ContextRetentionReceiptV1"] = "ContextRetentionReceiptV1"
+    operation: Literal["hold", "release"]
+    context_cycle_id: Ident
+    reason_code: Literal[
+        "audit_hold", "legal_hold", "incident_hold", "hold_released"
+    ]
+    effective_at: int = Field(ge=0)
+    revision: int = Field(ge=2)
+
+    @model_validator(mode="after")
+    def operation_reason(self) -> "ContextRetentionReceiptV1":
+        if self.operation == "release" and self.reason_code != "hold_released":
+            raise ValueError("release receipt reason mismatch")
+        if self.operation == "hold" and self.reason_code == "hold_released":
+            raise ValueError("hold receipt reason mismatch")
+        return self
+
+
+class ContextHydrateReceiptV2(ContextHydrateReceiptV1):
+    schema_version: Literal["ContextHydrateReceiptV2"] = "ContextHydrateReceiptV2"  # type: ignore[assignment]
+    hydrate_command_digest: Digest
+    expected_source_revision: Sha
+    checkpoint_durability_registration_receipt: SignedV1 | None = None
+    checkpoint_durability_registration_receipt_digest: Digest | None = None
+
+    @model_validator(mode="after")
+    def durability_registration_is_resolvable(self) -> "ContextHydrateReceiptV2":
+        if (
+            self.checkpoint_durability_registration_receipt is None
+        ) != (self.checkpoint_durability_registration_receipt_digest is None):
+            raise ValueError("hydrate durability receipt and digest must be paired")
+        if (
+            self.checkpoint_durability_registration_receipt is not None
+            and digest(self.checkpoint_durability_registration_receipt)
+            != self.checkpoint_durability_registration_receipt_digest
+        ):
+            raise ValueError("hydrate durability receipt digest mismatch")
+        return self
+
+
+class ContextDeletionReceiptV1(Closed):
+    """Closed rolling deletion evidence emitted for legacy durability rows."""
+
+    schema_version: Literal["ContextDeletionReceiptV1"] = "ContextDeletionReceiptV1"
+    context_cycle_id: Ident
+    segment_chain_root: Digest
+    context_seal_digest: Digest | None = None
+    retention_class: Literal["ephemeral", "audit"]
+    retention_expired_at: int = Field(ge=0)
+    deleted_at: int = Field(ge=0)
+    reason_code: Literal["policy_expiry", "operator_expiry"]
+    retention_operation_key: Ident
+    retention_request_digest: Digest
+    logical_deletion: Literal[True]
+    cryptographic_erasure: bool
+    local_key_destruction: dict | None = None
+    key_destruction_receipt: SignedV1 | None = None
+    key_destruction_receipt_digest: Digest | None = None
+    managed_key_provider_receipt_digest: Digest | None = None
+    remote_deletion_receipt_digest: Digest | None = None
+    checkpoint_manifest_checksum: Digest | None = None
+    checkpoint_object_ref_digest: Digest | None = None
+
+    @model_validator(mode="after")
+    def key_erasure_evidence(self) -> "ContextDeletionReceiptV1":
+        managed_parts = (
+            self.key_destruction_receipt,
+            self.key_destruction_receipt_digest,
+            self.managed_key_provider_receipt_digest,
+        )
+        managed_erasure = all(item is not None for item in managed_parts)
+        if any(item is not None for item in managed_parts) != managed_erasure:
+            raise ValueError("managed key destruction evidence must be complete")
+        if (
+            self.key_destruction_receipt is not None
+            and digest(self.key_destruction_receipt)
+            != self.key_destruction_receipt_digest
+        ):
+            raise ValueError("managed key destruction receipt digest mismatch")
+        if self.local_key_destruction is not None and managed_erasure:
+            raise ValueError("local and managed key destruction evidence are exclusive")
+        if self.cryptographic_erasure != managed_erasure:
+            raise ValueError("cryptographic erasure requires managed destruction evidence")
+        return self
+
+
+class ContextLocalKeyDestructionV1(Closed):
+    """Closed local key tombstone; it is canary evidence, not KMS erasure."""
+
+    schema_version: Literal["ContextLocalKeyDestructionV1"] = (
+        "ContextLocalKeyDestructionV1"
+    )
+    provider: Literal["file-wrapped-dek/v1"] = "file-wrapped-dek/v1"
+    key_ref: Ident
+    key_version: Ident
+    namespace_digest: Digest
+    wrapped_key_digest: Digest
+    destroyed_at: int = Field(ge=0)
+    verified: Literal[True]
+
+
+class ContextDeletionReceiptV2(Closed):
+    """Deletion evidence that binds the registered checkpoint durability mode."""
+
+    schema_version: Literal["ContextDeletionReceiptV2"] = "ContextDeletionReceiptV2"
+    context_cycle_id: Ident
+    segment_chain_root: Digest
+    context_seal_digest: Digest | None = None
+    retention_class: Literal["ephemeral", "audit"]
+    retention_expired_at: int = Field(ge=0)
+    deleted_at: int = Field(ge=0)
+    reason_code: Literal["policy_expiry", "operator_expiry"]
+    retention_operation_key: Ident
+    retention_request_digest: Digest
+    logical_deletion: Literal[True]
+    cryptographic_erasure: bool
+    local_key_destruction: ContextLocalKeyDestructionV1 | None = None
+    key_destruction_receipt: SignedV1 | None = None
+    key_destruction_receipt_digest: Digest | None = None
+    managed_key_provider_receipt_digest: Digest | None = None
+    remote_deletion_receipt_digest: Digest | None = None
+    checkpoint_manifest_checksum: Digest | None = None
+    checkpoint_object_ref_digest: Digest | None = None
+    checkpoint_durability_mode: Literal["unregistered", "local_ephemeral", "remote_registered"]
+    checkpoint_durability_registration_receipt_digest: Digest | None = None
+
+    @model_validator(mode="after")
+    def durability_evidence(self) -> "ContextDeletionReceiptV2":
+        managed_parts = (
+            self.key_destruction_receipt,
+            self.key_destruction_receipt_digest,
+            self.managed_key_provider_receipt_digest,
+        )
+        managed_erasure = all(item is not None for item in managed_parts)
+        if any(item is not None for item in managed_parts) != managed_erasure:
+            raise ValueError("managed key destruction evidence must be complete")
+        if (
+            self.key_destruction_receipt is not None
+            and digest(self.key_destruction_receipt)
+            != self.key_destruction_receipt_digest
+        ):
+            raise ValueError("managed key destruction receipt digest mismatch")
+        if self.local_key_destruction is not None and managed_erasure:
+            raise ValueError("local and managed key destruction evidence are exclusive")
+        if self.cryptographic_erasure != managed_erasure:
+            raise ValueError("cryptographic erasure requires managed destruction evidence")
+        if self.checkpoint_durability_mode == "unregistered":
+            if (
+                self.checkpoint_manifest_checksum is not None
+                or self.checkpoint_durability_registration_receipt_digest is not None
+                or self.remote_deletion_receipt_digest is not None
+                or self.checkpoint_object_ref_digest is not None
+            ):
+                raise ValueError("unregistered cleanup cannot contain checkpoint evidence")
+        elif self.checkpoint_durability_mode == "local_ephemeral":
+            if self.checkpoint_durability_registration_receipt_digest is None:
+                raise ValueError("local cleanup requires signed durability registration")
+            if (
+                self.remote_deletion_receipt_digest is not None
+                or self.checkpoint_object_ref_digest is not None
+            ):
+                raise ValueError("local cleanup cannot contain remote evidence")
+        else:
+            if self.checkpoint_durability_registration_receipt_digest is None:
+                raise ValueError("remote cleanup requires signed durability registration")
+            remote_evidence = (
+                self.remote_deletion_receipt_digest,
+                self.checkpoint_object_ref_digest,
+            )
+            if self.checkpoint_manifest_checksum is None:
+                if any(item is not None for item in remote_evidence):
+                    raise ValueError(
+                        "remote cleanup without a checkpoint cannot contain deletion evidence"
+                    )
+            elif any(item is None for item in remote_evidence):
+                raise ValueError(
+                    "remote checkpoint cleanup requires exact remote deletion evidence"
+                )
+        return self
+
+
 class RuntimeBuildManifestV1(Closed):
     """Signed build identity for the exact installed runtime package bytes."""
 
@@ -386,6 +1089,116 @@ class RuntimeBuildManifestV1(Closed):
     recall_dataset_digest: Digest
     data_plane_case_generator_digest: Digest | None = None
     built_at: int = Field(ge=0)
+
+
+class RuntimeEnvironmentV1(Closed):
+    """Live-measurable identity of the interpreter and hosted dependencies."""
+
+    schema_version: Literal["ContextRuntimeEnvironmentV1"] = (
+        "ContextRuntimeEnvironmentV1"
+    )
+    python_implementation: str = Field(min_length=1, max_length=40)
+    python_version: str = Field(min_length=1, max_length=40)
+    python_abi: str = Field(min_length=1, max_length=200)
+    python_executable_digest: Digest
+    dependency_versions: dict[str, str]
+    dependency_artifact_digests: dict[str, Digest]
+    sqlite_version: str = Field(min_length=1, max_length=40)
+    package_import_root_digest: Digest
+    bytecode_policy: Literal["source-only/no-bytecode/v1"] = (
+        "source-only/no-bytecode/v1"
+    )
+
+    @model_validator(mode="after")
+    def exact_hosted_dependencies(self) -> "RuntimeEnvironmentV1":
+        expected = {"cryptography", "numpy", "pydantic"}
+        if (
+            set(self.dependency_versions) != expected
+            or set(self.dependency_artifact_digests) != expected
+        ):
+            raise ValueError("runtime environment requires exact hosted dependency versions")
+        if any(
+            not isinstance(version, str) or not 1 <= len(version) <= 100
+            for version in self.dependency_versions.values()
+        ):
+            raise ValueError("runtime dependency versions are invalid")
+        return self
+
+
+class RuntimeBuildManifestV2(RuntimeBuildManifestV1):
+    """Build V1 plus a lock over the live executable runtime environment."""
+
+    schema_version: Literal["ContextRuntimeBuildManifestV2"] = "ContextRuntimeBuildManifestV2"  # type: ignore[assignment]
+    runtime_environment: RuntimeEnvironmentV1
+    locked_environment_digest: Digest
+
+    @model_validator(mode="after")
+    def environment_digest_matches(self) -> "RuntimeBuildManifestV2":
+        if digest(self.runtime_environment) != self.locked_environment_digest:
+            raise ValueError("runtime environment digest mismatch")
+        return self
+
+
+class RuntimeEnvironmentV2(Closed):
+    """Complete audited import closure for the hosted daemon."""
+
+    schema_version: Literal["ContextRuntimeEnvironmentV2"] = (
+        "ContextRuntimeEnvironmentV2"
+    )
+    python_implementation: str = Field(min_length=1, max_length=40)
+    python_version: str = Field(min_length=1, max_length=40)
+    python_abi: str = Field(min_length=1, max_length=200)
+    python_executable_digest: Digest
+    dependency_import_closure: list[str] = Field(min_length=6, max_length=32)
+    dependency_versions: dict[str, str]
+    dependency_artifact_digests: dict[str, Digest]
+    sqlite_version: str = Field(min_length=1, max_length=40)
+    package_import_root_digest: Digest
+    bytecode_policy: Literal["preimport-guard/source-only/v2"] = (
+        "preimport-guard/source-only/v2"
+    )
+
+    @model_validator(mode="after")
+    def complete_hosted_import_closure(self) -> "RuntimeEnvironmentV2":
+        required = {
+            "annotated-types",
+            "cffi",
+            "cryptography",
+            "numpy",
+            "pydantic",
+            "pydantic_core",
+            "pycparser",
+            "typing-inspection",
+            "typing_extensions",
+        }
+        closure = self.dependency_import_closure
+        if (
+            closure != sorted(set(closure))
+            or not required.issubset(closure)
+            or set(self.dependency_versions) != set(closure)
+            or set(self.dependency_artifact_digests) != set(closure)
+        ):
+            raise ValueError("runtime environment requires the audited import closure")
+        if any(
+            not isinstance(version, str) or not 1 <= len(version) <= 100
+            for version in self.dependency_versions.values()
+        ):
+            raise ValueError("runtime dependency versions are invalid")
+        return self
+
+
+class RuntimeBuildManifestV3(RuntimeBuildManifestV1):
+    """Build identity bound to the complete guarded executable environment."""
+
+    schema_version: Literal["ContextRuntimeBuildManifestV3"] = "ContextRuntimeBuildManifestV3"  # type: ignore[assignment]
+    runtime_environment: RuntimeEnvironmentV2
+    locked_environment_digest: Digest
+
+    @model_validator(mode="after")
+    def environment_digest_matches(self) -> "RuntimeBuildManifestV3":
+        if digest(self.runtime_environment) != self.locked_environment_digest:
+            raise ValueError("runtime environment digest mismatch")
+        return self
 
 
 class ExecutorStabilityReceiptV1(Closed):

--- a/aether_context/contracts/schema-v1.json
+++ b/aether_context/contracts/schema-v1.json
@@ -103,6 +103,1703 @@
     "title": "ContextRequestV1",
     "type": "object"
   },
+  "ContextReservationReceiptV1": {
+    "additionalProperties": false,
+    "description": "Rolling-compatible service evidence for one exact reservation.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationReceiptV1",
+        "default": "ContextReservationReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "context_bucket_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Bucket Id",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "context_bucket_id",
+      "request_digest",
+      "profile_digest"
+    ],
+    "title": "ContextReservationReceiptV1",
+    "type": "object"
+  },
+  "ContextReservationCommandV2": {
+    "additionalProperties": false,
+    "description": "Revision-aware reservation and explicit post-release revival.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationCommandV2",
+        "default": "ContextReservationCommandV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "reserve",
+        "default": "reserve",
+        "title": "Operation",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      },
+      "released_revision": {
+        "anyOf": [
+          {
+            "minimum": 2,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Released Revision"
+      }
+    },
+    "required": [
+      "owner_id",
+      "project_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "expires_at"
+    ],
+    "title": "ContextReservationCommandV2",
+    "type": "object"
+  },
+  "ContextReservationReceiptV2": {
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationReceiptV2",
+        "default": "ContextReservationReceiptV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "context_bucket_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Bucket Id",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "revision": {
+        "minimum": 1,
+        "title": "Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "context_bucket_id",
+      "request_digest",
+      "profile_digest",
+      "revision"
+    ],
+    "title": "ContextReservationReceiptV2",
+    "type": "object"
+  },
+  "ContextReservationCommandV3": {
+    "$defs": {
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Reservation revival authorized by an exact no-dispatch expiry receipt.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationCommandV3",
+        "default": "ContextReservationCommandV3",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "reserve",
+        "default": "reserve",
+        "title": "Operation",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      },
+      "expired_reservation_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      }
+    },
+    "required": [
+      "owner_id",
+      "project_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "expires_at",
+      "expired_reservation_receipt"
+    ],
+    "title": "ContextReservationCommandV3",
+    "type": "object"
+  },
+  "ContextReservationReceiptV3": {
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationReceiptV3",
+        "default": "ContextReservationReceiptV3",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "context_bucket_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Bucket Id",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "revision": {
+        "minimum": 3,
+        "title": "Revision",
+        "type": "integer"
+      },
+      "prior_expiry_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Prior Expiry Receipt Digest",
+        "type": "string"
+      },
+      "prior_expiry_revision": {
+        "minimum": 2,
+        "title": "Prior Expiry Revision",
+        "type": "integer"
+      },
+      "invocation_no_dispatch_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Invocation No Dispatch Receipt Digest",
+        "type": "string"
+      },
+      "revival_command_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Revival Command Digest",
+        "type": "string"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "context_bucket_id",
+      "request_digest",
+      "profile_digest",
+      "revision",
+      "prior_expiry_receipt_digest",
+      "prior_expiry_revision",
+      "invocation_no_dispatch_receipt_digest",
+      "revival_command_digest"
+    ],
+    "title": "ContextReservationReceiptV3",
+    "type": "object"
+  },
+  "ContextReservationReleaseCommandV1": {
+    "additionalProperties": false,
+    "description": "Gateway proof that authorization failed before objective dispatch.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationReleaseCommandV1",
+        "default": "ContextReservationReleaseCommandV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "release_reservation",
+        "default": "release_reservation",
+        "title": "Operation",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "expected_revision": {
+        "minimum": 1,
+        "title": "Expected Revision",
+        "type": "integer"
+      },
+      "reason_code": {
+        "const": "pre_dispatch_authorization_failed",
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "dispatch_started": {
+        "const": false,
+        "title": "Dispatch Started",
+        "type": "boolean"
+      },
+      "authorization_failure_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Authorization Failure Receipt Digest",
+        "type": "string"
+      },
+      "issued_at": {
+        "minimum": 0,
+        "title": "Issued At",
+        "type": "integer"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "owner_id",
+      "project_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "expected_revision",
+      "reason_code",
+      "dispatch_started",
+      "authorization_failure_receipt_digest",
+      "issued_at",
+      "expires_at"
+    ],
+    "title": "ContextReservationReleaseCommandV1",
+    "type": "object"
+  },
+  "ContextReservationReleaseReceiptV1": {
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationReleaseReceiptV1",
+        "default": "ContextReservationReleaseReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "release_reservation",
+        "default": "release_reservation",
+        "title": "Operation",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "authorization_failure_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Authorization Failure Receipt Digest",
+        "type": "string"
+      },
+      "release_command_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Release Command Digest",
+        "type": "string"
+      },
+      "final_state": {
+        "const": "EXPIRED",
+        "default": "EXPIRED",
+        "title": "Final State",
+        "type": "string"
+      },
+      "released": {
+        "const": true,
+        "default": true,
+        "title": "Released",
+        "type": "boolean"
+      },
+      "revision": {
+        "minimum": 2,
+        "title": "Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "owner_id",
+      "project_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "authorization_failure_receipt_digest",
+      "release_command_digest",
+      "revision"
+    ],
+    "title": "ContextReservationReleaseReceiptV1",
+    "type": "object"
+  },
+  "ContextReservationAbortCommandV1": {
+    "$defs": {
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Gateway proof that a dispatched objective stalled before context bind.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationAbortCommandV1",
+        "default": "ContextReservationAbortCommandV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "abort_reservation",
+        "default": "abort_reservation",
+        "title": "Operation",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "objective_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Objective Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "expected_revision": {
+        "minimum": 1,
+        "title": "Expected Revision",
+        "type": "integer"
+      },
+      "reason_code": {
+        "enum": [
+          "timeout",
+          "cancel",
+          "reconciliation_failed"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "dispatch_started": {
+        "const": true,
+        "title": "Dispatch Started",
+        "type": "boolean"
+      },
+      "objective_dispatch_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Objective Dispatch Receipt Digest",
+        "type": "string"
+      },
+      "reservation_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      },
+      "issued_at": {
+        "minimum": 0,
+        "title": "Issued At",
+        "type": "integer"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "owner_id",
+      "project_id",
+      "objective_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "expected_revision",
+      "reason_code",
+      "dispatch_started",
+      "objective_dispatch_receipt_digest",
+      "reservation_receipt",
+      "issued_at",
+      "expires_at"
+    ],
+    "title": "ContextReservationAbortCommandV1",
+    "type": "object"
+  },
+  "ContextReservationAbortReceiptV1": {
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationAbortReceiptV1",
+        "default": "ContextReservationAbortReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "abort_reservation",
+        "default": "abort_reservation",
+        "title": "Operation",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "objective_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Objective Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "reason_code": {
+        "enum": [
+          "timeout",
+          "cancel",
+          "reconciliation_failed"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "objective_dispatch_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Objective Dispatch Receipt Digest",
+        "type": "string"
+      },
+      "reservation_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Reservation Receipt Digest",
+        "type": "string"
+      },
+      "abort_command_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Abort Command Digest",
+        "type": "string"
+      },
+      "final_state": {
+        "const": "ABORTED",
+        "default": "ABORTED",
+        "title": "Final State",
+        "type": "string"
+      },
+      "aborted": {
+        "const": true,
+        "default": true,
+        "title": "Aborted",
+        "type": "boolean"
+      },
+      "aborted_at": {
+        "minimum": 0,
+        "title": "Aborted At",
+        "type": "integer"
+      },
+      "retention_expires_at": {
+        "minimum": 0,
+        "title": "Retention Expires At",
+        "type": "integer"
+      },
+      "revision": {
+        "minimum": 2,
+        "title": "Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "owner_id",
+      "project_id",
+      "objective_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "reason_code",
+      "objective_dispatch_receipt_digest",
+      "reservation_receipt_digest",
+      "abort_command_digest",
+      "aborted_at",
+      "retention_expires_at",
+      "revision"
+    ],
+    "title": "ContextReservationAbortReceiptV1",
+    "type": "object"
+  },
+  "ContextReservationAbortExpiryCommandV1": {
+    "$defs": {
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      },
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Authority to clean one terminal, never-bound reservation after retention.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationAbortExpiryCommandV1",
+        "default": "ContextReservationAbortExpiryCommandV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "expire_aborted_reservation",
+        "default": "expire_aborted_reservation",
+        "title": "Operation",
+        "type": "string"
+      },
+      "namespace": {
+        "$ref": "#/$defs/NamespaceV1"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "expected_revision": {
+        "minimum": 2,
+        "title": "Expected Revision",
+        "type": "integer"
+      },
+      "reason_code": {
+        "enum": [
+          "policy_expiry",
+          "operator_expiry"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "abort_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      },
+      "issued_at": {
+        "minimum": 0,
+        "title": "Issued At",
+        "type": "integer"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "namespace",
+      "idempotency_key",
+      "expected_revision",
+      "reason_code",
+      "abort_receipt",
+      "issued_at",
+      "expires_at"
+    ],
+    "title": "ContextReservationAbortExpiryCommandV1",
+    "type": "object"
+  },
+  "ContextInvocationNoDispatchSnapshotV1": {
+    "additionalProperties": false,
+    "description": "Exact atomically locked Cloud dispatch-fence projection.",
+    "properties": {
+      "owner_user_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner User Id",
+        "type": "string"
+      },
+      "objective_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Objective Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^sha256:[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "reservation_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Reservation Receipt Digest",
+        "type": "string"
+      },
+      "reservation_revision": {
+        "minimum": 1,
+        "title": "Reservation Revision",
+        "type": "integer"
+      },
+      "state": {
+        "const": "closed_without_dispatch",
+        "title": "State",
+        "type": "string"
+      },
+      "revision": {
+        "minimum": 1,
+        "title": "Revision",
+        "type": "integer"
+      },
+      "canonical_result_state": {
+        "enum": [
+          "absent",
+          "planned",
+          "blocked_without_authority"
+        ],
+        "title": "Canonical Result State",
+        "type": "string"
+      },
+      "canonical_result_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Canonical Result Digest"
+      }
+    },
+    "required": [
+      "owner_user_id",
+      "objective_id",
+      "idempotency_key",
+      "request_digest",
+      "context_cycle_id",
+      "reservation_receipt_digest",
+      "reservation_revision",
+      "state",
+      "revision",
+      "canonical_result_state"
+    ],
+    "title": "ContextInvocationNoDispatchSnapshotV1",
+    "type": "object"
+  },
+  "ContextInvocationNoDispatchReceiptV1": {
+    "$defs": {
+      "ContextInvocationNoDispatchSnapshotV1": {
+        "additionalProperties": false,
+        "description": "Exact atomically locked Cloud dispatch-fence projection.",
+        "properties": {
+          "owner_user_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner User Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "idempotency_key": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Idempotency Key",
+            "type": "string"
+          },
+          "request_digest": {
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "title": "Request Digest",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          },
+          "reservation_receipt_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Reservation Receipt Digest",
+            "type": "string"
+          },
+          "reservation_revision": {
+            "minimum": 1,
+            "title": "Reservation Revision",
+            "type": "integer"
+          },
+          "state": {
+            "const": "closed_without_dispatch",
+            "title": "State",
+            "type": "string"
+          },
+          "revision": {
+            "minimum": 1,
+            "title": "Revision",
+            "type": "integer"
+          },
+          "canonical_result_state": {
+            "enum": [
+              "absent",
+              "planned",
+              "blocked_without_authority"
+            ],
+            "title": "Canonical Result State",
+            "type": "string"
+          },
+          "canonical_result_digest": {
+            "anyOf": [
+              {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Canonical Result Digest"
+          }
+        },
+        "required": [
+          "owner_user_id",
+          "objective_id",
+          "idempotency_key",
+          "request_digest",
+          "context_cycle_id",
+          "reservation_receipt_digest",
+          "reservation_revision",
+          "state",
+          "revision",
+          "canonical_result_state"
+        ],
+        "title": "ContextInvocationNoDispatchSnapshotV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Signed exact snapshot of a terminal Cloud dispatch fence.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextInvocationNoDispatchReceiptV1",
+        "default": "ContextInvocationNoDispatchReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "close_without_dispatch",
+        "default": "close_without_dispatch",
+        "title": "Operation",
+        "type": "string"
+      },
+      "ledger_snapshot": {
+        "$ref": "#/$defs/ContextInvocationNoDispatchSnapshotV1"
+      },
+      "ledger_snapshot_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Ledger Snapshot Digest",
+        "type": "string"
+      },
+      "issued_at": {
+        "minimum": 0,
+        "title": "Issued At",
+        "type": "integer"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "ledger_snapshot",
+      "ledger_snapshot_digest",
+      "issued_at",
+      "expires_at"
+    ],
+    "title": "ContextInvocationNoDispatchReceiptV1",
+    "type": "object"
+  },
+  "ContextReservationExpiryCommandV1": {
+    "$defs": {
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Expire a clean reservation after canonical dispatch has been fenced out.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationExpiryCommandV1",
+        "default": "ContextReservationExpiryCommandV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "expire_reservation",
+        "default": "expire_reservation",
+        "title": "Operation",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "context_bucket_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Bucket Id",
+        "type": "string"
+      },
+      "objective_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Objective Id",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "expected_revision": {
+        "minimum": 1,
+        "title": "Expected Revision",
+        "type": "integer"
+      },
+      "reason_code": {
+        "enum": [
+          "reservation_timeout",
+          "client_cancel",
+          "reconciliation_failed"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "reservation_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      },
+      "invocation_no_dispatch_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      },
+      "invocation_no_dispatch_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Invocation No Dispatch Receipt Digest",
+        "type": "string"
+      },
+      "issued_at": {
+        "minimum": 0,
+        "title": "Issued At",
+        "type": "integer"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "context_bucket_id",
+      "objective_id",
+      "owner_id",
+      "project_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "expected_revision",
+      "reason_code",
+      "reservation_receipt",
+      "invocation_no_dispatch_receipt",
+      "invocation_no_dispatch_receipt_digest",
+      "issued_at",
+      "expires_at"
+    ],
+    "title": "ContextReservationExpiryCommandV1",
+    "type": "object"
+  },
+  "ContextReservationExpiryReceiptV1": {
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextReservationExpiryReceiptV1",
+        "default": "ContextReservationExpiryReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "expire_reservation",
+        "default": "expire_reservation",
+        "title": "Operation",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "context_bucket_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Bucket Id",
+        "type": "string"
+      },
+      "objective_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Objective Id",
+        "type": "string"
+      },
+      "owner_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Owner Id",
+        "type": "string"
+      },
+      "project_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Project Id",
+        "type": "string"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Request Digest",
+        "type": "string"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "reason_code": {
+        "enum": [
+          "reservation_timeout",
+          "client_cancel",
+          "reconciliation_failed"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "reservation_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Reservation Receipt Digest",
+        "type": "string"
+      },
+      "invocation_no_dispatch_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Invocation No Dispatch Receipt Digest",
+        "type": "string"
+      },
+      "expiry_command_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Expiry Command Digest",
+        "type": "string"
+      },
+      "final_state": {
+        "const": "EXPIRED",
+        "default": "EXPIRED",
+        "title": "Final State",
+        "type": "string"
+      },
+      "expired": {
+        "const": true,
+        "default": true,
+        "title": "Expired",
+        "type": "boolean"
+      },
+      "revivable": {
+        "const": true,
+        "default": true,
+        "title": "Revivable",
+        "type": "boolean"
+      },
+      "expired_at": {
+        "minimum": 0,
+        "title": "Expired At",
+        "type": "integer"
+      },
+      "revision": {
+        "minimum": 2,
+        "title": "Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "context_bucket_id",
+      "objective_id",
+      "owner_id",
+      "project_id",
+      "idempotency_key",
+      "request_digest",
+      "profile_digest",
+      "reason_code",
+      "reservation_receipt_digest",
+      "invocation_no_dispatch_receipt_digest",
+      "expiry_command_digest",
+      "expired_at",
+      "revision"
+    ],
+    "title": "ContextReservationExpiryReceiptV1",
+    "type": "object"
+  },
+  "ContextCheckpointDurabilityCommandV1": {
+    "$defs": {
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Immutable per-cycle choice between local-only and remote checkpoints.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextCheckpointDurabilityCommandV1",
+        "default": "ContextCheckpointDurabilityCommandV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "register_checkpoint_durability",
+        "default": "register_checkpoint_durability",
+        "title": "Operation",
+        "type": "string"
+      },
+      "namespace": {
+        "$ref": "#/$defs/NamespaceV1"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "expected_revision": {
+        "minimum": 1,
+        "title": "Expected Revision",
+        "type": "integer"
+      },
+      "mode": {
+        "enum": [
+          "local_ephemeral",
+          "remote_registered"
+        ],
+        "title": "Mode",
+        "type": "string"
+      },
+      "issued_at": {
+        "minimum": 0,
+        "title": "Issued At",
+        "type": "integer"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "namespace",
+      "idempotency_key",
+      "expected_revision",
+      "mode",
+      "issued_at",
+      "expires_at"
+    ],
+    "title": "ContextCheckpointDurabilityCommandV1",
+    "type": "object"
+  },
+  "ContextCheckpointDurabilityReceiptV1": {
+    "$defs": {
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextCheckpointDurabilityReceiptV1",
+        "default": "ContextCheckpointDurabilityReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "register_checkpoint_durability",
+        "default": "register_checkpoint_durability",
+        "title": "Operation",
+        "type": "string"
+      },
+      "namespace": {
+        "$ref": "#/$defs/NamespaceV1"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "mode": {
+        "enum": [
+          "local_ephemeral",
+          "remote_registered"
+        ],
+        "title": "Mode",
+        "type": "string"
+      },
+      "command_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Command Digest",
+        "type": "string"
+      },
+      "effective_at": {
+        "minimum": 0,
+        "title": "Effective At",
+        "type": "integer"
+      },
+      "revision": {
+        "minimum": 2,
+        "title": "Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "namespace",
+      "idempotency_key",
+      "mode",
+      "command_digest",
+      "effective_at",
+      "revision"
+    ],
+    "title": "ContextCheckpointDurabilityReceiptV1",
+    "type": "object"
+  },
+  "ContextCheckpointDurabilityReceiptV2": {
+    "$defs": {
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      },
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Replacement-host attestation over exact source registration evidence.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextCheckpointDurabilityReceiptV2",
+        "default": "ContextCheckpointDurabilityReceiptV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "register_checkpoint_durability",
+        "default": "register_checkpoint_durability",
+        "title": "Operation",
+        "type": "string"
+      },
+      "namespace": {
+        "$ref": "#/$defs/NamespaceV1"
+      },
+      "idempotency_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Idempotency Key",
+        "type": "string"
+      },
+      "mode": {
+        "enum": [
+          "local_ephemeral",
+          "remote_registered"
+        ],
+        "title": "Mode",
+        "type": "string"
+      },
+      "command_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Command Digest",
+        "type": "string"
+      },
+      "effective_at": {
+        "minimum": 0,
+        "title": "Effective At",
+        "type": "integer"
+      },
+      "revision": {
+        "minimum": 2,
+        "title": "Revision",
+        "type": "integer"
+      },
+      "source_registration_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      },
+      "source_registration_receipt_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Source Registration Receipt Digest",
+        "type": "string"
+      },
+      "reattested_at": {
+        "minimum": 0,
+        "title": "Reattested At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "namespace",
+      "idempotency_key",
+      "mode",
+      "command_digest",
+      "effective_at",
+      "revision",
+      "source_registration_receipt",
+      "source_registration_receipt_digest",
+      "reattested_at"
+    ],
+    "title": "ContextCheckpointDurabilityReceiptV2",
+    "type": "object"
+  },
   "ContextProfileV1": {
     "additionalProperties": false,
     "properties": {
@@ -626,6 +2323,464 @@
     "title": "SignedV1",
     "type": "object"
   },
+  "ContextBindingCommandV2": {
+    "$defs": {
+      "ContextBindingV1": {
+        "additionalProperties": false,
+        "properties": {
+          "schema_version": {
+            "const": "ContextBindingV1",
+            "default": "ContextBindingV1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "namespace": {
+            "$ref": "#/$defs/NamespaceV1"
+          },
+          "context_bucket_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Bucket Id",
+            "type": "string"
+          },
+          "repository_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "repo_main_sha": {
+            "pattern": "^[0-9a-f]{40}$",
+            "title": "Repo Main Sha",
+            "type": "string"
+          },
+          "project_graph_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Graph Id",
+            "type": "string"
+          },
+          "graph_revision": {
+            "minimum": 1,
+            "title": "Graph Revision",
+            "type": "integer"
+          },
+          "graph_checksum": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Graph Checksum",
+            "type": "string"
+          },
+          "plan_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Plan Digest",
+            "type": "string"
+          },
+          "execution_profile_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Execution Profile Digest",
+            "type": "string"
+          },
+          "shared_ir_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Shared Ir Digest",
+            "type": "string"
+          },
+          "authorization_receipt_ref": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Authorization Receipt Ref",
+            "type": "string"
+          },
+          "authorization_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Authorization Digest",
+            "type": "string"
+          },
+          "policy_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Policy Digest",
+            "type": "string"
+          },
+          "redaction_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Redaction Digest",
+            "type": "string"
+          },
+          "profile_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Profile Digest",
+            "type": "string"
+          },
+          "captain_binding_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Captain Binding Id",
+            "type": "string"
+          },
+          "retention_class": {
+            "default": "ephemeral",
+            "enum": [
+              "ephemeral",
+              "audit"
+            ],
+            "title": "Retention Class",
+            "type": "string"
+          },
+          "created_at": {
+            "minimum": 0,
+            "title": "Created At",
+            "type": "integer"
+          },
+          "expires_at": {
+            "minimum": 0,
+            "title": "Expires At",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "namespace",
+          "context_bucket_id",
+          "repository_id",
+          "repo_main_sha",
+          "project_graph_id",
+          "graph_revision",
+          "graph_checksum",
+          "plan_digest",
+          "execution_profile_digest",
+          "shared_ir_digest",
+          "authorization_receipt_ref",
+          "authorization_digest",
+          "policy_digest",
+          "redaction_digest",
+          "profile_digest",
+          "captain_binding_id",
+          "created_at",
+          "expires_at"
+        ],
+        "title": "ContextBindingV1",
+        "type": "object"
+      },
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      },
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Revision-CAS wrapper that keeps the persisted binding itself at V1.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextBindingCommandV2",
+        "default": "ContextBindingCommandV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "bind",
+        "default": "bind",
+        "title": "Operation",
+        "type": "string"
+      },
+      "binding": {
+        "$ref": "#/$defs/ContextBindingV1"
+      },
+      "reservation_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      },
+      "expected_reservation_revision": {
+        "minimum": 1,
+        "title": "Expected Reservation Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "binding",
+      "reservation_receipt",
+      "expected_reservation_revision"
+    ],
+    "title": "ContextBindingCommandV2",
+    "type": "object"
+  },
+  "ContextBindingCommandV3": {
+    "$defs": {
+      "ContextBindingV1": {
+        "additionalProperties": false,
+        "properties": {
+          "schema_version": {
+            "const": "ContextBindingV1",
+            "default": "ContextBindingV1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "namespace": {
+            "$ref": "#/$defs/NamespaceV1"
+          },
+          "context_bucket_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Bucket Id",
+            "type": "string"
+          },
+          "repository_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Repository Id",
+            "type": "string"
+          },
+          "repo_main_sha": {
+            "pattern": "^[0-9a-f]{40}$",
+            "title": "Repo Main Sha",
+            "type": "string"
+          },
+          "project_graph_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Graph Id",
+            "type": "string"
+          },
+          "graph_revision": {
+            "minimum": 1,
+            "title": "Graph Revision",
+            "type": "integer"
+          },
+          "graph_checksum": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Graph Checksum",
+            "type": "string"
+          },
+          "plan_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Plan Digest",
+            "type": "string"
+          },
+          "execution_profile_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Execution Profile Digest",
+            "type": "string"
+          },
+          "shared_ir_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Shared Ir Digest",
+            "type": "string"
+          },
+          "authorization_receipt_ref": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Authorization Receipt Ref",
+            "type": "string"
+          },
+          "authorization_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Authorization Digest",
+            "type": "string"
+          },
+          "policy_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Policy Digest",
+            "type": "string"
+          },
+          "redaction_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Redaction Digest",
+            "type": "string"
+          },
+          "profile_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Profile Digest",
+            "type": "string"
+          },
+          "captain_binding_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Captain Binding Id",
+            "type": "string"
+          },
+          "retention_class": {
+            "default": "ephemeral",
+            "enum": [
+              "ephemeral",
+              "audit"
+            ],
+            "title": "Retention Class",
+            "type": "string"
+          },
+          "created_at": {
+            "minimum": 0,
+            "title": "Created At",
+            "type": "integer"
+          },
+          "expires_at": {
+            "minimum": 0,
+            "title": "Expires At",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "namespace",
+          "context_bucket_id",
+          "repository_id",
+          "repo_main_sha",
+          "project_graph_id",
+          "graph_revision",
+          "graph_checksum",
+          "plan_digest",
+          "execution_profile_digest",
+          "shared_ir_digest",
+          "authorization_receipt_ref",
+          "authorization_digest",
+          "policy_digest",
+          "redaction_digest",
+          "profile_digest",
+          "captain_binding_id",
+          "created_at",
+          "expires_at"
+        ],
+        "title": "ContextBindingV1",
+        "type": "object"
+      },
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      },
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Bind an expiry-revived reservation to its exact V3 lineage.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextBindingCommandV3",
+        "default": "ContextBindingCommandV3",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "bind",
+        "default": "bind",
+        "title": "Operation",
+        "type": "string"
+      },
+      "binding": {
+        "$ref": "#/$defs/ContextBindingV1"
+      },
+      "reservation_receipt": {
+        "$ref": "#/$defs/SignedV1"
+      },
+      "expected_reservation_revision": {
+        "minimum": 3,
+        "title": "Expected Reservation Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "binding",
+      "reservation_receipt",
+      "expected_reservation_revision"
+    ],
+    "title": "ContextBindingCommandV3",
+    "type": "object"
+  },
   "PromotionCandidateV1": {
     "additionalProperties": false,
     "properties": {
@@ -800,6 +2955,1301 @@
     "title": "ContextCheckpointReceiptV1",
     "type": "object"
   },
+  "ContextHydrateCommandV2": {
+    "$defs": {
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Short-lived recovery authority for one checkpoint and runtime source.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextHydrateCommandV2",
+        "default": "ContextHydrateCommandV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "hydrate",
+        "default": "hydrate",
+        "title": "Operation",
+        "type": "string"
+      },
+      "namespace": {
+        "$ref": "#/$defs/NamespaceV1"
+      },
+      "manifest_checksum": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Manifest Checksum",
+        "type": "string"
+      },
+      "key_ref": {
+        "anyOf": [
+          {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Ref"
+      },
+      "key_provider": {
+        "anyOf": [
+          {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Provider"
+      },
+      "key_version": {
+        "anyOf": [
+          {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Version"
+      },
+      "fence": {
+        "minimum": 1,
+        "title": "Fence",
+        "type": "integer"
+      },
+      "expected_source_revision": {
+        "pattern": "^[0-9a-f]{40}$",
+        "title": "Expected Source Revision",
+        "type": "string"
+      },
+      "issued_at": {
+        "minimum": 0,
+        "title": "Issued At",
+        "type": "integer"
+      },
+      "expires_at": {
+        "minimum": 0,
+        "title": "Expires At",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "namespace",
+      "manifest_checksum",
+      "fence",
+      "expected_source_revision",
+      "issued_at",
+      "expires_at"
+    ],
+    "title": "ContextHydrateCommandV2",
+    "type": "object"
+  },
+  "ContextHealthV1": {
+    "additionalProperties": false,
+    "description": "Returned daemon health identity and measured readiness evidence.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextHealthV1",
+        "default": "ContextHealthV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "ready": {
+        "title": "Ready",
+        "type": "boolean"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "index_implementation": {
+        "maxLength": 100,
+        "minLength": 1,
+        "title": "Index Implementation",
+        "type": "string"
+      },
+      "index_version": {
+        "maxLength": 100,
+        "minLength": 1,
+        "title": "Index Version",
+        "type": "string"
+      },
+      "disk_free_bytes": {
+        "minimum": 0,
+        "title": "Disk Free Bytes",
+        "type": "integer"
+      },
+      "resident_cache_limit_bytes": {
+        "minimum": 0,
+        "title": "Resident Cache Limit Bytes",
+        "type": "integer"
+      },
+      "resident_process_limit_bytes": {
+        "minimum": 0,
+        "title": "Resident Process Limit Bytes",
+        "type": "integer"
+      },
+      "resident_process_observed_peak_bytes": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Resident Process Observed Peak Bytes"
+      },
+      "configured_max_records": {
+        "minimum": 1,
+        "title": "Configured Max Records",
+        "type": "integer"
+      },
+      "configured_max_indexed_bytes": {
+        "minimum": 1,
+        "title": "Configured Max Indexed Bytes",
+        "type": "integer"
+      },
+      "configured_reachable_tokens_upper_bound": {
+        "minimum": 0,
+        "title": "Configured Reachable Tokens Upper Bound",
+        "type": "integer"
+      },
+      "measured_indexed_records": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Measured Indexed Records"
+      },
+      "measured_indexed_bytes": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Measured Indexed Bytes"
+      },
+      "estimated_reachable_tokens": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Estimated Reachable Tokens"
+      },
+      "reach_claim_enabled": {
+        "title": "Reach Claim Enabled",
+        "type": "boolean"
+      },
+      "benchmark_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Benchmark Failures",
+        "type": "array"
+      },
+      "benchmark_source_revision": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{40}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Source Revision"
+      },
+      "benchmark_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Receipt Digest"
+      },
+      "benchmark_recall_dataset_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Recall Dataset Digest"
+      },
+      "runtime_build_ready": {
+        "title": "Runtime Build Ready",
+        "type": "boolean"
+      },
+      "runtime_build_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Runtime Build Failures",
+        "type": "array"
+      },
+      "runtime_build_manifest_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Build Manifest Digest"
+      },
+      "runtime_source_revision": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{40}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Source Revision"
+      },
+      "runtime_data_plane_case_generator_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Data Plane Case Generator Digest"
+      },
+      "cycle_key_provider": {
+        "anyOf": [
+          {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Cycle Key Provider"
+      },
+      "managed_cycle_keys_ready": {
+        "title": "Managed Cycle Keys Ready",
+        "type": "boolean"
+      },
+      "managed_cycle_key_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Managed Cycle Key Failures",
+        "type": "array"
+      },
+      "managed_key_provider_receipt_digests": {
+        "additionalProperties": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "title": "Managed Key Provider Receipt Digests",
+        "type": "object"
+      },
+      "managed_key_provider_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Managed Key Provider Receipt Digest"
+      }
+    },
+    "required": [
+      "ready",
+      "profile_digest",
+      "index_implementation",
+      "index_version",
+      "disk_free_bytes",
+      "resident_cache_limit_bytes",
+      "resident_process_limit_bytes",
+      "configured_max_records",
+      "configured_max_indexed_bytes",
+      "configured_reachable_tokens_upper_bound",
+      "reach_claim_enabled",
+      "benchmark_failures",
+      "runtime_build_ready",
+      "runtime_build_failures",
+      "managed_cycle_keys_ready",
+      "managed_cycle_key_failures",
+      "managed_key_provider_receipt_digests"
+    ],
+    "title": "ContextHealthV1",
+    "type": "object"
+  },
+  "ContextHealthV2": {
+    "additionalProperties": false,
+    "description": "Health V1 plus the measured executable runtime identity.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextHealthV2",
+        "default": "ContextHealthV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "ready": {
+        "title": "Ready",
+        "type": "boolean"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "index_implementation": {
+        "maxLength": 100,
+        "minLength": 1,
+        "title": "Index Implementation",
+        "type": "string"
+      },
+      "index_version": {
+        "maxLength": 100,
+        "minLength": 1,
+        "title": "Index Version",
+        "type": "string"
+      },
+      "disk_free_bytes": {
+        "minimum": 0,
+        "title": "Disk Free Bytes",
+        "type": "integer"
+      },
+      "resident_cache_limit_bytes": {
+        "minimum": 0,
+        "title": "Resident Cache Limit Bytes",
+        "type": "integer"
+      },
+      "resident_process_limit_bytes": {
+        "minimum": 0,
+        "title": "Resident Process Limit Bytes",
+        "type": "integer"
+      },
+      "resident_process_observed_peak_bytes": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Resident Process Observed Peak Bytes"
+      },
+      "configured_max_records": {
+        "minimum": 1,
+        "title": "Configured Max Records",
+        "type": "integer"
+      },
+      "configured_max_indexed_bytes": {
+        "minimum": 1,
+        "title": "Configured Max Indexed Bytes",
+        "type": "integer"
+      },
+      "configured_reachable_tokens_upper_bound": {
+        "minimum": 0,
+        "title": "Configured Reachable Tokens Upper Bound",
+        "type": "integer"
+      },
+      "measured_indexed_records": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Measured Indexed Records"
+      },
+      "measured_indexed_bytes": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Measured Indexed Bytes"
+      },
+      "estimated_reachable_tokens": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Estimated Reachable Tokens"
+      },
+      "reach_claim_enabled": {
+        "title": "Reach Claim Enabled",
+        "type": "boolean"
+      },
+      "benchmark_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Benchmark Failures",
+        "type": "array"
+      },
+      "benchmark_source_revision": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{40}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Source Revision"
+      },
+      "benchmark_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Receipt Digest"
+      },
+      "benchmark_recall_dataset_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Recall Dataset Digest"
+      },
+      "runtime_build_ready": {
+        "title": "Runtime Build Ready",
+        "type": "boolean"
+      },
+      "runtime_build_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Runtime Build Failures",
+        "type": "array"
+      },
+      "runtime_build_manifest_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Build Manifest Digest"
+      },
+      "runtime_source_revision": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{40}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Source Revision"
+      },
+      "runtime_data_plane_case_generator_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Data Plane Case Generator Digest"
+      },
+      "cycle_key_provider": {
+        "anyOf": [
+          {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Cycle Key Provider"
+      },
+      "managed_cycle_keys_ready": {
+        "title": "Managed Cycle Keys Ready",
+        "type": "boolean"
+      },
+      "managed_cycle_key_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Managed Cycle Key Failures",
+        "type": "array"
+      },
+      "managed_key_provider_receipt_digests": {
+        "additionalProperties": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "title": "Managed Key Provider Receipt Digests",
+        "type": "object"
+      },
+      "managed_key_provider_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Managed Key Provider Receipt Digest"
+      },
+      "runtime_package_tree_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Package Tree Digest"
+      },
+      "runtime_locked_environment_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Locked Environment Digest"
+      },
+      "runtime_python_implementation": {
+        "anyOf": [
+          {
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Implementation"
+      },
+      "runtime_python_version": {
+        "anyOf": [
+          {
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Version"
+      },
+      "runtime_python_abi": {
+        "anyOf": [
+          {
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Abi"
+      },
+      "runtime_python_executable_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Executable Digest"
+      },
+      "runtime_dependency_versions": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "Runtime Dependency Versions",
+        "type": "object"
+      },
+      "runtime_dependency_artifact_digests": {
+        "additionalProperties": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "title": "Runtime Dependency Artifact Digests",
+        "type": "object"
+      },
+      "runtime_sqlite_version": {
+        "anyOf": [
+          {
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Sqlite Version"
+      },
+      "runtime_package_import_root_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Package Import Root Digest"
+      },
+      "runtime_bytecode_policy": {
+        "anyOf": [
+          {
+            "const": "source-only/no-bytecode/v1",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Bytecode Policy"
+      }
+    },
+    "required": [
+      "ready",
+      "profile_digest",
+      "index_implementation",
+      "index_version",
+      "disk_free_bytes",
+      "resident_cache_limit_bytes",
+      "resident_process_limit_bytes",
+      "configured_max_records",
+      "configured_max_indexed_bytes",
+      "configured_reachable_tokens_upper_bound",
+      "reach_claim_enabled",
+      "benchmark_failures",
+      "runtime_build_ready",
+      "runtime_build_failures",
+      "managed_cycle_keys_ready",
+      "managed_cycle_key_failures",
+      "managed_key_provider_receipt_digests",
+      "runtime_dependency_versions",
+      "runtime_dependency_artifact_digests"
+    ],
+    "title": "ContextHealthV2",
+    "type": "object"
+  },
+  "ContextHealthV3": {
+    "additionalProperties": false,
+    "description": "Health V2 plus the guarded complete dependency import closure.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextHealthV3",
+        "default": "ContextHealthV3",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "ready": {
+        "title": "Ready",
+        "type": "boolean"
+      },
+      "profile_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Profile Digest",
+        "type": "string"
+      },
+      "index_implementation": {
+        "maxLength": 100,
+        "minLength": 1,
+        "title": "Index Implementation",
+        "type": "string"
+      },
+      "index_version": {
+        "maxLength": 100,
+        "minLength": 1,
+        "title": "Index Version",
+        "type": "string"
+      },
+      "disk_free_bytes": {
+        "minimum": 0,
+        "title": "Disk Free Bytes",
+        "type": "integer"
+      },
+      "resident_cache_limit_bytes": {
+        "minimum": 0,
+        "title": "Resident Cache Limit Bytes",
+        "type": "integer"
+      },
+      "resident_process_limit_bytes": {
+        "minimum": 0,
+        "title": "Resident Process Limit Bytes",
+        "type": "integer"
+      },
+      "resident_process_observed_peak_bytes": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Resident Process Observed Peak Bytes"
+      },
+      "configured_max_records": {
+        "minimum": 1,
+        "title": "Configured Max Records",
+        "type": "integer"
+      },
+      "configured_max_indexed_bytes": {
+        "minimum": 1,
+        "title": "Configured Max Indexed Bytes",
+        "type": "integer"
+      },
+      "configured_reachable_tokens_upper_bound": {
+        "minimum": 0,
+        "title": "Configured Reachable Tokens Upper Bound",
+        "type": "integer"
+      },
+      "measured_indexed_records": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Measured Indexed Records"
+      },
+      "measured_indexed_bytes": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Measured Indexed Bytes"
+      },
+      "estimated_reachable_tokens": {
+        "anyOf": [
+          {
+            "minimum": 0,
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Estimated Reachable Tokens"
+      },
+      "reach_claim_enabled": {
+        "title": "Reach Claim Enabled",
+        "type": "boolean"
+      },
+      "benchmark_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Benchmark Failures",
+        "type": "array"
+      },
+      "benchmark_source_revision": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{40}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Source Revision"
+      },
+      "benchmark_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Receipt Digest"
+      },
+      "benchmark_recall_dataset_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Benchmark Recall Dataset Digest"
+      },
+      "runtime_build_ready": {
+        "title": "Runtime Build Ready",
+        "type": "boolean"
+      },
+      "runtime_build_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Runtime Build Failures",
+        "type": "array"
+      },
+      "runtime_build_manifest_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Build Manifest Digest"
+      },
+      "runtime_source_revision": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{40}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Source Revision"
+      },
+      "runtime_data_plane_case_generator_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Data Plane Case Generator Digest"
+      },
+      "cycle_key_provider": {
+        "anyOf": [
+          {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Cycle Key Provider"
+      },
+      "managed_cycle_keys_ready": {
+        "title": "Managed Cycle Keys Ready",
+        "type": "boolean"
+      },
+      "managed_cycle_key_failures": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Managed Cycle Key Failures",
+        "type": "array"
+      },
+      "managed_key_provider_receipt_digests": {
+        "additionalProperties": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "title": "Managed Key Provider Receipt Digests",
+        "type": "object"
+      },
+      "managed_key_provider_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Managed Key Provider Receipt Digest"
+      },
+      "runtime_package_tree_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Package Tree Digest"
+      },
+      "runtime_locked_environment_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Locked Environment Digest"
+      },
+      "runtime_python_implementation": {
+        "anyOf": [
+          {
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Implementation"
+      },
+      "runtime_python_version": {
+        "anyOf": [
+          {
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Version"
+      },
+      "runtime_python_abi": {
+        "anyOf": [
+          {
+            "maxLength": 200,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Abi"
+      },
+      "runtime_python_executable_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Python Executable Digest"
+      },
+      "runtime_dependency_versions": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "Runtime Dependency Versions",
+        "type": "object"
+      },
+      "runtime_dependency_artifact_digests": {
+        "additionalProperties": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "title": "Runtime Dependency Artifact Digests",
+        "type": "object"
+      },
+      "runtime_sqlite_version": {
+        "anyOf": [
+          {
+            "maxLength": 40,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Sqlite Version"
+      },
+      "runtime_package_import_root_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Package Import Root Digest"
+      },
+      "runtime_bytecode_policy": {
+        "anyOf": [
+          {
+            "const": "preimport-guard/source-only/v2",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Runtime Bytecode Policy"
+      },
+      "runtime_dependency_import_closure": {
+        "items": {
+          "type": "string"
+        },
+        "maxItems": 32,
+        "title": "Runtime Dependency Import Closure",
+        "type": "array"
+      },
+      "context_protocol_version": {
+        "const": 3,
+        "default": 3,
+        "title": "Context Protocol Version",
+        "type": "integer"
+      },
+      "capabilities": {
+        "items": {
+          "enum": [
+            "reserve_v2",
+            "bind_v2",
+            "checkpoint_durability",
+            "release_reservation",
+            "abort_reservation",
+            "expire_aborted_reservation",
+            "expire_reservation",
+            "reserve_v3",
+            "bind_v3",
+            "hydrate_v2",
+            "deletion_v2"
+          ],
+          "type": "string"
+        },
+        "title": "Capabilities",
+        "type": "array"
+      },
+      "live_ipc_checkpoint_bytes": {
+        "maximum": 13000000,
+        "minimum": 1024,
+        "title": "Live Ipc Checkpoint Bytes",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "ready",
+      "profile_digest",
+      "index_implementation",
+      "index_version",
+      "disk_free_bytes",
+      "resident_cache_limit_bytes",
+      "resident_process_limit_bytes",
+      "configured_max_records",
+      "configured_max_indexed_bytes",
+      "configured_reachable_tokens_upper_bound",
+      "reach_claim_enabled",
+      "benchmark_failures",
+      "runtime_build_ready",
+      "runtime_build_failures",
+      "managed_cycle_keys_ready",
+      "managed_cycle_key_failures",
+      "managed_key_provider_receipt_digests",
+      "runtime_dependency_versions",
+      "runtime_dependency_artifact_digests",
+      "capabilities",
+      "live_ipc_checkpoint_bytes"
+    ],
+    "title": "ContextHealthV3",
+    "type": "object"
+  },
   "ContextHydrateReceiptV1": {
     "$defs": {
       "NamespaceV1": {
@@ -941,6 +4391,212 @@
       "fence"
     ],
     "title": "ContextHydrateReceiptV1",
+    "type": "object"
+  },
+  "ContextHydrateReceiptV2": {
+    "$defs": {
+      "NamespaceV1": {
+        "additionalProperties": false,
+        "properties": {
+          "owner_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "project_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Project Id",
+            "type": "string"
+          },
+          "objective_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Objective Id",
+            "type": "string"
+          },
+          "context_cycle_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Context Cycle Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner_id",
+          "project_id",
+          "objective_id",
+          "context_cycle_id"
+        ],
+        "title": "NamespaceV1",
+        "type": "object"
+      },
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextHydrateReceiptV2",
+        "default": "ContextHydrateReceiptV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "const": "hydrate",
+        "default": "hydrate",
+        "title": "Operation",
+        "type": "string"
+      },
+      "namespace": {
+        "$ref": "#/$defs/NamespaceV1"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "manifest_checksum": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Manifest Checksum",
+        "type": "string"
+      },
+      "checkpoint_number": {
+        "minimum": 1,
+        "title": "Checkpoint Number",
+        "type": "integer"
+      },
+      "cursor": {
+        "minimum": 0,
+        "title": "Cursor",
+        "type": "integer"
+      },
+      "root": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Root",
+        "type": "string"
+      },
+      "key_ref": {
+        "anyOf": [
+          {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Ref"
+      },
+      "key_provider": {
+        "anyOf": [
+          {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Provider"
+      },
+      "key_version": {
+        "anyOf": [
+          {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Version"
+      },
+      "replay_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Replay Digest",
+        "type": "string"
+      },
+      "fence": {
+        "minimum": 1,
+        "title": "Fence",
+        "type": "integer"
+      },
+      "hydrate_command_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Hydrate Command Digest",
+        "type": "string"
+      },
+      "expected_source_revision": {
+        "pattern": "^[0-9a-f]{40}$",
+        "title": "Expected Source Revision",
+        "type": "string"
+      },
+      "checkpoint_durability_registration_receipt": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SignedV1"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "checkpoint_durability_registration_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Checkpoint Durability Registration Receipt Digest"
+      }
+    },
+    "required": [
+      "namespace",
+      "context_cycle_id",
+      "manifest_checksum",
+      "checkpoint_number",
+      "cursor",
+      "root",
+      "replay_digest",
+      "fence",
+      "hydrate_command_digest",
+      "expected_source_revision"
+    ],
+    "title": "ContextHydrateReceiptV2",
     "type": "object"
   },
   "ContextFreezeReceiptV1": {
@@ -1396,6 +5052,59 @@
     "title": "RetentionCommandV1",
     "type": "object"
   },
+  "ContextRetentionReceiptV1": {
+    "additionalProperties": false,
+    "properties": {
+      "schema_version": {
+        "const": "ContextRetentionReceiptV1",
+        "default": "ContextRetentionReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "operation": {
+        "enum": [
+          "hold",
+          "release"
+        ],
+        "title": "Operation",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "reason_code": {
+        "enum": [
+          "audit_hold",
+          "legal_hold",
+          "incident_hold",
+          "hold_released"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "effective_at": {
+        "minimum": 0,
+        "title": "Effective At",
+        "type": "integer"
+      },
+      "revision": {
+        "minimum": 2,
+        "title": "Revision",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "operation",
+      "context_cycle_id",
+      "reason_code",
+      "effective_at",
+      "revision"
+    ],
+    "title": "ContextRetentionReceiptV1",
+    "type": "object"
+  },
   "ManagedKeyProviderReceiptV1": {
     "additionalProperties": false,
     "description": "Independent qualification for a shared managed key provider.",
@@ -1514,6 +5223,569 @@
     "title": "KeyDestructionReceiptV1",
     "type": "object"
   },
+  "ContextLocalKeyDestructionV1": {
+    "additionalProperties": false,
+    "description": "Closed local key tombstone; it is canary evidence, not KMS erasure.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextLocalKeyDestructionV1",
+        "default": "ContextLocalKeyDestructionV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "provider": {
+        "const": "file-wrapped-dek/v1",
+        "default": "file-wrapped-dek/v1",
+        "title": "Provider",
+        "type": "string"
+      },
+      "key_ref": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Key Ref",
+        "type": "string"
+      },
+      "key_version": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Key Version",
+        "type": "string"
+      },
+      "namespace_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Namespace Digest",
+        "type": "string"
+      },
+      "wrapped_key_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Wrapped Key Digest",
+        "type": "string"
+      },
+      "destroyed_at": {
+        "minimum": 0,
+        "title": "Destroyed At",
+        "type": "integer"
+      },
+      "verified": {
+        "const": true,
+        "title": "Verified",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "key_ref",
+      "key_version",
+      "namespace_digest",
+      "wrapped_key_digest",
+      "destroyed_at",
+      "verified"
+    ],
+    "title": "ContextLocalKeyDestructionV1",
+    "type": "object"
+  },
+  "ContextDeletionReceiptV1": {
+    "$defs": {
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Closed rolling deletion evidence emitted for legacy durability rows.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextDeletionReceiptV1",
+        "default": "ContextDeletionReceiptV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "segment_chain_root": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Segment Chain Root",
+        "type": "string"
+      },
+      "context_seal_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Context Seal Digest"
+      },
+      "retention_class": {
+        "enum": [
+          "ephemeral",
+          "audit"
+        ],
+        "title": "Retention Class",
+        "type": "string"
+      },
+      "retention_expired_at": {
+        "minimum": 0,
+        "title": "Retention Expired At",
+        "type": "integer"
+      },
+      "deleted_at": {
+        "minimum": 0,
+        "title": "Deleted At",
+        "type": "integer"
+      },
+      "reason_code": {
+        "enum": [
+          "policy_expiry",
+          "operator_expiry"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "retention_operation_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Retention Operation Key",
+        "type": "string"
+      },
+      "retention_request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Retention Request Digest",
+        "type": "string"
+      },
+      "logical_deletion": {
+        "const": true,
+        "title": "Logical Deletion",
+        "type": "boolean"
+      },
+      "cryptographic_erasure": {
+        "title": "Cryptographic Erasure",
+        "type": "boolean"
+      },
+      "local_key_destruction": {
+        "anyOf": [
+          {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Local Key Destruction"
+      },
+      "key_destruction_receipt": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SignedV1"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "key_destruction_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Destruction Receipt Digest"
+      },
+      "managed_key_provider_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Managed Key Provider Receipt Digest"
+      },
+      "remote_deletion_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Remote Deletion Receipt Digest"
+      },
+      "checkpoint_manifest_checksum": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Checkpoint Manifest Checksum"
+      },
+      "checkpoint_object_ref_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Checkpoint Object Ref Digest"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "segment_chain_root",
+      "retention_class",
+      "retention_expired_at",
+      "deleted_at",
+      "reason_code",
+      "retention_operation_key",
+      "retention_request_digest",
+      "logical_deletion",
+      "cryptographic_erasure"
+    ],
+    "title": "ContextDeletionReceiptV1",
+    "type": "object"
+  },
+  "ContextDeletionReceiptV2": {
+    "$defs": {
+      "ContextLocalKeyDestructionV1": {
+        "additionalProperties": false,
+        "description": "Closed local key tombstone; it is canary evidence, not KMS erasure.",
+        "properties": {
+          "schema_version": {
+            "const": "ContextLocalKeyDestructionV1",
+            "default": "ContextLocalKeyDestructionV1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "provider": {
+            "const": "file-wrapped-dek/v1",
+            "default": "file-wrapped-dek/v1",
+            "title": "Provider",
+            "type": "string"
+          },
+          "key_ref": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Ref",
+            "type": "string"
+          },
+          "key_version": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Version",
+            "type": "string"
+          },
+          "namespace_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Namespace Digest",
+            "type": "string"
+          },
+          "wrapped_key_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Wrapped Key Digest",
+            "type": "string"
+          },
+          "destroyed_at": {
+            "minimum": 0,
+            "title": "Destroyed At",
+            "type": "integer"
+          },
+          "verified": {
+            "const": true,
+            "title": "Verified",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "key_ref",
+          "key_version",
+          "namespace_digest",
+          "wrapped_key_digest",
+          "destroyed_at",
+          "verified"
+        ],
+        "title": "ContextLocalKeyDestructionV1",
+        "type": "object"
+      },
+      "SignedV1": {
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "key_id": {
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+            "title": "Key Id",
+            "type": "string"
+          },
+          "signature": {
+            "maxLength": 128,
+            "minLength": 64,
+            "title": "Signature",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payload",
+          "key_id",
+          "signature"
+        ],
+        "title": "SignedV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Deletion evidence that binds the registered checkpoint durability mode.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextDeletionReceiptV2",
+        "default": "ContextDeletionReceiptV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "context_cycle_id": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Context Cycle Id",
+        "type": "string"
+      },
+      "segment_chain_root": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Segment Chain Root",
+        "type": "string"
+      },
+      "context_seal_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Context Seal Digest"
+      },
+      "retention_class": {
+        "enum": [
+          "ephemeral",
+          "audit"
+        ],
+        "title": "Retention Class",
+        "type": "string"
+      },
+      "retention_expired_at": {
+        "minimum": 0,
+        "title": "Retention Expired At",
+        "type": "integer"
+      },
+      "deleted_at": {
+        "minimum": 0,
+        "title": "Deleted At",
+        "type": "integer"
+      },
+      "reason_code": {
+        "enum": [
+          "policy_expiry",
+          "operator_expiry"
+        ],
+        "title": "Reason Code",
+        "type": "string"
+      },
+      "retention_operation_key": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$",
+        "title": "Retention Operation Key",
+        "type": "string"
+      },
+      "retention_request_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Retention Request Digest",
+        "type": "string"
+      },
+      "logical_deletion": {
+        "const": true,
+        "title": "Logical Deletion",
+        "type": "boolean"
+      },
+      "cryptographic_erasure": {
+        "title": "Cryptographic Erasure",
+        "type": "boolean"
+      },
+      "local_key_destruction": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/ContextLocalKeyDestructionV1"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "key_destruction_receipt": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/SignedV1"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null
+      },
+      "key_destruction_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Key Destruction Receipt Digest"
+      },
+      "managed_key_provider_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Managed Key Provider Receipt Digest"
+      },
+      "remote_deletion_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Remote Deletion Receipt Digest"
+      },
+      "checkpoint_manifest_checksum": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Checkpoint Manifest Checksum"
+      },
+      "checkpoint_object_ref_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Checkpoint Object Ref Digest"
+      },
+      "checkpoint_durability_mode": {
+        "enum": [
+          "unregistered",
+          "local_ephemeral",
+          "remote_registered"
+        ],
+        "title": "Checkpoint Durability Mode",
+        "type": "string"
+      },
+      "checkpoint_durability_registration_receipt_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Checkpoint Durability Registration Receipt Digest"
+      }
+    },
+    "required": [
+      "context_cycle_id",
+      "segment_chain_root",
+      "retention_class",
+      "retention_expired_at",
+      "deleted_at",
+      "reason_code",
+      "retention_operation_key",
+      "retention_request_digest",
+      "logical_deletion",
+      "cryptographic_erasure",
+      "checkpoint_durability_mode"
+    ],
+    "title": "ContextDeletionReceiptV2",
+    "type": "object"
+  },
   "RuntimeBuildManifestV1": {
     "additionalProperties": false,
     "description": "Signed build identity for the exact installed runtime package bytes.",
@@ -1584,6 +5856,510 @@
       "built_at"
     ],
     "title": "RuntimeBuildManifestV1",
+    "type": "object"
+  },
+  "RuntimeEnvironmentV1": {
+    "additionalProperties": false,
+    "description": "Live-measurable identity of the interpreter and hosted dependencies.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextRuntimeEnvironmentV1",
+        "default": "ContextRuntimeEnvironmentV1",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "python_implementation": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Python Implementation",
+        "type": "string"
+      },
+      "python_version": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Python Version",
+        "type": "string"
+      },
+      "python_abi": {
+        "maxLength": 200,
+        "minLength": 1,
+        "title": "Python Abi",
+        "type": "string"
+      },
+      "python_executable_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Python Executable Digest",
+        "type": "string"
+      },
+      "dependency_versions": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "Dependency Versions",
+        "type": "object"
+      },
+      "dependency_artifact_digests": {
+        "additionalProperties": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "title": "Dependency Artifact Digests",
+        "type": "object"
+      },
+      "sqlite_version": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Sqlite Version",
+        "type": "string"
+      },
+      "package_import_root_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Package Import Root Digest",
+        "type": "string"
+      },
+      "bytecode_policy": {
+        "const": "source-only/no-bytecode/v1",
+        "default": "source-only/no-bytecode/v1",
+        "title": "Bytecode Policy",
+        "type": "string"
+      }
+    },
+    "required": [
+      "python_implementation",
+      "python_version",
+      "python_abi",
+      "python_executable_digest",
+      "dependency_versions",
+      "dependency_artifact_digests",
+      "sqlite_version",
+      "package_import_root_digest"
+    ],
+    "title": "RuntimeEnvironmentV1",
+    "type": "object"
+  },
+  "RuntimeBuildManifestV2": {
+    "$defs": {
+      "RuntimeEnvironmentV1": {
+        "additionalProperties": false,
+        "description": "Live-measurable identity of the interpreter and hosted dependencies.",
+        "properties": {
+          "schema_version": {
+            "const": "ContextRuntimeEnvironmentV1",
+            "default": "ContextRuntimeEnvironmentV1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "python_implementation": {
+            "maxLength": 40,
+            "minLength": 1,
+            "title": "Python Implementation",
+            "type": "string"
+          },
+          "python_version": {
+            "maxLength": 40,
+            "minLength": 1,
+            "title": "Python Version",
+            "type": "string"
+          },
+          "python_abi": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Python Abi",
+            "type": "string"
+          },
+          "python_executable_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Python Executable Digest",
+            "type": "string"
+          },
+          "dependency_versions": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Dependency Versions",
+            "type": "object"
+          },
+          "dependency_artifact_digests": {
+            "additionalProperties": {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "title": "Dependency Artifact Digests",
+            "type": "object"
+          },
+          "sqlite_version": {
+            "maxLength": 40,
+            "minLength": 1,
+            "title": "Sqlite Version",
+            "type": "string"
+          },
+          "package_import_root_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Package Import Root Digest",
+            "type": "string"
+          },
+          "bytecode_policy": {
+            "const": "source-only/no-bytecode/v1",
+            "default": "source-only/no-bytecode/v1",
+            "title": "Bytecode Policy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "python_implementation",
+          "python_version",
+          "python_abi",
+          "python_executable_digest",
+          "dependency_versions",
+          "dependency_artifact_digests",
+          "sqlite_version",
+          "package_import_root_digest"
+        ],
+        "title": "RuntimeEnvironmentV1",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Build V1 plus a lock over the live executable runtime environment.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextRuntimeBuildManifestV2",
+        "default": "ContextRuntimeBuildManifestV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "distribution": {
+        "const": "aether-context",
+        "default": "aether-context",
+        "title": "Distribution",
+        "type": "string"
+      },
+      "version": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Version",
+        "type": "string"
+      },
+      "source_revision": {
+        "pattern": "^[0-9a-f]{40}$",
+        "title": "Source Revision",
+        "type": "string"
+      },
+      "package_tree_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Package Tree Digest",
+        "type": "string"
+      },
+      "wheel_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Wheel Digest",
+        "type": "string"
+      },
+      "recall_dataset_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Recall Dataset Digest",
+        "type": "string"
+      },
+      "data_plane_case_generator_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Data Plane Case Generator Digest"
+      },
+      "built_at": {
+        "minimum": 0,
+        "title": "Built At",
+        "type": "integer"
+      },
+      "runtime_environment": {
+        "$ref": "#/$defs/RuntimeEnvironmentV1"
+      },
+      "locked_environment_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Locked Environment Digest",
+        "type": "string"
+      }
+    },
+    "required": [
+      "version",
+      "source_revision",
+      "package_tree_digest",
+      "wheel_digest",
+      "recall_dataset_digest",
+      "built_at",
+      "runtime_environment",
+      "locked_environment_digest"
+    ],
+    "title": "RuntimeBuildManifestV2",
+    "type": "object"
+  },
+  "RuntimeEnvironmentV2": {
+    "additionalProperties": false,
+    "description": "Complete audited import closure for the hosted daemon.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextRuntimeEnvironmentV2",
+        "default": "ContextRuntimeEnvironmentV2",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "python_implementation": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Python Implementation",
+        "type": "string"
+      },
+      "python_version": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Python Version",
+        "type": "string"
+      },
+      "python_abi": {
+        "maxLength": 200,
+        "minLength": 1,
+        "title": "Python Abi",
+        "type": "string"
+      },
+      "python_executable_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Python Executable Digest",
+        "type": "string"
+      },
+      "dependency_import_closure": {
+        "items": {
+          "type": "string"
+        },
+        "maxItems": 32,
+        "minItems": 6,
+        "title": "Dependency Import Closure",
+        "type": "array"
+      },
+      "dependency_versions": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "title": "Dependency Versions",
+        "type": "object"
+      },
+      "dependency_artifact_digests": {
+        "additionalProperties": {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        "title": "Dependency Artifact Digests",
+        "type": "object"
+      },
+      "sqlite_version": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Sqlite Version",
+        "type": "string"
+      },
+      "package_import_root_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Package Import Root Digest",
+        "type": "string"
+      },
+      "bytecode_policy": {
+        "const": "preimport-guard/source-only/v2",
+        "default": "preimport-guard/source-only/v2",
+        "title": "Bytecode Policy",
+        "type": "string"
+      }
+    },
+    "required": [
+      "python_implementation",
+      "python_version",
+      "python_abi",
+      "python_executable_digest",
+      "dependency_import_closure",
+      "dependency_versions",
+      "dependency_artifact_digests",
+      "sqlite_version",
+      "package_import_root_digest"
+    ],
+    "title": "RuntimeEnvironmentV2",
+    "type": "object"
+  },
+  "RuntimeBuildManifestV3": {
+    "$defs": {
+      "RuntimeEnvironmentV2": {
+        "additionalProperties": false,
+        "description": "Complete audited import closure for the hosted daemon.",
+        "properties": {
+          "schema_version": {
+            "const": "ContextRuntimeEnvironmentV2",
+            "default": "ContextRuntimeEnvironmentV2",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "python_implementation": {
+            "maxLength": 40,
+            "minLength": 1,
+            "title": "Python Implementation",
+            "type": "string"
+          },
+          "python_version": {
+            "maxLength": 40,
+            "minLength": 1,
+            "title": "Python Version",
+            "type": "string"
+          },
+          "python_abi": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Python Abi",
+            "type": "string"
+          },
+          "python_executable_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Python Executable Digest",
+            "type": "string"
+          },
+          "dependency_import_closure": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 32,
+            "minItems": 6,
+            "title": "Dependency Import Closure",
+            "type": "array"
+          },
+          "dependency_versions": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Dependency Versions",
+            "type": "object"
+          },
+          "dependency_artifact_digests": {
+            "additionalProperties": {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            "title": "Dependency Artifact Digests",
+            "type": "object"
+          },
+          "sqlite_version": {
+            "maxLength": 40,
+            "minLength": 1,
+            "title": "Sqlite Version",
+            "type": "string"
+          },
+          "package_import_root_digest": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Package Import Root Digest",
+            "type": "string"
+          },
+          "bytecode_policy": {
+            "const": "preimport-guard/source-only/v2",
+            "default": "preimport-guard/source-only/v2",
+            "title": "Bytecode Policy",
+            "type": "string"
+          }
+        },
+        "required": [
+          "python_implementation",
+          "python_version",
+          "python_abi",
+          "python_executable_digest",
+          "dependency_import_closure",
+          "dependency_versions",
+          "dependency_artifact_digests",
+          "sqlite_version",
+          "package_import_root_digest"
+        ],
+        "title": "RuntimeEnvironmentV2",
+        "type": "object"
+      }
+    },
+    "additionalProperties": false,
+    "description": "Build identity bound to the complete guarded executable environment.",
+    "properties": {
+      "schema_version": {
+        "const": "ContextRuntimeBuildManifestV3",
+        "default": "ContextRuntimeBuildManifestV3",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "distribution": {
+        "const": "aether-context",
+        "default": "aether-context",
+        "title": "Distribution",
+        "type": "string"
+      },
+      "version": {
+        "maxLength": 40,
+        "minLength": 1,
+        "title": "Version",
+        "type": "string"
+      },
+      "source_revision": {
+        "pattern": "^[0-9a-f]{40}$",
+        "title": "Source Revision",
+        "type": "string"
+      },
+      "package_tree_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Package Tree Digest",
+        "type": "string"
+      },
+      "wheel_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Wheel Digest",
+        "type": "string"
+      },
+      "recall_dataset_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Recall Dataset Digest",
+        "type": "string"
+      },
+      "data_plane_case_generator_digest": {
+        "anyOf": [
+          {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "title": "Data Plane Case Generator Digest"
+      },
+      "built_at": {
+        "minimum": 0,
+        "title": "Built At",
+        "type": "integer"
+      },
+      "runtime_environment": {
+        "$ref": "#/$defs/RuntimeEnvironmentV2"
+      },
+      "locked_environment_digest": {
+        "pattern": "^[0-9a-f]{64}$",
+        "title": "Locked Environment Digest",
+        "type": "string"
+      }
+    },
+    "required": [
+      "version",
+      "source_revision",
+      "package_tree_digest",
+      "wheel_digest",
+      "recall_dataset_digest",
+      "built_at",
+      "runtime_environment",
+      "locked_environment_digest"
+    ],
+    "title": "RuntimeBuildManifestV3",
     "type": "object"
   },
   "ExecutorStabilityReceiptV1": {

--- a/aether_context/engine.py
+++ b/aether_context/engine.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import shutil
 import sqlite3
+import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -16,23 +18,58 @@ from .contracts import (
     CapabilityV1,
     ClosureProofV1,
     ContextBindingV1,
+    ContextBindingCommandV2,
+    ContextBindingCommandV3,
+    ContextCheckpointDurabilityCommandV1,
+    ContextCheckpointDurabilityReceiptV1,
+    ContextCheckpointDurabilityReceiptV2,
     ContextCheckpointReceiptV1,
+    ContextDeletionReceiptV2,
     ContextFreezeReceiptV1,
+    ContextHealthV1,
+    ContextHealthV2,
+    ContextHealthV3,
+    ContextHydrateCommandV2,
     ContextHydrateReceiptV1,
+    ContextHydrateReceiptV2,
     ContextProfileV1,
+    ContextReservationAbortCommandV1,
+    ContextReservationAbortExpiryCommandV1,
+    ContextReservationAbortReceiptV1,
+    ContextReservationCommandV2,
+    ContextReservationCommandV3,
+    ContextInvocationNoDispatchReceiptV1,
+    ContextReservationExpiryCommandV1,
+    ContextReservationExpiryReceiptV1,
+    ContextReservationReceiptV1,
+    ContextReservationReceiptV2,
+    ContextReservationReceiptV3,
+    ContextReservationReleaseCommandV1,
+    ContextReservationReleaseReceiptV1,
     ManagedKeyProviderReceiptV1,
     PromotionCandidateV1,
     RetrieveRequestV1,
+    RuntimeEnvironmentV2,
+    SignedV1,
+    HOSTED_CONTEXT_CAPABILITIES,
+    LIVE_IPC_MAX_CHECKPOINT_BYTES,
     canonical,
     digest,
 )
 from .crypto import ContextFault, EnvelopeCipher, ReceiptSigner, verify, require_disjoint_keys
 from .policy import NOTICE, filter_text, namespace_matches, token_bound, visible, words, writable
-from .scale import qualify_runtime_build, qualify_scale_receipt, runtime_package_tree_digest
+from .scale import (
+    HOSTED_RUNTIME_DISTRIBUTIONS,
+    qualify_runtime_build,
+    qualify_scale_receipt,
+    runtime_environment_identity,
+    runtime_package_tree_digest,
+)
 from .storage_v2 import SegmentStoreV2
 
 ZERO = "0" * 64
 TERMINAL = {"SEALED", "EXPIRED", "ABORTED", "QUARANTINED"}
+HOT_ATTESTATION_SECONDS = 60
 
 
 class ContextEngine:
@@ -103,17 +140,68 @@ class ContextEngine:
         self._benchmark_keys = benchmark_keys or {}
         self._executor_stability_keys = executor_stability_keys or {}
         self._data_plane_isolation_keys = data_plane_isolation_keys or {}
+        self._runtime_build_manifest = runtime_build_manifest
+        self._runtime_build_keys = runtime_build_keys or {}
         self.store = SegmentStoreV2(path, profile.resident_cache_bytes)
         from . import __version__
 
-        self._runtime_package_tree_digest = runtime_package_tree_digest()
+        self._runtime_source_only = bool(
+            isinstance(runtime_build_manifest, dict)
+            and isinstance(runtime_build_manifest.get("payload"), dict)
+            and runtime_build_manifest["payload"].get("schema_version")
+            in {"ContextRuntimeBuildManifestV2", "ContextRuntimeBuildManifestV3"}
+        )
+        manifest_payload = (
+            runtime_build_manifest.get("payload", {})
+            if isinstance(runtime_build_manifest, dict)
+            else {}
+        )
+        configured_closure = (
+            manifest_payload.get("runtime_environment", {}).get(
+                "dependency_import_closure"
+            )
+            if manifest_payload.get("schema_version")
+            == "ContextRuntimeBuildManifestV3"
+            else None
+        )
+        self._runtime_distributions = (
+            tuple(configured_closure)
+            if isinstance(configured_closure, list)
+            and all(isinstance(item, str) for item in configured_closure)
+            else HOSTED_RUNTIME_DISTRIBUTIONS
+        )
+        self._runtime_startup_failure: str | None = None
+        self._runtime_package_tree_digest: str | None
+        runtime_environment = None
+        try:
+            self._runtime_package_tree_digest = runtime_package_tree_digest(
+                require_source_only=self._runtime_source_only
+            )
+            if self._runtime_source_only:
+                runtime_environment = runtime_environment_identity(
+                    distributions=self._runtime_distributions
+                )
+        except (ContextFault, OSError):
+            self._runtime_package_tree_digest = None
+            self._runtime_startup_failure = "runtime_package_tree_unavailable"
+        self._runtime_environment_identity = runtime_environment
         self.build_qualification = qualify_runtime_build(
-            runtime_build_manifest,
-            runtime_build_keys or {},
+            self._runtime_build_manifest,
+            self._runtime_build_keys,
             expected_version=__version__,
-            package_tree_digest=self._runtime_package_tree_digest,
+            package_tree_digest=self._runtime_package_tree_digest or ZERO,
+            runtime_environment=runtime_environment,
         )
         self.scale_qualification = self._qualify_scale()
+        self._attestation_lock = threading.RLock()
+        self._hot_attestation_checked_at = -1
+        self._hot_attestation_valid_until = -1
+        self._hot_attestation_ready = False
+        self._hot_reach_claim_enabled = False
+        # Startup already measured the package and executable environment. This
+        # validates the remaining signed evidence once without repeating either
+        # expensive measurement.
+        self._health(version=3, measure_environment=False, measure_package=False)
         from .retention import RetentionManager
 
         self.retention_manager = RetentionManager(self)
@@ -316,8 +404,54 @@ class ContextEngine:
         return not failures, tuple(failures), receipt_digests
 
     def health(self) -> dict:
-        # Time-bounded benchmark and provider evidence is rechecked on every
-        # health/admission call, so a once-valid startup cache cannot outlive it.
+        """Rolling-compatible ContextHealthV1 response."""
+        return self._health(version=1, measure_environment=True, measure_package=True)
+
+    def health_v2(self) -> dict:
+        """ContextHealthV2 adds the current imported package-tree digest."""
+        return self._health(version=2, measure_environment=True, measure_package=True)
+
+    def health_v3(self) -> dict:
+        """ContextHealthV3 proves the guarded complete import closure."""
+        return self._health(version=3, measure_environment=True, measure_package=True)
+
+    def _health(
+        self, *, version: int, measure_environment: bool, measure_package: bool
+    ) -> dict:
+        # Package bytes plus time-bounded benchmark/provider evidence are
+        # rechecked on every health/admission call.
+        runtime_package_digest: str | None
+        runtime_environment = None
+        runtime_hash_failure: str | None = None
+        if measure_package:
+            try:
+                runtime_package_digest = runtime_package_tree_digest(
+                    require_source_only=self._runtime_source_only
+                )
+                if self._runtime_source_only:
+                    runtime_environment = (
+                        runtime_environment_identity(
+                            distributions=self._runtime_distributions
+                        )
+                        if measure_environment
+                        else self._runtime_environment_identity
+                    )
+                from . import __version__
+
+                self.build_qualification = qualify_runtime_build(
+                    self._runtime_build_manifest,
+                    self._runtime_build_keys,
+                    expected_version=__version__,
+                    package_tree_digest=runtime_package_digest,
+                    runtime_environment=runtime_environment,
+                )
+            except (ContextFault, OSError):
+                runtime_package_digest = None
+                runtime_hash_failure = "runtime_package_tree_unavailable"
+        else:
+            runtime_package_digest = self._runtime_package_tree_digest
+            runtime_environment = self._runtime_environment_identity
+            runtime_hash_failure = self._runtime_startup_failure
         self.scale_qualification = self._qualify_scale()
         free = shutil.disk_usage(self.store.path.parent).free
         with self.store.connection() as db:
@@ -326,12 +460,33 @@ class ContextEngine:
         managed_keys_ready, managed_key_failures, managed_key_receipt_digests = (
             self._managed_key_qualification()
         )
-        profile_ready = self.profile.name != "hosted-v1" or (
-            benchmark_ready and managed_keys_ready and self.build_qualification.valid
+        runtime_build_failures = list(self.build_qualification.failures)
+        if runtime_hash_failure is not None:
+            runtime_build_failures.append(runtime_hash_failure)
+        runtime_package_stable = (
+            runtime_package_digest is not None
+            and runtime_package_digest == self._runtime_package_tree_digest
+            and self._runtime_startup_failure is None
         )
-        return {
+        runtime_build_ready = (
+            runtime_hash_failure is None
+            and runtime_package_stable
+            and self.build_qualification.valid
+        )
+        if self._runtime_startup_failure is not None:
+            runtime_build_failures.append("runtime_package_tree_startup_unavailable")
+        if runtime_package_digest is not None and not runtime_package_stable:
+            runtime_build_failures.append("runtime_package_tree_changed")
+        profile_ready = self.profile.name != "hosted-v1" or (
+            benchmark_ready and managed_keys_ready and runtime_build_ready
+        )
+        payload = {
             "schema_version": "ContextHealthV1",
-            "ready": free >= self.profile.disk_free_floor and profile_ready,
+            "ready": (
+                free >= self.profile.disk_free_floor
+                and profile_ready
+                and runtime_package_stable
+            ),
             "profile_digest": digest(self.profile),
             "index_implementation": self.profile.index_implementation,
             "index_version": sqlite3.sqlite_version,
@@ -356,8 +511,8 @@ class ContextEngine:
             "benchmark_recall_dataset_digest": (
                 self.scale_qualification.recall_dataset_digest
             ),
-            "runtime_build_ready": self.build_qualification.valid,
-            "runtime_build_failures": list(self.build_qualification.failures),
+            "runtime_build_ready": runtime_build_ready,
+            "runtime_build_failures": runtime_build_failures,
             "runtime_build_manifest_digest": self.build_qualification.manifest_digest,
             "runtime_source_revision": self.build_qualification.source_revision,
             "runtime_data_plane_case_generator_digest": (
@@ -373,12 +528,129 @@ class ContextEngine:
                 else None
             ),
         }
+        if version >= 2:
+            payload["schema_version"] = (
+                "ContextHealthV3" if version == 3 else "ContextHealthV2"
+            )
+            payload["runtime_package_tree_digest"] = runtime_package_digest
+            payload["runtime_locked_environment_digest"] = (
+                digest(runtime_environment) if runtime_environment is not None else None
+            )
+            payload["runtime_python_implementation"] = (
+                runtime_environment.python_implementation
+                if runtime_environment is not None
+                else None
+            )
+            payload["runtime_python_version"] = (
+                runtime_environment.python_version if runtime_environment is not None else None
+            )
+            payload["runtime_python_abi"] = (
+                runtime_environment.python_abi if runtime_environment is not None else None
+            )
+            payload["runtime_python_executable_digest"] = (
+                runtime_environment.python_executable_digest
+                if runtime_environment is not None
+                else None
+            )
+            payload["runtime_dependency_versions"] = (
+                dict(runtime_environment.dependency_versions)
+                if runtime_environment is not None
+                else {}
+            )
+            payload["runtime_dependency_artifact_digests"] = (
+                dict(runtime_environment.dependency_artifact_digests)
+                if runtime_environment is not None
+                else {}
+            )
+            payload["runtime_sqlite_version"] = (
+                runtime_environment.sqlite_version if runtime_environment is not None else None
+            )
+            payload["runtime_package_import_root_digest"] = (
+                runtime_environment.package_import_root_digest
+                if runtime_environment is not None
+                else None
+            )
+            payload["runtime_bytecode_policy"] = (
+                runtime_environment.bytecode_policy
+                if version == 3 and runtime_environment is not None
+                else "source-only/no-bytecode/v1"
+                if runtime_environment is not None
+                else None
+            )
+            if version == 3:
+                payload["runtime_dependency_import_closure"] = (
+                    list(runtime_environment.dependency_import_closure)
+                    if isinstance(runtime_environment, RuntimeEnvironmentV2)
+                    else []
+                )
+                payload["context_protocol_version"] = 3
+                payload["capabilities"] = list(HOSTED_CONTEXT_CAPABILITIES)
+                payload["live_ipc_checkpoint_bytes"] = min(
+                    self.profile.max_checkpoint_bytes,
+                    LIVE_IPC_MAX_CHECKPOINT_BYTES,
+                )
+                result = ContextHealthV3.model_validate(payload).model_dump(mode="json")
+            else:
+                result = ContextHealthV2.model_validate(payload).model_dump(mode="json")
+        else:
+            result = ContextHealthV1.model_validate(payload).model_dump(mode="json")
+        now = self.now()
+        self._hot_attestation_checked_at = now
+        self._hot_attestation_valid_until = min(
+            now + HOT_ATTESTATION_SECONDS,
+            self._evidence_valid_until(now + HOT_ATTESTATION_SECONDS),
+        )
+        self._hot_attestation_ready = bool(result["ready"])
+        self._hot_reach_claim_enabled = bool(result["reach_claim_enabled"])
+        return result
 
-    def _space(self) -> None:
-        health = self.health()
-        if health["disk_free_bytes"] < self.profile.disk_free_floor:
+    def _evidence_valid_until(self, fallback: int) -> int:
+        expiries: list[int] = []
+
+        def collect(value: Any) -> None:
+            if isinstance(value, dict):
+                if type(value.get("expires_at")) is int:
+                    expiries.append(value["expires_at"])
+                for nested in value.values():
+                    collect(nested)
+            elif isinstance(value, (list, tuple)):
+                for nested in value:
+                    collect(nested)
+
+        collect(self._benchmark_receipt)
+        collect(self.managed_key_provider_receipts)
+        return min(expiries, default=fallback)
+
+    def _space(self, *, full_environment: bool = False) -> None:
+        if full_environment:
+            health = self._health(
+                version=2, measure_environment=True, measure_package=True
+            )
+            ready = bool(health["ready"])
+            free = health["disk_free_bytes"]
+        else:
+            now = self.now()
+            if (
+                now >= self._hot_attestation_valid_until
+                or now - self._hot_attestation_checked_at >= HOT_ATTESTATION_SECONDS
+            ):
+                with self._attestation_lock:
+                    now = self.now()
+                    if (
+                        now >= self._hot_attestation_valid_until
+                        or now - self._hot_attestation_checked_at
+                        >= HOT_ATTESTATION_SECONDS
+                    ):
+                        self._health(
+                            version=3,
+                            measure_environment=True,
+                            measure_package=True,
+                        )
+            free = shutil.disk_usage(self.store.path.parent).free
+            ready = self._hot_attestation_ready and now < self._hot_attestation_valid_until
+        if free < self.profile.disk_free_floor:
             raise ContextFault("context_disk_watermark")
-        if not health["ready"]:
+        if not ready:
             raise ContextFault("context_hosted_gate_unready")
 
     def _cycle(self, db, cycle: str):
@@ -406,8 +678,19 @@ class ContextEngine:
 
     def reserve(self, signed_reservation: dict) -> dict:
         """Only Gateway can mint this command, before consuming run authority."""
+        return self._reserve(signed_reservation, version=1)
+
+    def reserve_v2(self, signed_reservation: dict) -> dict:
+        """Revisioned reservation wire required for explicit release revival."""
+        return self._reserve(signed_reservation, version=2)
+
+    def reserve_v3(self, signed_reservation: dict) -> dict:
+        """Revive only from an exact service-signed no-dispatch expiry."""
+        return self._reserve(signed_reservation, version=3)
+
+    def _reserve(self, signed_reservation: dict, *, version: int) -> dict:
         request = verify(signed_reservation, self.authority_keys)
-        if set(request) != {
+        base_fields = {
             "operation",
             "owner_id",
             "project_id",
@@ -415,34 +698,212 @@ class ContextEngine:
             "request_digest",
             "profile_digest",
             "expires_at",
-        }:
+        }
+        reservation_v3: ContextReservationCommandV3 | None = None
+        if version == 3:
+            try:
+                reservation_v3 = ContextReservationCommandV3.model_validate(request)
+            except (TypeError, ValueError) as exc:
+                raise ContextFault("context_reservation_schema") from exc
+            if request != reservation_v3.model_dump(mode="json"):
+                raise ContextFault("context_reservation_schema")
+        elif version == 2:
+            try:
+                reservation_v2 = ContextReservationCommandV2.model_validate(request)
+            except (TypeError, ValueError) as exc:
+                raise ContextFault("context_reservation_schema") from exc
+            if request != reservation_v2.model_dump(mode="json"):
+                raise ContextFault("context_reservation_schema")
+        elif version != 1 or set(request) != base_fields:
             raise ContextFault("context_reservation_schema")
         if request["operation"] != "reserve" or request["profile_digest"] != digest(self.profile):
             raise ContextFault("context_profile_mismatch")
-        if not self.now() < request["expires_at"] <= self.now() + 3600:
-            raise ContextFault("context_reservation_expired")
+        reservation_authority_valid = (
+            self.now() < request["expires_at"] <= self.now() + 3600
+        )
         for field in ("owner_id", "project_id", "idempotency_key", "request_digest"):
             if not isinstance(request[field], str) or not 1 <= len(request[field]) <= 200:
                 raise ContextFault("context_reservation_schema")
-        self._space()
+        if (
+            len(request["request_digest"]) != 64
+            or any(item not in "0123456789abcdef" for item in request["request_digest"])
+        ):
+            raise ContextFault("context_reservation_schema")
+        released_revision = request.get("released_revision")
+        if released_revision is not None and (
+            type(released_revision) is not int or released_revision < 2
+        ):
+            raise ContextFault("context_reservation_schema")
+        expiry_envelope: dict | None = None
+        expiry_claim: ContextReservationExpiryReceiptV1 | None = None
+        if version == 3:
+            if reservation_v3 is None:
+                raise ContextFault("context_reservation_schema")
+            try:
+                expiry_envelope = reservation_v3.expired_reservation_receipt.model_dump(
+                    mode="json"
+                )
+                expiry_payload = verify(
+                    expiry_envelope,
+                    {self.signer.key_id: self.signer.key.public_key()},
+                )
+                expiry_claim = ContextReservationExpiryReceiptV1.model_validate(
+                    expiry_payload
+                )
+            except (ContextFault, TypeError, ValueError) as exc:
+                raise ContextFault("context_reservation_expiry_receipt_invalid") from exc
+            if expiry_payload != expiry_claim.model_dump(mode="json"):
+                raise ContextFault("context_reservation_expiry_receipt_invalid")
+        self._space(full_environment=True)
         identity = {k: request[k] for k in ("owner_id", "project_id", "idempotency_key")}
         cycle = "ctx_" + digest(identity)[:32]
         with self.store.transaction() as db:
             for expired in db.execute(
                 "SELECT id FROM cycles WHERE state='RESERVED' AND expires<=?", (self.now(),)
             ).fetchall():
-                db.execute(
+                changed = db.execute(
                     "UPDATE cycles SET state='EXPIRED',revision=revision+1 WHERE id=?",
                     (expired[0],),
                 )
                 self._event(db, expired[0], "context.reservation_expired")
             existing = db.execute("SELECT * FROM cycles WHERE id=?", (cycle,)).fetchone()
             if existing is not None:
-                if existing["request_digest"] != request["request_digest"]:
+                if (
+                    existing["owner"] != request["owner_id"]
+                    or existing["project"] != request["project_id"]
+                    or existing["request_key"] != request["idempotency_key"]
+                    or existing["profile"] != request["profile_digest"]
+                    or existing["request_digest"] != request["request_digest"]
+                ):
                     raise ContextFault("context_idempotency_conflict")
-                if existing["state"] in TERMINAL:
+                if not reservation_authority_valid:
+                    if existing["state"] in TERMINAL:
+                        raise ContextFault("context_reservation_terminal")
+                    raise ContextFault("context_reservation_expired")
+                if (
+                    existing["state"] == "EXPIRED"
+                    and existing["reservation_release_digest"] is not None
+                ):
+                    if released_revision is None:
+                        raise ContextFault("context_reservation_terminal")
+                    if released_revision != existing["revision"]:
+                        raise ContextFault("context_stale_state")
+                    if not self._reservation_never_bound(
+                        existing
+                    ) or not self._reservation_data_empty(db, cycle):
+                        raise ContextFault("context_integrity_failure")
+                    self._reservation_release_replay(
+                        db, existing, existing["reservation_release_digest"]
+                    )
+                    count = db.execute(
+                        "SELECT count(*) FROM cycles WHERE owner=? AND state NOT IN "
+                        "('SEALED','EXPIRED','ABORTED','QUARANTINED')",
+                        (request["owner_id"],),
+                    ).fetchone()[0]
+                    if count >= self.profile.max_concurrent_cycles:
+                        raise ContextFault("context_cycle_quota")
+                    changed = db.execute(
+                        "UPDATE cycles SET state='RESERVED',expires=?,revision=revision+1,"
+                        "reservation_release_digest=NULL,reservation_release_receipt=NULL,"
+                        "reservation_revival_from_revision=?,reservation_revival_kind='release',"
+                        "reservation_revival_command_digest=?,"
+                        "reservation_revival_receipt_digest=NULL,"
+                        "reservation_revival_no_dispatch_receipt_digest=NULL "
+                        "WHERE id=? AND state='EXPIRED' AND revision=?",
+                        (
+                            request["expires_at"],
+                            released_revision,
+                            digest(request),
+                            cycle,
+                            existing["revision"],
+                        ),
+                    ).rowcount
+                    if changed != 1:
+                        raise ContextFault("context_stale_state")
+                    self._event(db, cycle, "context.reservation_revived")
+                    existing = self._cycle(db, cycle)
+                elif (
+                    existing["state"] == "EXPIRED"
+                    and existing["reservation_expiry_digest"] is not None
+                ):
+                    if version != 3 or expiry_envelope is None or expiry_claim is None:
+                        raise ContextFault("context_reservation_terminal")
+                    if (
+                        existing["reservation_expiry_receipt"]
+                        != canonical(expiry_envelope).decode()
+                        or expiry_claim.expiry_command_digest
+                        != existing["reservation_expiry_digest"]
+                        or expiry_claim.context_cycle_id != cycle
+                        or expiry_claim.owner_id != request["owner_id"]
+                        or expiry_claim.project_id != request["project_id"]
+                        or expiry_claim.idempotency_key != request["idempotency_key"]
+                        or expiry_claim.request_digest != request["request_digest"]
+                        or expiry_claim.profile_digest != request["profile_digest"]
+                        or expiry_claim.revision != existing["revision"]
+                        or not self._reservation_never_bound(existing)
+                        or not self._reservation_data_empty(db, cycle)
+                        or existing["reservation_release_digest"] is not None
+                        or existing["reservation_abort_digest"] is not None
+                    ):
+                        raise ContextFault("context_integrity_failure")
+                    count = db.execute(
+                        "SELECT count(*) FROM cycles WHERE owner=? AND state NOT IN "
+                        "('SEALED','EXPIRED','ABORTED','QUARANTINED')",
+                        (request["owner_id"],),
+                    ).fetchone()[0]
+                    if count >= self.profile.max_concurrent_cycles:
+                        raise ContextFault("context_cycle_quota")
+                    changed = db.execute(
+                        "UPDATE cycles SET state='RESERVED',expires=?,revision=revision+1,"
+                        "reservation_expiry_digest=NULL,reservation_expiry_receipt=NULL,"
+                        "reservation_revival_from_revision=?,reservation_revival_kind='expiry',"
+                        "reservation_revival_command_digest=?,"
+                        "reservation_revival_receipt_digest=?,"
+                        "reservation_revival_no_dispatch_receipt_digest=? "
+                        "WHERE id=? AND state='EXPIRED' AND revision=?",
+                        (
+                            request["expires_at"],
+                            expiry_claim.revision,
+                            digest(request),
+                            digest(expiry_envelope),
+                            expiry_claim.invocation_no_dispatch_receipt_digest,
+                            cycle,
+                            existing["revision"],
+                        ),
+                    ).rowcount
+                    if changed != 1:
+                        raise ContextFault("context_stale_state")
+                    self._event(db, cycle, "context.reservation_revived")
+                    existing = self._cycle(db, cycle)
+                elif existing["state"] in TERMINAL:
                     raise ContextFault("context_reservation_terminal")
+                elif existing["reservation_revival_from_revision"] is not None:
+                    if (
+                        version == 1
+                        or existing["state"] != "RESERVED"
+                        or existing["reservation_revival_command_digest"]
+                        != digest(request)
+                        or existing["revision"]
+                        != existing["reservation_revival_from_revision"] + 1
+                    ):
+                        raise ContextFault("context_stale_state")
+                    if version == 2 and existing["reservation_revival_kind"] != "release":
+                        raise ContextFault("context_stale_state")
+                    if version == 3 and (
+                        expiry_envelope is None
+                        or expiry_claim is None
+                        or existing["reservation_revival_kind"] != "expiry"
+                        or existing["reservation_revival_receipt_digest"]
+                        != digest(expiry_envelope)
+                        or existing["reservation_revival_no_dispatch_receipt_digest"]
+                        != expiry_claim.invocation_no_dispatch_receipt_digest
+                    ):
+                        raise ContextFault("context_integrity_failure")
+                elif released_revision is not None or version == 3:
+                    raise ContextFault("context_stale_state")
             else:
+                if released_revision is not None or version == 3:
+                    raise ContextFault("context_stale_state")
                 count = db.execute(
                     "SELECT count(*) FROM cycles WHERE owner=? AND state NOT IN ('SEALED','EXPIRED','ABORTED','QUARANTINED')",
                     (request["owner_id"],),
@@ -450,7 +911,10 @@ class ContextEngine:
                 if count >= self.profile.max_concurrent_cycles:
                     raise ContextFault("context_cycle_quota")
                 db.execute(
-                    "INSERT INTO cycles(id,owner,project,request_key,request_digest,profile,state,root,expires) VALUES(?,?,?,?,?,?,'RESERVED',?,?)",
+                    "INSERT INTO cycles(id,owner,project,request_key,request_digest,profile,state,"
+                    "root,expires,checkpoint_durability_mode,checkpoint_durability_legacy,"
+                    "reservation_protocol_version) "
+                    "VALUES(?,?,?,?,?,?,'RESERVED',?,?,?,?,?)",
                     (
                         cycle,
                         request["owner_id"],
@@ -460,22 +924,1184 @@ class ContextEngine:
                         digest(self.profile),
                         ZERO,
                         request["expires_at"],
+                        "remote_registered" if version == 1 else "unregistered",
+                        1 if version == 1 else 0,
+                        version,
                     ),
                 )
                 self._event(db, cycle, "context.reserved")
-            return self.signer.sign(
-                {
-                    "schema_version": "ContextReservationReceiptV1",
-                    "context_cycle_id": cycle,
-                    "context_bucket_id": "bucket_" + cycle[4:],
-                    "request_digest": request["request_digest"],
-                    "profile_digest": digest(self.profile),
-                }
+                existing = self._cycle(db, cycle)
+            receipt_fields = {
+                "context_cycle_id": cycle,
+                "context_bucket_id": "bucket_" + cycle[4:],
+                "request_digest": request["request_digest"],
+                "profile_digest": digest(self.profile),
+            }
+            receipt: (
+                ContextReservationReceiptV1
+                | ContextReservationReceiptV2
+                | ContextReservationReceiptV3
             )
+            if version == 3:
+                if (
+                    existing["reservation_revival_from_revision"] is None
+                    or existing["reservation_revival_receipt_digest"] is None
+                    or existing["reservation_revival_no_dispatch_receipt_digest"] is None
+                    or existing["reservation_revival_command_digest"] is None
+                ):
+                    raise ContextFault("context_integrity_failure")
+                receipt = ContextReservationReceiptV3(
+                    **receipt_fields,
+                    revision=existing["revision"],
+                    prior_expiry_receipt_digest=existing[
+                        "reservation_revival_receipt_digest"
+                    ],
+                    prior_expiry_revision=existing[
+                        "reservation_revival_from_revision"
+                    ],
+                    invocation_no_dispatch_receipt_digest=existing[
+                        "reservation_revival_no_dispatch_receipt_digest"
+                    ],
+                    revival_command_digest=existing[
+                        "reservation_revival_command_digest"
+                    ],
+                )
+            elif version == 2:
+                receipt = ContextReservationReceiptV2(
+                    **receipt_fields, revision=existing["revision"]
+                )
+            else:
+                if not reservation_authority_valid:
+                    raise ContextFault("context_reservation_expired")
+                receipt = ContextReservationReceiptV1(**receipt_fields)
+            return self.signer.sign(receipt.model_dump(mode="json"))
+
+    @staticmethod
+    def _reservation_unbound_metadata(row: sqlite3.Row) -> bool:
+        return (
+            row["binding"] is None
+            and row["binding_digest"] is None
+            and row["authority"] is None
+            and row["snapshot"] is None
+            and row["cursor"] == 0
+            and row["root"] == ZERO
+            and row["bytes"] == 0
+            and row["checkpoint"] == 0
+            and row["key_ref"] is None
+            and row["key_version"] is None
+            and row["seal_digest"] is None
+            and row["checkpoint_manifest_checksum"] is None
+            and row["checkpoint_object_ref_digest"] is None
+            and row["checkpoint_durability_mode"] == "unregistered"
+            and row["checkpoint_durability_legacy"] == 0
+            and row["checkpoint_durability_command_digest"] is None
+            and row["checkpoint_durability_receipt"] is None
+            and row["hydrate_command_digest"] is None
+            and row["hydrate_request_digest"] is None
+            and row["hydrate_receipt"] is None
+            and row["hold"] == 0
+            and row["hold_reason"] is None
+            and row["reservation_binding_receipt_digest"] is None
+            and row["reservation_binding_revision"] is None
+        )
+
+    @classmethod
+    def _reservation_never_bound(cls, row: sqlite3.Row) -> bool:
+        return (
+            cls._reservation_unbound_metadata(row)
+            and row["cleanup_state"] == "NONE"
+            and row["cleanup_remote_receipt"] is None
+            and row["cleanup_operation_key"] is None
+            and row["cleanup_request_digest"] is None
+            and row["deletion_receipt"] is None
+        )
+
+    @staticmethod
+    def _reservation_data_empty(
+        db: sqlite3.Connection, cycle: str, *, include_retention: bool = True
+    ) -> bool:
+        tables = ["segments", "postings", "operations", "fences", "call_budgets"]
+        if include_retention:
+            tables.append("retention_operations")
+        return all(
+            db.execute(
+                f"SELECT 1 FROM {table} WHERE cycle=? LIMIT 1", (cycle,)
+            ).fetchone()
+            is None
+            for table in tables
+        )
+
+    def _reservation_release_replay(
+        self, db: sqlite3.Connection, row: sqlite3.Row, command_digest: str
+    ) -> dict | None:
+        stored_digest = row["reservation_release_digest"]
+        stored_receipt = row["reservation_release_receipt"]
+        if stored_digest is None and stored_receipt is None:
+            return None
+        if stored_digest is None or stored_receipt is None:
+            raise ContextFault("context_integrity_failure")
+        if stored_digest != command_digest:
+            raise ContextFault("context_reservation_release_conflict")
+        try:
+            envelope = json.loads(stored_receipt)
+            payload = verify(
+                envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            receipt = ContextReservationReleaseReceiptV1.model_validate(payload)
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        if (
+            payload != receipt.model_dump(mode="json")
+            or receipt.context_cycle_id != row["id"]
+            or receipt.owner_id != row["owner"]
+            or receipt.project_id != row["project"]
+            or receipt.idempotency_key != row["request_key"]
+            or receipt.request_digest != row["request_digest"]
+            or receipt.profile_digest != row["profile"]
+            or receipt.release_command_digest != stored_digest
+            or receipt.revision != row["revision"]
+            or row["state"] != "EXPIRED"
+            or row["reservation_protocol_version"] < 2
+            or row["reservation_abort_digest"] is not None
+            or row["reservation_abort_receipt"] is not None
+            or row["reservation_expiry_digest"] is not None
+            or row["reservation_expiry_receipt"] is not None
+            or row["reservation_revival_from_revision"] is not None
+            or row["reservation_revival_kind"] is not None
+            or row["reservation_revival_command_digest"] is not None
+            or row["reservation_revival_receipt_digest"] is not None
+            or row["reservation_revival_no_dispatch_receipt_digest"] is not None
+            or not self._reservation_never_bound(row)
+            or not self._reservation_data_empty(db, row["id"])
+        ):
+            raise ContextFault("context_integrity_failure")
+        return envelope
+
+    def release_reservation(self, signed_command: dict) -> dict:
+        """Release only a Gateway-attested pre-dispatch failure, with CAS replay safety."""
+
+        payload = verify(signed_command, self.authority_keys)
+        try:
+            command = ContextReservationReleaseCommandV1.model_validate(payload)
+        except (TypeError, ValueError) as exc:
+            raise ContextFault("context_reservation_release_schema") from exc
+        if payload != command.model_dump(mode="json"):
+            raise ContextFault("context_reservation_release_schema")
+        command_digest = digest(payload)
+        with self.store.transaction() as db:
+            row = self._cycle(db, command.context_cycle_id)
+            replay = self._reservation_release_replay(db, row, command_digest)
+            if replay is not None:
+                return replay
+            if not command.issued_at <= self.now() < command.expires_at:
+                raise ContextFault("context_reservation_release_expired")
+            if (
+                row["owner"] != command.owner_id
+                or row["project"] != command.project_id
+                or row["request_key"] != command.idempotency_key
+                or row["request_digest"] != command.request_digest
+                or row["profile"] != command.profile_digest
+                or row["reservation_protocol_version"] < 2
+                or not self._reservation_never_bound(row)
+                or not self._reservation_data_empty(db, row["id"])
+                or row["state"] not in {"RESERVED", "EXPIRED"}
+                or row["reservation_abort_digest"] is not None
+                or row["reservation_abort_receipt"] is not None
+                or row["reservation_expiry_digest"] is not None
+                or row["reservation_expiry_receipt"] is not None
+            ):
+                raise ContextFault("context_reservation_release_denied")
+            allowed_revisions = {row["revision"]}
+            if row["state"] == "EXPIRED":
+                # The reservation expiry sweep is the only never-bound transition
+                # that may advance the receipt revision before this proof arrives.
+                allowed_revisions.add(row["revision"] - 1)
+            if command.expected_revision not in allowed_revisions:
+                raise ContextFault("context_stale_state")
+            revision = row["revision"] + 1
+            receipt = self.signer.sign(
+                ContextReservationReleaseReceiptV1(
+                    context_cycle_id=row["id"],
+                    owner_id=row["owner"],
+                    project_id=row["project"],
+                    idempotency_key=row["request_key"],
+                    request_digest=row["request_digest"],
+                    profile_digest=row["profile"],
+                    authorization_failure_receipt_digest=(
+                        command.authorization_failure_receipt_digest
+                    ),
+                    release_command_digest=command_digest,
+                    revision=revision,
+                ).model_dump(mode="json")
+            )
+            changed = db.execute(
+                "UPDATE cycles SET state='EXPIRED',expires=?,revision=?,"
+                "reservation_release_digest=?,reservation_release_receipt=?,"
+                "reservation_revival_from_revision=NULL,reservation_revival_kind=NULL,"
+                "reservation_revival_command_digest=NULL,"
+                "reservation_revival_receipt_digest=NULL,"
+                "reservation_revival_no_dispatch_receipt_digest=NULL "
+                "WHERE id=? AND revision=? AND binding IS NULL",
+                (
+                    self.now(),
+                    revision,
+                    command_digest,
+                    canonical(receipt).decode(),
+                    row["id"],
+                    row["revision"],
+                ),
+            ).rowcount
+            if changed != 1:
+                raise ContextFault("context_stale_state")
+            self._event(
+                db,
+                row["id"],
+                "context.reservation_released",
+                authorization_failure_receipt_digest=(
+                    command.authorization_failure_receipt_digest
+                ),
+                release_command_digest=command_digest,
+            )
+            return receipt
+
+    def _reservation_expiry_replay(
+        self,
+        db: sqlite3.Connection,
+        row: sqlite3.Row,
+        command_digest: str,
+        reservation_receipt_digest: str,
+        no_dispatch_receipt_digest: str,
+    ) -> dict | None:
+        stored_digest = row["reservation_expiry_digest"]
+        stored_receipt = row["reservation_expiry_receipt"]
+        if stored_digest is None and stored_receipt is None:
+            return None
+        if stored_digest is None or stored_receipt is None:
+            raise ContextFault("context_integrity_failure")
+        if stored_digest != command_digest:
+            raise ContextFault("context_reservation_expiry_conflict")
+        try:
+            envelope = json.loads(stored_receipt)
+            payload = verify(
+                envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            receipt = ContextReservationExpiryReceiptV1.model_validate(payload)
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        if (
+            payload != receipt.model_dump(mode="json")
+            or receipt.context_cycle_id != row["id"]
+            or receipt.context_bucket_id != "bucket_" + row["id"][4:]
+            or receipt.objective_id == ""
+            or receipt.owner_id != row["owner"]
+            or receipt.project_id != row["project"]
+            or receipt.idempotency_key != row["request_key"]
+            or receipt.request_digest != row["request_digest"]
+            or receipt.profile_digest != row["profile"]
+            or receipt.reservation_receipt_digest != reservation_receipt_digest
+            or receipt.invocation_no_dispatch_receipt_digest != no_dispatch_receipt_digest
+            or receipt.expiry_command_digest != stored_digest
+            or receipt.revision != row["revision"]
+            or receipt.expired_at != row["expires"]
+            or row["state"] != "EXPIRED"
+            or row["reservation_release_digest"] is not None
+            or row["reservation_release_receipt"] is not None
+            or row["reservation_abort_digest"] is not None
+            or row["reservation_abort_receipt"] is not None
+            or row["reservation_revival_from_revision"] is not None
+            or row["reservation_revival_kind"] is not None
+            or row["reservation_revival_command_digest"] is not None
+            or row["reservation_revival_receipt_digest"] is not None
+            or row["reservation_revival_no_dispatch_receipt_digest"] is not None
+            or not self._reservation_never_bound(row)
+            or not self._reservation_data_empty(db, row["id"])
+        ):
+            raise ContextFault("context_integrity_failure")
+        return envelope
+
+    def _validated_reservation_receipt(
+        self, envelope: dict
+    ) -> ContextReservationReceiptV2 | ContextReservationReceiptV3:
+        try:
+            payload = verify(
+                envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            if payload.get("schema_version") == "ContextReservationReceiptV3":
+                claim: ContextReservationReceiptV2 | ContextReservationReceiptV3 = (
+                    ContextReservationReceiptV3.model_validate(payload)
+                )
+            else:
+                claim = ContextReservationReceiptV2.model_validate(payload)
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_reservation_receipt_invalid") from exc
+        if payload != claim.model_dump(mode="json"):
+            raise ContextFault("context_reservation_receipt_invalid")
+        return claim
+
+    @staticmethod
+    def _reservation_receipt_lineage_matches(
+        row: sqlite3.Row,
+        claim: ContextReservationReceiptV2 | ContextReservationReceiptV3,
+    ) -> bool:
+        if isinstance(claim, ContextReservationReceiptV3):
+            return (
+                row["reservation_revival_kind"] == "expiry"
+                and row["reservation_revival_from_revision"]
+                == claim.prior_expiry_revision
+                and row["reservation_revival_receipt_digest"]
+                == claim.prior_expiry_receipt_digest
+                and row["reservation_revival_no_dispatch_receipt_digest"]
+                == claim.invocation_no_dispatch_receipt_digest
+                and row["reservation_revival_command_digest"]
+                == claim.revival_command_digest
+            )
+        return row["reservation_revival_kind"] != "expiry"
+
+    def expire_reservation(self, signed_command: dict) -> dict:
+        """Expire a never-dispatched reservation only after ledger closure proof."""
+
+        payload = verify(signed_command, self.authority_keys)
+        try:
+            command = ContextReservationExpiryCommandV1.model_validate(payload)
+        except (TypeError, ValueError) as exc:
+            raise ContextFault("context_reservation_expiry_schema") from exc
+        if payload != command.model_dump(mode="json"):
+            raise ContextFault("context_reservation_expiry_schema")
+        reservation_envelope = command.reservation_receipt.model_dump(mode="json")
+        try:
+            reservation_claim = self._validated_reservation_receipt(
+                reservation_envelope
+            )
+        except ContextFault as exc:
+            raise ContextFault("context_reservation_expiry_receipt_invalid") from exc
+        try:
+            no_dispatch_envelope = command.invocation_no_dispatch_receipt.model_dump(mode="json")
+            no_dispatch_payload = verify(no_dispatch_envelope, self.authority_keys)
+            no_dispatch_claim = ContextInvocationNoDispatchReceiptV1.model_validate(
+                no_dispatch_payload
+            )
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_invocation_no_dispatch_receipt_invalid") from exc
+        if no_dispatch_payload != no_dispatch_claim.model_dump(mode="json"):
+            raise ContextFault("context_invocation_no_dispatch_receipt_invalid")
+        command_digest = digest(payload)
+        reservation_receipt_digest = digest(reservation_envelope)
+        no_dispatch_receipt_digest = digest(no_dispatch_envelope)
+        no_dispatch_snapshot = no_dispatch_claim.ledger_snapshot
+        with self.store.transaction() as db:
+            row = self._cycle(db, command.context_cycle_id)
+            replay = self._reservation_expiry_replay(
+                db,
+                row,
+                command_digest,
+                reservation_receipt_digest,
+                no_dispatch_receipt_digest,
+            )
+            if replay is not None:
+                return replay
+            if row["state"] == "RESERVED":
+                if not (
+                    reservation_claim.revision
+                    == command.expected_revision
+                    == row["revision"]
+                ):
+                    raise ContextFault("context_stale_state")
+            elif row["state"] == "EXPIRED" and not (
+                reservation_claim.revision == row["revision"] - 1
+                and command.expected_revision
+                in {row["revision"] - 1, row["revision"]}
+            ):
+                raise ContextFault("context_stale_state")
+            now = self.now()
+            if (
+                not command.issued_at <= now < command.expires_at
+                or not no_dispatch_claim.issued_at <= now < no_dispatch_claim.expires_at
+            ):
+                raise ContextFault("context_reservation_expiry_expired")
+            bucket = "bucket_" + row["id"][4:]
+            if (
+                row["owner"] != command.owner_id
+                or row["project"] != command.project_id
+                or row["request_key"] != command.idempotency_key
+                or row["request_digest"] != command.request_digest
+                or row["profile"] != command.profile_digest
+                or command.context_bucket_id != bucket
+                or command.objective_id != no_dispatch_snapshot.objective_id
+                or reservation_claim.context_cycle_id != row["id"]
+                or reservation_claim.context_bucket_id != bucket
+                or reservation_claim.request_digest != row["request_digest"]
+                or reservation_claim.profile_digest != row["profile"]
+                or no_dispatch_snapshot.context_cycle_id != row["id"]
+                or no_dispatch_snapshot.reservation_revision != reservation_claim.revision
+                or no_dispatch_snapshot.reservation_receipt_digest
+                != reservation_receipt_digest
+                or no_dispatch_snapshot.owner_user_id != row["owner"]
+                or no_dispatch_snapshot.idempotency_key != row["request_key"]
+                or no_dispatch_snapshot.request_digest
+                != "sha256:" + row["request_digest"]
+                or command.invocation_no_dispatch_receipt_digest
+                != no_dispatch_receipt_digest
+                or not self._reservation_receipt_lineage_matches(
+                    row, reservation_claim
+                )
+                or row["state"] not in {"RESERVED", "EXPIRED"}
+                or not self._reservation_never_bound(row)
+                or not self._reservation_data_empty(db, row["id"])
+                or row["reservation_release_digest"] is not None
+                or row["reservation_release_receipt"] is not None
+                or row["reservation_abort_digest"] is not None
+                or row["reservation_abort_receipt"] is not None
+            ):
+                raise ContextFault("context_reservation_expiry_denied")
+            revision = row["revision"] + 1
+            receipt = self.signer.sign(
+                ContextReservationExpiryReceiptV1(
+                    context_cycle_id=row["id"],
+                    context_bucket_id=bucket,
+                    objective_id=command.objective_id,
+                    owner_id=row["owner"],
+                    project_id=row["project"],
+                    idempotency_key=row["request_key"],
+                    request_digest=row["request_digest"],
+                    profile_digest=row["profile"],
+                    reason_code=command.reason_code,
+                    reservation_receipt_digest=reservation_receipt_digest,
+                    invocation_no_dispatch_receipt_digest=no_dispatch_receipt_digest,
+                    expiry_command_digest=command_digest,
+                    expired_at=now,
+                    revision=revision,
+                ).model_dump(mode="json")
+            )
+            changed = db.execute(
+                "UPDATE cycles SET state='EXPIRED',expires=?,revision=?,"
+                "reservation_expiry_digest=?,reservation_expiry_receipt=?,"
+                "reservation_revival_from_revision=NULL,reservation_revival_kind=NULL,"
+                "reservation_revival_command_digest=NULL,"
+                "reservation_revival_receipt_digest=NULL,"
+                "reservation_revival_no_dispatch_receipt_digest=NULL "
+                "WHERE id=? AND state=? AND revision=? AND binding IS NULL",
+                (
+                    now,
+                    revision,
+                    command_digest,
+                    canonical(receipt).decode(),
+                    row["id"],
+                    row["state"],
+                    row["revision"],
+                ),
+            ).rowcount
+            if changed != 1:
+                raise ContextFault("context_stale_state")
+            self._event(
+                db,
+                row["id"],
+                "context.reservation_expired_without_dispatch",
+                reservation_receipt_digest=reservation_receipt_digest,
+                invocation_no_dispatch_receipt_digest=no_dispatch_receipt_digest,
+                expiry_command_digest=command_digest,
+            )
+            return receipt
+
+    def _reservation_abort_replay(
+        self,
+        db: sqlite3.Connection,
+        row: sqlite3.Row,
+        command_digest: str,
+        reservation_receipt_digest: str,
+    ) -> dict | None:
+        stored_digest = row["reservation_abort_digest"]
+        stored_receipt = row["reservation_abort_receipt"]
+        if stored_digest is None and stored_receipt is None:
+            return None
+        if stored_digest is None or stored_receipt is None:
+            raise ContextFault("context_integrity_failure")
+        if stored_digest != command_digest:
+            raise ContextFault("context_reservation_abort_conflict")
+        try:
+            envelope = json.loads(stored_receipt)
+            payload = verify(
+                envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            receipt = ContextReservationAbortReceiptV1.model_validate(payload)
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        if (
+            payload != receipt.model_dump(mode="json")
+            or receipt.context_cycle_id != row["id"]
+            or receipt.owner_id != row["owner"]
+            or receipt.project_id != row["project"]
+            or receipt.idempotency_key != row["request_key"]
+            or receipt.request_digest != row["request_digest"]
+            or receipt.profile_digest != row["profile"]
+            or receipt.abort_command_digest != stored_digest
+            or receipt.reservation_receipt_digest != reservation_receipt_digest
+            or receipt.retention_expires_at != row["expires"]
+            or row["reservation_expiry_digest"] is not None
+            or row["reservation_expiry_receipt"] is not None
+            or row["reservation_revival_from_revision"] is not None
+            or row["reservation_revival_kind"] is not None
+            or row["reservation_revival_command_digest"] is not None
+            or row["reservation_revival_receipt_digest"] is not None
+            or row["reservation_revival_no_dispatch_receipt_digest"] is not None
+        ):
+            raise ContextFault("context_integrity_failure")
+        active_abort = (
+            row["state"] == "ABORTED"
+            and receipt.revision == row["revision"]
+            and self._reservation_never_bound(row)
+            and self._reservation_data_empty(db, row["id"])
+        )
+        completed_cleanup = self._reservation_abort_cleanup_valid(db, row, receipt)
+        if not active_abort and not completed_cleanup:
+            raise ContextFault("context_integrity_failure")
+        return envelope
+
+    def _reservation_abort_cleanup_valid(
+        self,
+        db: sqlite3.Connection,
+        row: sqlite3.Row,
+        abort_receipt: ContextReservationAbortReceiptV1,
+    ) -> bool:
+        if (
+            row["state"] != "EXPIRED"
+            or row["revision"] != abort_receipt.revision + 1
+            or row["cleanup_state"] != "COMPLETE"
+            or row["cleanup_remote_receipt"] is not None
+            or row["cleanup_operation_key"] is None
+            or row["cleanup_request_digest"] is None
+            or row["deletion_receipt"] is None
+            or not self._reservation_unbound_metadata(row)
+            or not self._reservation_data_empty(
+                db, row["id"], include_retention=False
+            )
+        ):
+            return False
+        try:
+            deletion_envelope = json.loads(row["deletion_receipt"])
+            deletion_payload = verify(
+                deletion_envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            deletion = ContextDeletionReceiptV2.model_validate(deletion_payload)
+        except (ContextFault, TypeError, ValueError):
+            return False
+        if (
+            deletion_payload != deletion.model_dump(mode="json")
+            or deletion.context_cycle_id != row["id"]
+            or deletion.segment_chain_root != ZERO
+            or deletion.context_seal_digest is not None
+            or deletion.retention_class != row["retention_class"]
+            or deletion.retention_expired_at != abort_receipt.retention_expires_at
+            or deletion.retention_operation_key != row["cleanup_operation_key"]
+            or deletion.retention_request_digest != row["cleanup_request_digest"]
+            or deletion.cryptographic_erasure
+            or deletion.checkpoint_durability_mode != "unregistered"
+        ):
+            return False
+        operation = db.execute(
+            "SELECT request_digest,result FROM retention_operations "
+            "WHERE cycle=? AND operation='expire_aborted_reservation' AND key=?",
+            (row["id"], row["cleanup_operation_key"]),
+        ).fetchone()
+        count = db.execute(
+            "SELECT count(*) FROM retention_operations WHERE cycle=?",
+            (row["id"],),
+        ).fetchone()[0]
+        return (
+            operation is not None
+            and count == 1
+            and operation["request_digest"] == row["cleanup_request_digest"]
+            and operation["result"] == canonical(deletion_envelope).decode()
+        )
+
+    def abort_reservation(self, signed_command: dict) -> dict:
+        """Abort an exact dispatched objective that never reached context bind."""
+
+        payload = verify(signed_command, self.authority_keys)
+        try:
+            command = ContextReservationAbortCommandV1.model_validate(payload)
+        except (TypeError, ValueError) as exc:
+            raise ContextFault("context_reservation_abort_schema") from exc
+        if payload != command.model_dump(mode="json"):
+            raise ContextFault("context_reservation_abort_schema")
+        reservation_envelope = command.reservation_receipt.model_dump(mode="json")
+        try:
+            reservation_claim = self._validated_reservation_receipt(
+                reservation_envelope
+            )
+        except ContextFault as exc:
+            raise ContextFault("context_reservation_abort_receipt_invalid") from exc
+        command_digest = digest(payload)
+        with self.store.transaction() as db:
+            row = self._cycle(db, command.context_cycle_id)
+            replay = self._reservation_abort_replay(
+                db, row, command_digest, digest(reservation_envelope)
+            )
+            if replay is not None:
+                return replay
+            if row["state"] == "RESERVED":
+                if not (
+                    reservation_claim.revision
+                    == command.expected_revision
+                    == row["revision"]
+                ):
+                    raise ContextFault("context_stale_state")
+            elif row["state"] == "EXPIRED" and not (
+                reservation_claim.revision == row["revision"] - 1
+                and command.expected_revision
+                in {row["revision"] - 1, row["revision"]}
+            ):
+                raise ContextFault("context_stale_state")
+            now = self.now()
+            if not command.issued_at <= now < command.expires_at:
+                raise ContextFault("context_reservation_abort_expired")
+            if (
+                row["owner"] != command.owner_id
+                or row["project"] != command.project_id
+                or row["request_key"] != command.idempotency_key
+                or row["request_digest"] != command.request_digest
+                or row["profile"] != command.profile_digest
+                or reservation_claim.context_cycle_id != row["id"]
+                or reservation_claim.context_bucket_id
+                != "bucket_" + row["id"][4:]
+                or reservation_claim.request_digest != row["request_digest"]
+                or reservation_claim.profile_digest != row["profile"]
+                or not self._reservation_receipt_lineage_matches(
+                    row, reservation_claim
+                )
+                or row["state"] not in {"RESERVED", "EXPIRED"}
+                or not self._reservation_never_bound(row)
+                or not self._reservation_data_empty(db, row["id"])
+                or row["reservation_release_digest"] is not None
+                or row["reservation_release_receipt"] is not None
+                or row["reservation_expiry_digest"] is not None
+                or row["reservation_expiry_receipt"] is not None
+            ):
+                raise ContextFault("context_reservation_abort_denied")
+            revision = row["revision"] + 1
+            retention_expires_at = now + self.profile.retention_seconds
+            receipt = self.signer.sign(
+                ContextReservationAbortReceiptV1(
+                    context_cycle_id=row["id"],
+                    owner_id=row["owner"],
+                    project_id=row["project"],
+                    objective_id=command.objective_id,
+                    idempotency_key=row["request_key"],
+                    request_digest=row["request_digest"],
+                    profile_digest=row["profile"],
+                    reason_code=command.reason_code,
+                    objective_dispatch_receipt_digest=(
+                        command.objective_dispatch_receipt_digest
+                    ),
+                    reservation_receipt_digest=digest(reservation_envelope),
+                    abort_command_digest=command_digest,
+                    aborted_at=now,
+                    retention_expires_at=retention_expires_at,
+                    revision=revision,
+                ).model_dump(mode="json")
+            )
+            changed = db.execute(
+                "UPDATE cycles SET state='ABORTED',expires=?,revision=?,"
+                "reservation_abort_digest=?,reservation_abort_receipt=?,"
+                "reservation_revival_from_revision=NULL,reservation_revival_kind=NULL,"
+                "reservation_revival_command_digest=NULL,"
+                "reservation_revival_receipt_digest=NULL,"
+                "reservation_revival_no_dispatch_receipt_digest=NULL "
+                "WHERE id=? AND state=? AND revision=? AND binding IS NULL "
+                "AND binding_digest IS NULL AND authority IS NULL AND snapshot IS NULL "
+                "AND cursor=0 AND root=? AND bytes=0 AND checkpoint=0 "
+                "AND key_ref IS NULL AND key_version IS NULL AND seal_digest IS NULL "
+                "AND checkpoint_manifest_checksum IS NULL",
+                (
+                    retention_expires_at,
+                    revision,
+                    command_digest,
+                    canonical(receipt).decode(),
+                    row["id"],
+                    row["state"],
+                    row["revision"],
+                    ZERO,
+                ),
+            ).rowcount
+            if changed != 1:
+                raise ContextFault("context_stale_state")
+            self._event(
+                db,
+                row["id"],
+                "context.reservation_aborted",
+                objective_id=command.objective_id,
+                reason_code=command.reason_code,
+                objective_dispatch_receipt_digest=(
+                    command.objective_dispatch_receipt_digest
+                ),
+                reservation_receipt_digest=digest(reservation_envelope),
+                abort_command_digest=command_digest,
+            )
+            return receipt
+
+    def expire_aborted_reservation(self, signed_command: dict) -> dict:
+        """Clean an empty unbound abort after its retention deadline."""
+
+        payload = verify(signed_command, self.authority_keys)
+        try:
+            command = ContextReservationAbortExpiryCommandV1.model_validate(payload)
+        except (TypeError, ValueError) as exc:
+            raise ContextFault("context_reservation_abort_expiry_schema") from exc
+        if payload != command.model_dump(mode="json"):
+            raise ContextFault("context_reservation_abort_expiry_schema")
+        try:
+            abort_envelope = command.abort_receipt.model_dump(mode="json")
+            abort_payload = verify(
+                abort_envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            abort_receipt = ContextReservationAbortReceiptV1.model_validate(
+                abort_payload
+            )
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_reservation_abort_receipt_invalid") from exc
+        if abort_payload != abort_receipt.model_dump(mode="json"):
+            raise ContextFault("context_reservation_abort_receipt_invalid")
+        request_digest = digest(payload)
+        with self.store.transaction() as db:
+            row = self._cycle(db, command.namespace.context_cycle_id)
+            replay = db.execute(
+                "SELECT request_digest,result FROM retention_operations "
+                "WHERE cycle=? AND operation='expire_aborted_reservation' AND key=?",
+                (row["id"], command.idempotency_key),
+            ).fetchone()
+            if replay is not None:
+                if replay["request_digest"] != request_digest:
+                    raise ContextFault("context_idempotency_conflict")
+                if replay["result"] is None:
+                    raise ContextFault("context_integrity_failure")
+                try:
+                    result = json.loads(replay["result"])
+                    result_payload = verify(
+                        result,
+                        {self.signer.key_id: self.signer.key.public_key()},
+                    )
+                    result_claim = ContextDeletionReceiptV2.model_validate(
+                        result_payload
+                    )
+                except (ContextFault, TypeError, ValueError) as exc:
+                    raise ContextFault("context_integrity_failure") from exc
+                if (
+                    result_payload != result_claim.model_dump(mode="json")
+                    or row["deletion_receipt"] != canonical(result).decode()
+                    or not self._reservation_abort_cleanup_valid(
+                        db, row, abort_receipt
+                    )
+                ):
+                    raise ContextFault("context_integrity_failure")
+                return result
+            now = self.now()
+            if not command.issued_at <= now < command.expires_at:
+                raise ContextFault("context_reservation_abort_expiry_expired")
+            namespace = command.namespace.model_dump(mode="json")
+            if (
+                row["state"] != "ABORTED"
+                or row["owner"] != namespace["owner_id"]
+                or row["project"] != namespace["project_id"]
+                or row["revision"] != command.expected_revision
+                or abort_receipt.context_cycle_id != row["id"]
+                or abort_receipt.owner_id != row["owner"]
+                or abort_receipt.project_id != row["project"]
+                or abort_receipt.objective_id != namespace["objective_id"]
+                or abort_receipt.idempotency_key != row["request_key"]
+                or abort_receipt.request_digest != row["request_digest"]
+                or abort_receipt.profile_digest != row["profile"]
+                or abort_receipt.revision != row["revision"]
+                or abort_receipt.retention_expires_at != row["expires"]
+                or abort_receipt.abort_command_digest
+                != row["reservation_abort_digest"]
+                or row["reservation_abort_receipt"]
+                != canonical(abort_envelope).decode()
+                or now < row["expires"]
+                or not self._reservation_never_bound(row)
+                or not self._reservation_data_empty(db, row["id"])
+            ):
+                raise ContextFault("context_reservation_abort_expiry_denied")
+            db.execute(
+                "INSERT INTO retention_operations(cycle,operation,key,request_digest,result) "
+                "VALUES(?,'expire_aborted_reservation',?,?,NULL)",
+                (row["id"], command.idempotency_key, request_digest),
+            )
+            deletion_payload = ContextDeletionReceiptV2(
+                context_cycle_id=row["id"],
+                segment_chain_root=ZERO,
+                context_seal_digest=None,
+                retention_class=row["retention_class"],
+                retention_expired_at=row["expires"],
+                deleted_at=now,
+                reason_code=command.reason_code,
+                retention_operation_key=command.idempotency_key,
+                retention_request_digest=request_digest,
+                logical_deletion=True,
+                cryptographic_erasure=False,
+                local_key_destruction=None,
+                key_destruction_receipt=None,
+                key_destruction_receipt_digest=None,
+                managed_key_provider_receipt_digest=None,
+                remote_deletion_receipt_digest=None,
+                checkpoint_manifest_checksum=None,
+                checkpoint_object_ref_digest=None,
+                checkpoint_durability_mode="unregistered",
+                checkpoint_durability_registration_receipt_digest=None,
+            ).model_dump(mode="json")
+            receipt = self.signer.sign(deletion_payload)
+            changed = db.execute(
+                "UPDATE cycles SET state='EXPIRED',cleanup_state='COMPLETE',"
+                "cleanup_operation_key=?,cleanup_request_digest=?,"
+                "deletion_receipt=?,revision=revision+1 "
+                "WHERE id=? AND state='ABORTED' AND revision=? AND binding IS NULL",
+                (
+                    command.idempotency_key,
+                    request_digest,
+                    canonical(receipt).decode(),
+                    row["id"],
+                    row["revision"],
+                ),
+            ).rowcount
+            if changed != 1:
+                raise ContextFault("context_stale_state")
+            db.execute(
+                "UPDATE retention_operations SET result=? WHERE cycle=? "
+                "AND operation='expire_aborted_reservation' AND key=?",
+                (
+                    canonical(receipt).decode(),
+                    row["id"],
+                    command.idempotency_key,
+                ),
+            )
+            self._event(
+                db,
+                row["id"],
+                "context.expired",
+                deletion_receipt_digest=digest(receipt),
+                cryptographic_erasure=False,
+            )
+            return receipt
+
+    def register_checkpoint_durability(self, signed_command: dict) -> dict:
+        """Register an immutable checkpoint persistence mode before the first pack."""
+
+        payload = verify(signed_command, self.authority_keys)
+        try:
+            command = ContextCheckpointDurabilityCommandV1.model_validate(payload)
+        except (TypeError, ValueError) as exc:
+            raise ContextFault("context_checkpoint_durability_schema") from exc
+        if payload != command.model_dump(mode="json"):
+            raise ContextFault("context_checkpoint_durability_schema")
+        command_digest = digest(payload)
+        with self.store.transaction() as db:
+            row = self._cycle(db, command.namespace.context_cycle_id)
+            stored_digest = row["checkpoint_durability_command_digest"]
+            stored_receipt = row["checkpoint_durability_receipt"]
+            if stored_digest is not None or stored_receipt is not None:
+                if stored_digest is None or stored_receipt is None:
+                    raise ContextFault("context_integrity_failure")
+                if stored_digest != command_digest:
+                    raise ContextFault("context_checkpoint_durability_conflict")
+                try:
+                    envelope = json.loads(stored_receipt)
+                    receipt, receipt_payload = self._validated_durability_receipt(
+                        envelope,
+                        {self.signer.key_id: self.signer.key.public_key()},
+                    )
+                except (ContextFault, TypeError, ValueError) as exc:
+                    raise ContextFault("context_integrity_failure") from exc
+                if (
+                    receipt_payload != receipt.model_dump(mode="json")
+                    or receipt.namespace != command.namespace
+                    or receipt.idempotency_key != command.idempotency_key
+                    or receipt.mode != command.mode
+                    or row["checkpoint_durability_mode"] != receipt.mode
+                    or row["checkpoint_durability_legacy"]
+                    or receipt.command_digest != stored_digest
+                    or receipt.revision > row["revision"]
+                ):
+                    raise ContextFault("context_integrity_failure")
+                return envelope
+            if not command.issued_at <= self.now() < command.expires_at:
+                raise ContextFault("context_checkpoint_durability_expired")
+            try:
+                binding_payload = json.loads(row["binding"])
+                binding = ContextBindingV1.model_validate(binding_payload)
+            except (TypeError, ValueError) as exc:
+                raise ContextFault("context_checkpoint_durability_denied") from exc
+            if (
+                binding.namespace != command.namespace
+                or row["binding_digest"] != digest(binding_payload)
+                or row["state"] != "ACTIVE"
+                or row["checkpoint"] != 0
+                or row["checkpoint_manifest_checksum"] is not None
+            ):
+                raise ContextFault("context_checkpoint_durability_denied")
+            if row["revision"] != command.expected_revision:
+                raise ContextFault("context_stale_state")
+            revision = row["revision"] + 1
+            receipt_envelope = self.signer.sign(
+                ContextCheckpointDurabilityReceiptV1(
+                    namespace=command.namespace,
+                    idempotency_key=command.idempotency_key,
+                    mode=command.mode,
+                    command_digest=command_digest,
+                    effective_at=self.now(),
+                    revision=revision,
+                ).model_dump(mode="json")
+            )
+            changed = db.execute(
+                "UPDATE cycles SET checkpoint_durability_mode=?,"
+                "checkpoint_durability_command_digest=?,checkpoint_durability_receipt=?,"
+                "checkpoint_durability_legacy=0,revision=? WHERE id=? AND revision=?",
+                (
+                    command.mode,
+                    command_digest,
+                    canonical(receipt_envelope).decode(),
+                    revision,
+                    row["id"],
+                    row["revision"],
+                ),
+            ).rowcount
+            if changed != 1:
+                raise ContextFault("context_stale_state")
+            self._event(
+                db,
+                row["id"],
+                "context.checkpoint_durability_registered",
+                mode=command.mode,
+                command_digest=command_digest,
+            )
+            return receipt_envelope
+
+    @staticmethod
+    def _validated_durability_receipt(
+        envelope: dict, keys: dict
+    ) -> tuple[ContextCheckpointDurabilityReceiptV1, dict]:
+        payload = verify(envelope, keys)
+        model = (
+            ContextCheckpointDurabilityReceiptV2
+            if payload.get("schema_version")
+            == "ContextCheckpointDurabilityReceiptV2"
+            else ContextCheckpointDurabilityReceiptV1
+        )
+        receipt = model.model_validate(payload)
+        if payload != receipt.model_dump(mode="json"):
+            raise ContextFault("context_integrity_failure")
+        return receipt, payload
+
+    def _verify_checkpoint_durability_registration(self, row: sqlite3.Row) -> None:
+        mode = row["checkpoint_durability_mode"]
+        command_digest = row["checkpoint_durability_command_digest"]
+        stored_receipt = row["checkpoint_durability_receipt"]
+        if row["checkpoint_durability_legacy"]:
+            if (
+                mode != "remote_registered"
+                or command_digest is not None
+                or stored_receipt is not None
+            ):
+                raise ContextFault("context_integrity_failure")
+            return
+        if mode == "unregistered":
+            if command_digest is not None or stored_receipt is not None:
+                raise ContextFault("context_integrity_failure")
+            raise ContextFault("context_checkpoint_durability_unregistered")
+        if command_digest is None or stored_receipt is None:
+            raise ContextFault("context_checkpoint_durability_unregistered")
+        try:
+            envelope = json.loads(stored_receipt)
+            receipt, payload = self._validated_durability_receipt(
+                envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        if (
+            payload != receipt.model_dump(mode="json")
+            or receipt.namespace.context_cycle_id != row["id"]
+            or receipt.namespace.owner_id != row["owner"]
+            or receipt.namespace.project_id != row["project"]
+            or receipt.mode != mode
+            or receipt.command_digest != command_digest
+            or receipt.revision > row["revision"]
+        ):
+            raise ContextFault("context_integrity_failure")
+
+    def _restore_checkpoint_durability_registration(
+        self,
+        snapshot: dict,
+        namespace: dict,
+        mode: str,
+        receipt_keys: dict,
+        hydrated_revision: int,
+    ) -> tuple[str | None, dict | None, int, str | None]:
+        fields = {
+            "checkpoint_durability_command_digest",
+            "checkpoint_durability_receipt",
+        }
+        present = fields & snapshot.keys()
+        if not present:
+            if mode != "remote_registered":
+                raise ContextFault("context_hydrate_durability_denied")
+            return None, None, 1, None
+        if present != fields:
+            raise ContextFault("context_integrity_failure")
+        command_digest = snapshot["checkpoint_durability_command_digest"]
+        source_envelope = snapshot["checkpoint_durability_receipt"]
+        if (
+            not isinstance(command_digest, str)
+            or len(command_digest) != 64
+            or any(character not in "0123456789abcdef" for character in command_digest)
+            or not isinstance(source_envelope, dict)
+        ):
+            raise ContextFault("context_integrity_failure")
+        try:
+            source_receipt, source_payload = self._validated_durability_receipt(
+                source_envelope, receipt_keys
+            )
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        if (
+            source_payload != source_receipt.model_dump(mode="json")
+            or source_receipt.namespace.model_dump(mode="json") != namespace
+            or source_receipt.mode != mode
+            or source_receipt.command_digest != command_digest
+            or source_receipt.revision > hydrated_revision
+        ):
+            raise ContextFault("context_integrity_failure")
+        if isinstance(source_receipt, ContextCheckpointDurabilityReceiptV2):
+            # Each replacement verifies the immediate source host's V2 receipt,
+            # then carries the original signed V1 registration forward. This
+            # keeps the evidence constant-sized while preserving a resolvable
+            # authority-issued root through arbitrarily many replacements.
+            original_envelope = source_receipt.source_registration_receipt.model_dump(
+                mode="json"
+            )
+            try:
+                original_receipt = (
+                    ContextCheckpointDurabilityReceiptV1.model_validate(
+                        original_envelope["payload"]
+                    )
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise ContextFault("context_integrity_failure") from exc
+            if (
+                original_envelope["payload"]
+                != original_receipt.model_dump(mode="json")
+                or source_receipt.source_registration_receipt_digest
+                != digest(original_envelope)
+            ):
+                raise ContextFault("context_integrity_failure")
+        else:
+            original_envelope = source_envelope
+            original_receipt = source_receipt
+        reattested = self.signer.sign(
+            ContextCheckpointDurabilityReceiptV2(
+                namespace=original_receipt.namespace,
+                idempotency_key=original_receipt.idempotency_key,
+                mode=original_receipt.mode,
+                command_digest=original_receipt.command_digest,
+                effective_at=original_receipt.effective_at,
+                revision=original_receipt.revision,
+                source_registration_receipt=SignedV1.model_validate(
+                    original_envelope
+                ),
+                source_registration_receipt_digest=digest(original_envelope),
+                reattested_at=self.now(),
+            ).model_dump(mode="json")
+        )
+        return command_digest, reattested, 0, digest(original_envelope)
 
     def bind(self, signed_binding: dict, authority: dict, project_snapshot: dict) -> dict:
         binding_payload = verify(signed_binding, self.authority_keys)
-        binding = ContextBindingV1.model_validate(binding_payload)
+        try:
+            binding = ContextBindingV1.model_validate(binding_payload)
+        except (TypeError, ValueError) as exc:
+            raise ContextFault("context_binding_invalid") from exc
+        return self._bind(
+            binding,
+            binding_payload,
+            authority,
+            project_snapshot,
+            reservation_claim=None,
+            reservation_receipt_digest=None,
+        )
+
+    def bind_v2(self, signed_command: dict, authority: dict, project_snapshot: dict) -> dict:
+        payload = verify(signed_command, self.authority_keys)
+        try:
+            command = ContextBindingCommandV2.model_validate(payload)
+            reservation_envelope = command.reservation_receipt.model_dump(mode="json")
+            reservation_payload = verify(
+                reservation_envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            reservation_claim = ContextReservationReceiptV2.model_validate(
+                reservation_payload
+            )
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_binding_invalid") from exc
+        if (
+            payload != command.model_dump(mode="json")
+            or reservation_payload != reservation_claim.model_dump(mode="json")
+            or command.expected_reservation_revision != reservation_claim.revision
+        ):
+            raise ContextFault("context_binding_invalid")
+        binding_payload = command.binding.model_dump(mode="json")
+        return self._bind(
+            command.binding,
+            binding_payload,
+            authority,
+            project_snapshot,
+            reservation_claim=reservation_claim,
+            reservation_receipt_digest=digest(reservation_envelope),
+        )
+
+    def bind_v3(self, signed_command: dict, authority: dict, project_snapshot: dict) -> dict:
+        payload = verify(signed_command, self.authority_keys)
+        try:
+            command = ContextBindingCommandV3.model_validate(payload)
+            reservation_envelope = command.reservation_receipt.model_dump(mode="json")
+            reservation_payload = verify(
+                reservation_envelope,
+                {self.signer.key_id: self.signer.key.public_key()},
+            )
+            reservation_claim = ContextReservationReceiptV3.model_validate(
+                reservation_payload
+            )
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_binding_invalid") from exc
+        if (
+            payload != command.model_dump(mode="json")
+            or reservation_payload != reservation_claim.model_dump(mode="json")
+            or command.expected_reservation_revision != reservation_claim.revision
+        ):
+            raise ContextFault("context_binding_invalid")
+        binding_payload = command.binding.model_dump(mode="json")
+        return self._bind(
+            command.binding,
+            binding_payload,
+            authority,
+            project_snapshot,
+            reservation_claim=reservation_claim,
+            reservation_receipt_digest=digest(reservation_envelope),
+        )
+
+    def _bind(
+        self,
+        binding: ContextBindingV1,
+        binding_payload: dict,
+        authority: dict,
+        project_snapshot: dict,
+        *,
+        reservation_claim: ContextReservationReceiptV2 | ContextReservationReceiptV3 | None,
+        reservation_receipt_digest: str | None,
+    ) -> dict:
         binding_digest = digest(binding_payload)
         # Authority comes from the same authenticated control plane; its exact
         # digest is already committed by the authorization receipt.
@@ -502,12 +2128,53 @@ class ContextEngine:
             row = self._cycle(db, cycle)
             if row["owner"] != ns["owner_id"] or row["project"] != ns["project_id"]:
                 raise ContextFault("context_namespace_denied")
+            if isinstance(reservation_claim, ContextReservationReceiptV3):
+                if (
+                    row["reservation_revival_kind"] != "expiry"
+                    or row["reservation_revival_from_revision"]
+                    != reservation_claim.prior_expiry_revision
+                    or row["reservation_revival_receipt_digest"]
+                    != reservation_claim.prior_expiry_receipt_digest
+                    or row["reservation_revival_no_dispatch_receipt_digest"]
+                    != reservation_claim.invocation_no_dispatch_receipt_digest
+                    or row["reservation_revival_command_digest"]
+                    != reservation_claim.revival_command_digest
+                ):
+                    raise ContextFault("context_stale_state")
+            elif row["reservation_revival_kind"] == "expiry":
+                raise ContextFault("context_binding_revision_required")
             if row["binding"]:
                 if row["binding_digest"] != binding_digest:
                     raise ContextFault("context_binding_conflict")
+                if reservation_claim is None:
+                    if row["reservation_binding_revision"] is not None:
+                        raise ContextFault("context_binding_revision_required")
+                elif (
+                    row["reservation_binding_receipt_digest"]
+                    != reservation_receipt_digest
+                    or row["reservation_binding_revision"]
+                    != reservation_claim.revision
+                    or reservation_claim.context_cycle_id != row["id"]
+                    or reservation_claim.context_bucket_id != binding.context_bucket_id
+                    or reservation_claim.request_digest != row["request_digest"]
+                    or reservation_claim.profile_digest != row["profile"]
+                ):
+                    raise ContextFault("context_stale_state")
             else:
                 if row["state"] != "RESERVED" or row["expires"] <= self.now():
                     raise ContextFault("context_state_conflict")
+                if row["reservation_revival_from_revision"] is not None and (
+                    reservation_claim is None
+                ):
+                    raise ContextFault("context_binding_revision_required")
+                if reservation_claim is not None and (
+                    reservation_claim.context_cycle_id != row["id"]
+                    or reservation_claim.context_bucket_id != binding.context_bucket_id
+                    or reservation_claim.request_digest != row["request_digest"]
+                    or reservation_claim.profile_digest != row["profile"]
+                    or reservation_claim.revision != row["revision"]
+                ):
+                    raise ContextFault("context_stale_state")
                 key_ref = self.cycle_keys.ensure(ns) if self.cycle_keys is not None else None
                 key_version = (
                     self._provider_key_version(key_ref) if key_ref is not None else None
@@ -527,11 +2194,11 @@ class ContextEngine:
                 cipher = (
                     self.cycle_keys.cipher(key_ref, ns) if key_ref is not None else self.cipher
                 )
-                db.execute(
+                changed = db.execute(
                     "UPDATE cycles SET binding=?,binding_digest=?,authority=?,snapshot=?,"
                     "state='BOUND',expires=?,key_ref=?,key_version=?,retention_class=?,"
-                    "revision=revision+1 "
-                    "WHERE id=?",
+                    "reservation_binding_receipt_digest=?,reservation_binding_revision=?,"
+                    "revision=revision+1 WHERE id=? AND revision=?",
                     (
                         canonical(binding_payload).decode(),
                         binding_digest,
@@ -541,9 +2208,14 @@ class ContextEngine:
                         key_ref,
                         key_version,
                         binding.retention_class,
+                        reservation_receipt_digest,
+                        reservation_claim.revision if reservation_claim is not None else None,
                         cycle,
+                        row["revision"],
                     ),
-                )
+                ).rowcount
+                if changed != 1:
+                    raise ContextFault("context_stale_state")
                 self._event(db, cycle, "context.bound", binding_digest=binding_digest)
                 db.execute(
                     "UPDATE cycles SET state='HYDRATING',revision=revision+1 WHERE id=?", (cycle,)
@@ -892,6 +2564,7 @@ class ContextEngine:
         return {"metadata": metadata, "text": text}
 
     def retrieve(self, capability: dict, request: RetrieveRequestV1) -> dict:
+        self._space()
         filter_text(request.query)
         with self._transaction(capability) as db:
             cap, cycle = self._authorize(db, capability, "retrieve")
@@ -1025,8 +2698,30 @@ class ContextEngine:
                 db, cycle["id"], "retrieve", request.turn_id, req_digest, result, cipher
             )
 
-    def checkpoint(self, capability: dict, idempotency_key: str) -> dict:
+    def checkpoint(
+        self,
+        capability: dict,
+        idempotency_key: str,
+        *,
+        transport_max_bytes: int | None = None,
+        transport_snapshot_max_bytes: int | None = None,
+    ) -> dict:
         self._space()
+        checkpoint_limit = self.profile.max_checkpoint_bytes
+        snapshot_limit = self.profile.max_checkpoint_bytes
+        if transport_max_bytes is not None:
+            if type(transport_max_bytes) is not int or transport_max_bytes < 1024:
+                raise ContextFault("context_checkpoint_transport_limit")
+            checkpoint_limit = min(checkpoint_limit, transport_max_bytes)
+        if transport_snapshot_max_bytes is not None:
+            if (
+                type(transport_snapshot_max_bytes) is not int
+                or transport_snapshot_max_bytes < 1024
+            ):
+                raise ContextFault("context_checkpoint_transport_limit")
+            snapshot_limit = min(
+                snapshot_limit, transport_snapshot_max_bytes
+            )
         with self._transaction(capability) as db:
             cap, cycle = self._authorize(db, capability, "checkpoint")
             if cap.role not in {"coordinator", "verifier", "durability"}:
@@ -1042,9 +2737,30 @@ class ContextEngine:
                 cipher,
             )
             if replay:
+                if transport_max_bytes is not None:
+                    try:
+                        replay_pack = base64.b64decode(
+                            replay.get("pack", ""), validate=True
+                        )
+                    except (TypeError, ValueError) as exc:
+                        raise ContextFault("context_integrity_failure") from exc
+                    if (
+                        base64.b64encode(replay_pack).decode("ascii")
+                        != replay.get("pack")
+                    ):
+                        raise ContextFault("context_integrity_failure")
+                    if len(replay_pack) > checkpoint_limit:
+                        raise ContextFault("context_checkpoint_transport_limit")
                 return replay
             if cycle["state"] not in {"ACTIVE", "SEALING"}:
                 raise ContextFault("context_not_active")
+            if cycle["checkpoint_durability_mode"] not in {
+                "unregistered",
+                "local_ephemeral",
+                "remote_registered",
+            }:
+                raise ContextFault("context_integrity_failure")
+            self._verify_checkpoint_durability_registration(cycle)
             records: list[dict] = []
             previous = ZERO
             for row in db.execute(
@@ -1077,6 +2793,7 @@ class ContextEngine:
                 "request_key": cycle["request_key"],
                 "request_digest": cycle["request_digest"],
                 "fence": cycle["fence"],
+                "revision": cycle["revision"],
                 "checkpoint": cycle["checkpoint"] + 1,
                 "key_ref": cycle["key_ref"],
                 "key_provider": (
@@ -1086,11 +2803,18 @@ class ContextEngine:
                 ),
                 "key_version": cycle["key_version"],
                 "retention_class": cycle["retention_class"],
+                "checkpoint_durability_mode": cycle["checkpoint_durability_mode"],
+                "reservation_protocol_version": cycle["reservation_protocol_version"],
             }
+            if not cycle["checkpoint_durability_legacy"]:
+                snapshot["checkpoint_durability_command_digest"] = cycle[
+                    "checkpoint_durability_command_digest"
+                ]
+                snapshot["checkpoint_durability_receipt"] = json.loads(
+                    cycle["checkpoint_durability_receipt"]
+                )
             snapshot["state"] = cycle["state"]
             # Replays survive host replacement too, including immutable capsules.
-            import base64
-
             snapshot["operations"] = [
                 {**dict(row), "result": base64.b64encode(row["result"]).decode()}
                 for row in db.execute(
@@ -1098,9 +2822,11 @@ class ContextEngine:
                     (cycle["id"],),
                 )
             ]
-            if len(canonical(snapshot)) > self.profile.max_checkpoint_bytes:
+            if len(canonical(snapshot)) > snapshot_limit:
                 raise ContextFault("context_checkpoint_quota")
             pack = cipher.encrypt(snapshot, {"namespace": ns, "domain": "checkpoint/v1"})
+            if len(pack) > checkpoint_limit:
+                raise ContextFault("context_checkpoint_quota")
             checksum = hashlib.sha256(pack).hexdigest()
             number = cycle["checkpoint"] + 1
             receipt = self.signer.sign(
@@ -1146,17 +2872,43 @@ class ContextEngine:
                 cipher,
             )
 
-    def hydrate(self, signed_grant: dict, receipt: dict, pack: bytes, receipt_keys: dict) -> dict:
+    def hydrate(
+        self,
+        signed_grant: dict,
+        receipt: dict,
+        pack: bytes,
+        receipt_keys: dict,
+        *,
+        snapshot_max_bytes: int | None = None,
+    ) -> dict:
         """Host replacement needs a fresh fence and the exact cloud-selected root."""
+        hydrate_snapshot_limit = self.profile.max_checkpoint_bytes
+        if snapshot_max_bytes is not None:
+            if type(snapshot_max_bytes) is not int or snapshot_max_bytes < 1024:
+                raise ContextFault("context_checkpoint_transport_limit")
+            hydrate_snapshot_limit = min(
+                hydrate_snapshot_limit, snapshot_max_bytes
+            )
         grant = verify(signed_grant, self.authority_keys)
         legacy_grant = {"operation", "namespace", "manifest_checksum", "fence", "expires_at"}
         keyed_grant = legacy_grant | {"key_ref", "key_provider", "key_version"}
-        if frozenset(grant) not in {frozenset(legacy_grant), frozenset(keyed_grant)} or grant[
-            "operation"
-        ] != "hydrate":
+        hydrate_command_digest: str | None = None
+        expected_source_revision: str | None = None
+        if grant.get("schema_version") == "ContextHydrateCommandV2":
+            try:
+                command = ContextHydrateCommandV2.model_validate(grant)
+            except (TypeError, ValueError) as exc:
+                raise ContextFault("context_hydrate_grant_invalid") from exc
+            if grant != command.model_dump(mode="json"):
+                raise ContextFault("context_hydrate_grant_invalid")
+            grant = command.model_dump(mode="json")
+            hydrate_command_digest = digest(grant)
+            expected_source_revision = command.expected_source_revision
+        elif (
+            frozenset(grant) not in {frozenset(legacy_grant), frozenset(keyed_grant)}
+            or grant.get("operation") != "hydrate"
+        ):
             raise ContextFault("context_hydrate_grant_invalid")
-        if grant["expires_at"] <= self.now():
-            raise ContextFault("context_capability_denied")
         try:
             claim = ContextCheckpointReceiptV1.model_validate(
                 verify(receipt, receipt_keys)
@@ -1164,6 +2916,13 @@ class ContextEngine:
         except (ValueError, TypeError) as exc:
             raise ContextFault("context_checkpoint_receipt_invalid") from exc
         checksum = hashlib.sha256(pack).hexdigest()
+        hydrate_request_digest = digest(
+            {
+                "grant": signed_grant,
+                "checkpoint_receipt": receipt,
+                "manifest_checksum": checksum,
+            }
+        )
         if (
             claim.get("schema_version") != "ContextCheckpointReceiptV1"
             or checksum != grant["manifest_checksum"]
@@ -1172,12 +2931,25 @@ class ContextEngine:
             or len(pack) > self.profile.max_checkpoint_bytes
         ):
             raise ContextFault("context_integrity_failure")
+        if hydrate_command_digest is None:
+            legacy_now = self.now()
+            if (
+                type(grant.get("expires_at")) is not int
+                or not legacy_now < grant["expires_at"] <= legacy_now + 900
+            ):
+                raise ContextFault("context_capability_denied")
         key_ref = claim.get("key_ref")
         key_provider = claim.get("key_provider")
         key_version = claim.get("key_version")
+        if hydrate_command_digest is not None and (
+            grant.get("key_ref") != key_ref
+            or grant.get("key_provider") != key_provider
+            or grant.get("key_version") != key_version
+        ):
+            raise ContextFault("context_hydrate_grant_invalid")
         if key_ref is None:
             if (
-                set(grant) != legacy_grant
+                (hydrate_command_digest is None and set(grant) != legacy_grant)
                 or key_provider is not None
                 or key_version is not None
             ):
@@ -1185,7 +2957,7 @@ class ContextEngine:
             cipher = self.cipher
         else:
             if (
-                set(grant) != keyed_grant
+                (hydrate_command_digest is None and set(grant) != keyed_grant)
                 or grant["key_ref"] != key_ref
                 or grant["key_provider"] != key_provider
                 or grant["key_version"] != key_version
@@ -1204,10 +2976,17 @@ class ContextEngine:
         snapshot = cipher.decrypt(
             pack,
             {"namespace": grant["namespace"], "domain": "checkpoint/v1"},
-            self.profile.max_checkpoint_bytes,
+            hydrate_snapshot_limit,
         )
         binding_payload = snapshot["binding"]
         binding = ContextBindingV1.model_validate(binding_payload)
+        hydrated_revision = snapshot.get("revision", 1)
+        reservation_protocol_version = snapshot.get(
+            "reservation_protocol_version", 1
+        )
+        checkpoint_durability_mode = snapshot.get(
+            "checkpoint_durability_mode", "remote_registered"
+        )
         if (
             binding.namespace.model_dump() != grant["namespace"]
             or binding.profile_digest != digest(self.profile)
@@ -1219,8 +2998,27 @@ class ContextEngine:
             or snapshot.get("key_ref") != key_ref
             or snapshot.get("key_provider") != key_provider
             or snapshot.get("key_version") != key_version
+            or type(hydrated_revision) is not int
+            or hydrated_revision < 1
+            or type(reservation_protocol_version) is not int
+            or reservation_protocol_version not in {1, 2, 3}
+            or checkpoint_durability_mode not in {"local_ephemeral", "remote_registered"}
         ):
             raise ContextFault("context_hydrate_grant_invalid")
+        if checkpoint_durability_mode != "remote_registered":
+            raise ContextFault("context_hydrate_durability_denied")
+        (
+            durability_command_digest,
+            restored_durability_receipt,
+            durability_legacy,
+            source_durability_receipt_digest,
+        ) = self._restore_checkpoint_durability_registration(
+            snapshot,
+            grant["namespace"],
+            checkpoint_durability_mode,
+            receipt_keys,
+            hydrated_revision,
+        )
         if (
             snapshot["state"] not in {"ACTIVE", "SEALING"}
             or digest(snapshot["authority"]) != binding.authorization_digest
@@ -1244,7 +3042,7 @@ class ContextEngine:
         if previous != snapshot["root"]:
             raise ContextFault("context_chain_corrupt")
         ns, cycle = grant["namespace"], binding.namespace.context_cycle_id
-        hydrate_payload = ContextHydrateReceiptV1(
+        hydrate_fields = dict(
             namespace=binding.namespace,
             context_cycle_id=cycle,
             manifest_checksum=checksum,
@@ -1256,29 +3054,124 @@ class ContextEngine:
             key_version=key_version,
             replay_digest=digest(snapshot["operations"]),
             fence=grant["fence"],
-        ).model_dump()
-        import base64
+        )
+        def hydrate_result_payload(durability_receipt: dict | None) -> dict:
+            if hydrate_command_digest is not None:
+                if expected_source_revision is None:
+                    raise ContextFault("context_hydrate_source_mismatch")
+                return ContextHydrateReceiptV2(
+                    **hydrate_fields,
+                    hydrate_command_digest=hydrate_command_digest,
+                    expected_source_revision=expected_source_revision,
+                    checkpoint_durability_registration_receipt=(
+                        SignedV1.model_validate(durability_receipt)
+                        if durability_receipt is not None
+                        else None
+                    ),
+                    checkpoint_durability_registration_receipt_digest=(
+                        digest(durability_receipt)
+                        if durability_receipt is not None
+                        else None
+                    ),
+                ).model_dump(mode="json")
+            return ContextHydrateReceiptV1(**hydrate_fields).model_dump(
+                mode="json"
+            )
+
+        hydrate_payload = hydrate_result_payload(restored_durability_receipt)
 
         with self.store.transaction() as db:
             existing = db.execute("SELECT * FROM cycles WHERE id=?", (cycle,)).fetchone()
             if existing:
-                if (
-                    existing["root"] == previous
-                    and existing["fence"] == grant["fence"]
-                    and existing["checkpoint_manifest_checksum"] == checksum
-                    and existing["checkpoint"] == claim["checkpoint_number"]
-                    and existing["cursor"] == claim["cursor"]
-                    and existing["key_ref"] == key_ref
-                    and existing["key_version"] == key_version
-                    and existing["binding_digest"] == digest(binding_payload)
-                ):
-                    return self.signer.sign(hydrate_payload)
+                try:
+                    exact_replay = self._hydrate_replay_exact(
+                        db,
+                        existing,
+                        snapshot,
+                        ns,
+                        cipher,
+                        checksum=checksum,
+                        fence=grant["fence"],
+                        binding_digest=digest(binding_payload),
+                        durability_mode=checkpoint_durability_mode,
+                        revision=hydrated_revision,
+                        reservation_protocol_version=(
+                            reservation_protocol_version
+                        ),
+                        durability_command_digest=durability_command_digest,
+                        durability_legacy=durability_legacy,
+                        source_durability_receipt_digest=(
+                            source_durability_receipt_digest
+                        ),
+                        hydrate_command_digest=hydrate_command_digest,
+                        hydrate_request_digest=hydrate_request_digest,
+                    )
+                except (ContextFault, TypeError, ValueError):
+                    exact_replay = False
+                if exact_replay:
+                    if hydrate_command_digest is not None:
+                        try:
+                            persisted_result = json.loads(existing["hydrate_receipt"])
+                            persisted_payload = verify(
+                                persisted_result,
+                                {self.signer.key_id: self.signer.key.public_key()},
+                            )
+                            persisted_claim = ContextHydrateReceiptV2.model_validate(
+                                persisted_payload
+                            )
+                        except (ContextFault, TypeError, ValueError) as exc:
+                            raise ContextFault("context_integrity_failure") from exc
+                        if (
+                            persisted_payload
+                            != persisted_claim.model_dump(mode="json")
+                            or persisted_payload
+                            != hydrate_result_payload(
+                                json.loads(
+                                    existing["checkpoint_durability_receipt"]
+                                )
+                                if not durability_legacy
+                                else None
+                            )
+                        ):
+                            raise ContextFault("context_integrity_failure")
+                        return persisted_result
+                    replay_durability_receipt = (
+                        None
+                        if durability_legacy
+                        else json.loads(existing["checkpoint_durability_receipt"])
+                    )
+                    return self.signer.sign(
+                        hydrate_result_payload(replay_durability_receipt)
+                    )
                 raise ContextFault("context_hydrate_conflict")
+            now = self.now()
+            if (
+                hydrate_command_digest is not None
+                and (
+                    type(grant.get("expires_at")) is not int
+                    or not grant["issued_at"] <= now < grant["expires_at"] <= now + 900
+                )
+            ):
+                raise ContextFault("context_capability_denied")
+            if hydrate_command_digest is not None:
+                runtime_health = self.health_v2()
+                if (
+                    not runtime_health["runtime_build_ready"]
+                    or expected_source_revision
+                    != self.build_qualification.source_revision
+                ):
+                    raise ContextFault("context_hydrate_source_mismatch")
+            hydrate_result = self.signer.sign(hydrate_payload)
             db.execute(
-                "INSERT INTO cycles(id,owner,project,request_key,request_digest,profile,state,fence,"
+                "INSERT INTO cycles(id,owner,project,request_key,request_digest,profile,state,"
+                "revision,fence,"
                 "binding,binding_digest,authority,snapshot,cursor,root,bytes,expires,checkpoint,"
-                "key_ref,key_version,retention_class,checkpoint_manifest_checksum) "
-                "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                "key_ref,key_version,retention_class,checkpoint_manifest_checksum,"
+                "checkpoint_durability_mode,checkpoint_durability_legacy,"
+                "checkpoint_durability_command_digest,checkpoint_durability_receipt,"
+                "hydrate_command_digest,hydrate_request_digest,hydrate_receipt,"
+                "reservation_protocol_version) "
+                "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     cycle,
                     ns["owner_id"],
@@ -1287,6 +3180,7 @@ class ContextEngine:
                     snapshot["request_digest"],
                     digest(self.profile),
                     snapshot["state"],
+                    hydrated_revision,
                     grant["fence"],
                     canonical(binding_payload).decode(),
                     digest(binding_payload),
@@ -1303,6 +3197,22 @@ class ContextEngine:
                     key_version,
                     snapshot.get("retention_class", binding.retention_class),
                     checksum,
+                    checkpoint_durability_mode,
+                    durability_legacy,
+                    durability_command_digest,
+                    (
+                        canonical(restored_durability_receipt).decode()
+                        if restored_durability_receipt is not None
+                        else None
+                    ),
+                    hydrate_command_digest,
+                    hydrate_request_digest if hydrate_command_digest is not None else None,
+                    (
+                        canonical(hydrate_result).decode()
+                        if hydrate_command_digest is not None
+                        else None
+                    ),
+                    reservation_protocol_version,
                 ),
             )
             for record in records:
@@ -1353,7 +3263,132 @@ class ContextEngine:
                     ),
                 )
             self._event(db, cycle, "context.recovered", root=previous, fence=grant["fence"])
-            return self.signer.sign(hydrate_payload)
+            return hydrate_result
+
+    def _hydrate_replay_exact(
+        self,
+        db: sqlite3.Connection,
+        row: sqlite3.Row,
+        snapshot: dict,
+        namespace: dict,
+        cipher: EnvelopeCipher,
+        *,
+        checksum: str,
+        fence: int,
+        binding_digest: str,
+        durability_mode: str,
+        revision: int,
+        reservation_protocol_version: int,
+        durability_command_digest: str | None,
+        durability_legacy: int,
+        source_durability_receipt_digest: str | None,
+        hydrate_command_digest: str | None,
+        hydrate_request_digest: str,
+    ) -> bool:
+        records = snapshot["records"]
+        if (
+            row["owner"] != namespace["owner_id"]
+            or row["project"] != namespace["project_id"]
+            or row["request_key"] != snapshot["request_key"]
+            or row["request_digest"] != snapshot["request_digest"]
+            or row["profile"] != digest(self.profile)
+            or row["state"] != snapshot["state"]
+            or row["state"] not in {"ACTIVE", "SEALING"}
+            or row["revision"] != revision
+            or row["reservation_protocol_version"]
+            != reservation_protocol_version
+            or row["fence"] != fence
+            or row["binding_digest"] != binding_digest
+            or row["cursor"] != snapshot["cursor"]
+            or row["root"] != snapshot["root"]
+            or row["bytes"] != sum(len(item["text"].encode()) for item in records)
+            or row["expires"] != json.loads(row["binding"])["expires_at"]
+            or row["checkpoint"] != snapshot["checkpoint"]
+            or row["key_ref"] != snapshot.get("key_ref")
+            or row["key_version"] != snapshot.get("key_version")
+            or row["retention_class"]
+            != snapshot.get("retention_class", "ephemeral")
+            or row["checkpoint_manifest_checksum"] != checksum
+            or row["checkpoint_durability_mode"] != durability_mode
+            or row["checkpoint_durability_legacy"] != durability_legacy
+            or row["checkpoint_durability_command_digest"]
+            != durability_command_digest
+        ):
+            return False
+        if hydrate_command_digest is not None:
+            if (
+                row["hydrate_command_digest"] != hydrate_command_digest
+                or row["hydrate_request_digest"] != hydrate_request_digest
+                or row["hydrate_receipt"] is None
+            ):
+                return False
+        if durability_legacy:
+            if row["checkpoint_durability_receipt"] is not None:
+                return False
+        else:
+            try:
+                stored_envelope = json.loads(row["checkpoint_durability_receipt"])
+                stored_receipt, _ = self._validated_durability_receipt(
+                    stored_envelope,
+                    {self.signer.key_id: self.signer.key.public_key()},
+                )
+            except (ContextFault, TypeError, ValueError):
+                return False
+            if (
+                not isinstance(stored_receipt, ContextCheckpointDurabilityReceiptV2)
+                or stored_receipt.source_registration_receipt_digest
+                != source_durability_receipt_digest
+            ):
+                return False
+        if (
+            cipher.decrypt(row["authority"], namespace, self.profile.max_record_bytes)
+            != snapshot["authority"]
+            or self._snapshot(row, namespace) != snapshot["project_snapshot"]
+        ):
+            return False
+        stored_records = db.execute(
+            "SELECT * FROM segments WHERE cycle=? ORDER BY seq", (row["id"],)
+        ).fetchall()
+        if len(stored_records) != len(records):
+            return False
+        expected_postings: set[tuple[str, int]] = set()
+        for stored, expected in zip(stored_records, records):
+            readback = self._record(stored, namespace, cipher)
+            if (
+                readback["metadata"] != expected["metadata"]
+                or readback["text"] != expected["text"]
+                or stored["root"] != expected["root"]
+                or stored["superseded"] != expected["superseded"]
+                or stored["quarantined"] != expected["quarantined"]
+            ):
+                return False
+            expected_postings.update(
+                (cipher.token(namespace, word), stored["seq"])
+                for word in words(expected["text"])
+            )
+        stored_postings = {
+            (item["term"], item["seq"])
+            for item in db.execute(
+                "SELECT term,seq FROM postings WHERE cycle=?", (row["id"],)
+            )
+        }
+        if stored_postings != expected_postings:
+            return False
+        stored_operations = [
+            {
+                **dict(item),
+                "result": base64.b64encode(item["result"]).decode(),
+            }
+            for item in db.execute(
+                "SELECT * FROM operations WHERE cycle=? AND operation!='checkpoint' "
+                "ORDER BY operation,key",
+                (row["id"],),
+            )
+        ]
+        expected_operations = sorted(
+            snapshot["operations"], key=lambda item: (item["operation"], item["key"])
+        )
+        return stored_operations == expected_operations
 
     def _promotion_entry(self, row, namespace: dict, cipher: EnvelopeCipher) -> dict | None:
         metadata = self._record(row, namespace, cipher)["metadata"]
@@ -1537,15 +3572,24 @@ class ContextEngine:
                 or row["revision"] != command["expected_revision"]
             ):
                 raise ContextFault("context_stale_state")
+            if (
+                row["binding"] is None
+                or row["binding_digest"] is None
+                or row["state"] == "RESERVED"
+            ):
+                raise ContextFault("context_transition_denied")
             transitions = {
                 "degrade": ({"ACTIVE"}, "DEGRADED"),
                 "recover": ({"DEGRADED"}, "ACTIVE"),
-                "abort": ({"RESERVED", "BOUND", "ACTIVE", "DEGRADED"}, "ABORTED"),
+                "abort": ({"BOUND", "ACTIVE", "DEGRADED"}, "ABORTED"),
                 "quarantine": ({"ACTIVE", "DEGRADED", "SEALING"}, "QUARANTINED"),
             }
             op = command["operation"]
             if op == "fence":
-                if command["fence"] <= row["fence"] or row["state"] in TERMINAL:
+                if (
+                    command["fence"] <= row["fence"]
+                    or row["state"] not in {"BOUND", "ACTIVE", "DEGRADED", "SEALING"}
+                ):
                     raise ContextFault("context_stale_fence")
                 db.execute(
                     "UPDATE cycles SET fence=?,revision=revision+1 WHERE id=?",
@@ -1576,7 +3620,8 @@ class ContextEngine:
     def status(self, capability: dict, after: int = 0) -> dict:
         if type(after) is not int or after < 0:
             raise ContextFault("context_stale_cursor")
-        reach_claim_enabled = self.health()["reach_claim_enabled"]
+        self._space()
+        reach_claim_enabled = self._hot_reach_claim_enabled
         with self.store.connection() as db:
             _, row = self._authorize(db, capability, "status")
             events = [

--- a/aether_context/guard.py
+++ b/aether_context/guard.py
@@ -1,0 +1,554 @@
+"""Stdlib-only pre-import guard for the production context daemon."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import json
+import platform
+import re
+import sqlite3
+import stat
+import sys
+import sysconfig
+from email.parser import Parser
+from pathlib import Path, PurePosixPath
+
+
+_IMPORT_ROOTS = {
+    "aether-context": ("aether_context",),
+    "annotated-types": ("annotated_types",),
+    "bcrypt": ("bcrypt",),
+    "cffi": ("cffi", "_cffi_backend"),
+    "cryptography": ("cryptography",),
+    "numpy": ("numpy",),
+    "pydantic": ("pydantic",),
+    "pydantic_core": ("pydantic_core",),
+    "pycparser": ("pycparser",),
+    "typing-inspection": ("typing_inspection",),
+    "typing_extensions": ("typing_extensions",),
+}
+_REQUIRED_DEPENDENCY_CLOSURE = {
+    "annotated-types",
+    "cffi",
+    "cryptography",
+    "numpy",
+    "pydantic",
+    "pydantic_core",
+    "pycparser",
+    "typing-inspection",
+    "typing_extensions",
+}
+_OPTIONAL_IMPORT_DISTRIBUTIONS = {"bcrypt"}
+_IMPORTABLE_SUFFIXES = {".py", ".pyc", ".pyo", ".so", ".pyd", ".dll", ".dylib"}
+_IDENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,199}$")
+_ED25519_Q = 2**255 - 19
+_ED25519_L = 2**252 + 27742317777372353535851937790883648493
+_ED25519_D = (-121665 * pow(121666, _ED25519_Q - 2, _ED25519_Q)) % _ED25519_Q
+_ED25519_I = pow(2, (_ED25519_Q - 1) // 4, _ED25519_Q)
+_ED25519_IDENTITY = (0, 1, 1, 0)
+
+
+class GuardFailure(RuntimeError):
+    pass
+
+
+def _canonical(value: object) -> bytes:
+    def validate(item: object) -> None:
+        if item is None or isinstance(item, (bool, str)):
+            return
+        if isinstance(item, int) and abs(item) <= 9007199254740991:
+            return
+        if isinstance(item, list):
+            for child in item:
+                validate(child)
+            return
+        if isinstance(item, dict) and all(
+            isinstance(key, str) and key.isascii() for key in item
+        ):
+            for child in item.values():
+                validate(child)
+            return
+        raise GuardFailure("context_guard_manifest_invalid")
+
+    validate(value)
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode()
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _normalized(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def _immutable(path: Path, *, owner_uid: int) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise GuardFailure("context_guard_path_unavailable") from exc
+    if path.is_symlink() or info.st_uid != owner_uid or stat.S_IMODE(info.st_mode) & 0o022:
+        raise GuardFailure("context_guard_path_mutable")
+
+
+def _secure_path(
+    raw: str | Path, *, owner_uid: int, trust_root: str | Path = "/"
+) -> Path:
+    """Resolve a path only after every existing component passes lstat policy."""
+
+    path = Path(raw).absolute()
+    root = Path(trust_root).absolute()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise GuardFailure("context_guard_path_outside_root") from exc
+    chain = [path]
+    while chain[-1] != root:
+        parent = chain[-1].parent
+        if parent == chain[-1]:
+            raise GuardFailure("context_guard_path_outside_root")
+        chain.append(parent)
+    for component in reversed(chain):
+        _immutable(component, owner_uid=owner_uid)
+    return path.resolve(strict=True)
+
+
+def _json_no_duplicates(raw: str) -> object:
+    def closed_object(pairs):
+        value = {}
+        for key, item in pairs:
+            if key in value:
+                raise GuardFailure("context_guard_manifest_invalid")
+            value[key] = item
+        return value
+
+    try:
+        return json.loads(raw, object_pairs_hook=closed_object)
+    except (TypeError, ValueError) as exc:
+        raise GuardFailure("context_guard_manifest_invalid") from exc
+
+
+def _edwards_add(first, second):
+    x1, y1, z1, t1 = first
+    x2, y2, z2, t2 = second
+    a = ((y1 - x1) * (y2 - x2)) % _ED25519_Q
+    b = ((y1 + x1) * (y2 + x2)) % _ED25519_Q
+    c = (2 * _ED25519_D * t1 * t2) % _ED25519_Q
+    d = (2 * z1 * z2) % _ED25519_Q
+    e, f, g, h = b - a, d - c, d + c, b + a
+    return (
+        (e * f) % _ED25519_Q,
+        (g * h) % _ED25519_Q,
+        (f * g) % _ED25519_Q,
+        (e * h) % _ED25519_Q,
+    )
+
+
+def _edwards_multiply(point, scalar: int):
+    result = _ED25519_IDENTITY
+    addend = point
+    while scalar:
+        if scalar & 1:
+            result = _edwards_add(result, addend)
+        addend = _edwards_add(addend, addend)
+        scalar >>= 1
+    return result
+
+
+def _recover_x(y: int) -> int:
+    yy = y * y % _ED25519_Q
+    xx = (yy - 1) * pow(_ED25519_D * yy + 1, _ED25519_Q - 2, _ED25519_Q)
+    x = pow(xx, (_ED25519_Q + 3) // 8, _ED25519_Q)
+    if (x * x - xx) % _ED25519_Q:
+        x = x * _ED25519_I % _ED25519_Q
+    if (x * x - xx) % _ED25519_Q:
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    return x
+
+
+def _decode_ed25519_point(raw: bytes):
+    if len(raw) != 32:
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    encoded = int.from_bytes(raw, "little")
+    sign = encoded >> 255
+    y = encoded & ((1 << 255) - 1)
+    if y >= _ED25519_Q:
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    x = _recover_x(y)
+    if (x & 1) != sign:
+        x = _ED25519_Q - x
+    if x == 0 and sign:
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    if (-x * x + y * y - 1 - _ED25519_D * x * x * y * y) % _ED25519_Q:
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    return (x, y, 1, x * y % _ED25519_Q)
+
+
+def _same_point(first, second) -> bool:
+    return (
+        (first[0] * second[2] - second[0] * first[2]) % _ED25519_Q == 0
+        and (first[1] * second[2] - second[1] * first[2]) % _ED25519_Q == 0
+    )
+
+
+_ED25519_BASE = _decode_ed25519_point(
+    bytes.fromhex("5866666666666666666666666666666666666666666666666666666666666666")
+)
+
+
+def _verify_ed25519(public_key: bytes, signature: bytes, message: bytes) -> None:
+    if len(public_key) != 32 or len(signature) != 64:
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    public_point = _decode_ed25519_point(public_key)
+    encoded_r, encoded_s = signature[:32], signature[32:]
+    r_point = _decode_ed25519_point(encoded_r)
+    scalar = int.from_bytes(encoded_s, "little")
+    if scalar >= _ED25519_L or _same_point(public_point, _ED25519_IDENTITY):
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    if not _same_point(
+        _edwards_multiply(public_point, _ED25519_L), _ED25519_IDENTITY
+    ) or not _same_point(
+        _edwards_multiply(r_point, _ED25519_L), _ED25519_IDENTITY
+    ):
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    challenge = int.from_bytes(
+        hashlib.sha512(encoded_r + public_key + message).digest(), "little"
+    ) % _ED25519_L
+    if not _same_point(
+        _edwards_multiply(_ED25519_BASE, scalar),
+        _edwards_add(r_point, _edwards_multiply(public_point, challenge)),
+    ):
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+
+
+def _verified_manifest_payload(manifest_file: Path, key_file: Path) -> dict:
+    if manifest_file.stat().st_size > 4_000_000 or key_file.stat().st_size > 64_000:
+        raise GuardFailure("context_guard_manifest_invalid")
+    envelope = _json_no_duplicates(manifest_file.read_text(encoding="utf-8"))
+    keys = _json_no_duplicates(key_file.read_text(encoding="utf-8"))
+    if (
+        not isinstance(envelope, dict)
+        or set(envelope) != {"payload", "key_id", "signature"}
+        or not isinstance(envelope.get("payload"), dict)
+        or not isinstance(envelope.get("key_id"), str)
+        or _IDENT.fullmatch(envelope["key_id"]) is None
+        or not isinstance(envelope.get("signature"), str)
+        or not isinstance(keys, dict)
+        or not keys
+        or len(keys) > 32
+        or any(
+            not isinstance(key_id, str)
+            or _IDENT.fullmatch(key_id) is None
+            or not isinstance(value, str)
+            for key_id, value in keys.items()
+        )
+        or envelope["key_id"] not in keys
+    ):
+        raise GuardFailure("context_guard_manifest_invalid")
+    try:
+        public_key = base64.b64decode(keys[envelope["key_id"]], validate=True)
+        signature = base64.b64decode(envelope["signature"], validate=True)
+    except (ValueError, TypeError) as exc:
+        raise GuardFailure("context_guard_manifest_signature_invalid") from exc
+    if (
+        base64.b64encode(public_key).decode("ascii") != keys[envelope["key_id"]]
+        or base64.b64encode(signature).decode("ascii") != envelope["signature"]
+    ):
+        raise GuardFailure("context_guard_manifest_signature_invalid")
+    _verify_ed25519(
+        public_key,
+        signature,
+        _canonical({"key_id": envelope["key_id"], "payload": envelope["payload"]}),
+    )
+    return envelope["payload"]
+
+
+def _distribution(site: Path, name: str, *, owner_uid: int):
+    matches = []
+    for metadata_dir in site.glob("*.dist-info"):
+        metadata_path = metadata_dir / "METADATA"
+        try:
+            _immutable(metadata_dir, owner_uid=owner_uid)
+            _immutable(metadata_path, owner_uid=owner_uid)
+            metadata = Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if _normalized(metadata.get("Name", "")) == _normalized(name):
+            matches.append((metadata_dir, metadata))
+    if len(matches) != 1:
+        raise GuardFailure("context_guard_distribution_ambiguous")
+    metadata_dir, metadata = matches[0]
+    _immutable(metadata_dir, owner_uid=owner_uid)
+    record_path = metadata_dir / "RECORD"
+    _immutable(record_path, owner_uid=owner_uid)
+    records: dict[str, str | None] = {}
+    try:
+        with record_path.open(newline="", encoding="utf-8") as stream:
+            for row in csv.reader(stream):
+                if len(row) != 3 or row[0] in records:
+                    raise GuardFailure("context_guard_record_invalid")
+                records[row[0].replace("\\", "/")] = row[1] or None
+    except OSError as exc:
+        raise GuardFailure("context_guard_record_invalid") from exc
+    return metadata, records
+
+
+def _record_artifact_digest(
+    site: Path, records: dict[str, str | None], *, owner_uid: int
+) -> str:
+    entries = []
+    for relative in sorted(records):
+        record_path = PurePosixPath(relative)
+        if record_path.is_absolute() or not record_path.parts:
+            raise GuardFailure("context_guard_record_invalid")
+        path = site
+        for part in record_path.parts:
+            if part == ".":
+                continue
+            path = path.parent if part == ".." else path / part
+            _immutable(path, owner_uid=owner_uid)
+        path = path.resolve(strict=True)
+        venv = Path(sys.executable).absolute().parent.parent
+        try:
+            path.relative_to(venv)
+        except ValueError as exc:
+            raise GuardFailure("context_guard_record_invalid") from exc
+        if not path.is_file():
+            raise GuardFailure("context_guard_record_invalid")
+        sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+        recorded = records[relative]
+        if recorded is not None:
+            try:
+                algorithm, expected = recorded.split("=", 1)
+                observed = base64.urlsafe_b64encode(
+                    hashlib.new(algorithm, path.read_bytes()).digest()
+                ).rstrip(b"=").decode()
+            except (ValueError, OSError) as exc:
+                raise GuardFailure("context_guard_record_invalid") from exc
+            if observed != expected:
+                raise GuardFailure("context_guard_record_mismatch")
+        entries.append({"path": relative, "sha256": sha256})
+    return _digest(entries)
+
+
+def _audit_site_import_surface(site: Path, closure: list[str], *, owner_uid: int) -> None:
+    """Reject executable top-level paths outside the signed runtime closure."""
+
+    allowed_roots = {
+        root
+        for distribution in ("aether-context", *closure)
+        for root in _IMPORT_ROOTS[distribution]
+    }
+    for path in site.iterdir():
+        _immutable(path, owner_uid=owner_uid)
+        name = path.name
+        if name == "__pycache__" or path.suffix.lower() in {".pyc", ".pyo", ".pth"}:
+            raise GuardFailure("context_guard_unlocked_import_artifact")
+        if path.is_dir():
+            if name.isidentifier() and name not in allowed_roots:
+                raise GuardFailure("context_guard_unlocked_import_artifact")
+            continue
+        root = name.split(".", 1)[0]
+        if (
+            path.suffix.lower() in _IMPORTABLE_SUFFIXES
+            and root.isidentifier()
+            and root not in allowed_roots
+        ):
+            raise GuardFailure("context_guard_unlocked_import_artifact")
+
+
+def _import_paths(site: Path, distribution: str) -> list[Path]:
+    roots = _IMPORT_ROOTS.get(distribution)
+    if roots is None:
+        raise GuardFailure("context_guard_import_closure_unknown")
+    values: list[Path] = []
+    for root in roots:
+        candidates = [site / root, *sorted(site.glob(root + ".*"))]
+        values.extend(
+            item
+            for item in candidates
+            if item.is_dir()
+            or (item.is_file() and item.suffix.lower() in _IMPORTABLE_SUFFIXES)
+        )
+    if not values:
+        raise GuardFailure("context_guard_import_root_missing")
+    return values
+
+
+def _audit_import_roots(
+    site: Path,
+    distribution: str,
+    records: dict[str, str | None],
+    *,
+    owner_uid: int,
+) -> None:
+    roots = _import_paths(site, distribution)
+    if distribution == "aether-context":
+        expected = site / "aether_context"
+        if roots != [expected] or not expected.is_dir():
+            raise GuardFailure("context_guard_package_import_collision")
+    for root in roots:
+        candidates = [root] if root.is_file() else [root, *root.rglob("*")]
+        for path in candidates:
+            _immutable(path, owner_uid=owner_uid)
+            if path.is_dir():
+                if path.name == "__pycache__":
+                    raise GuardFailure("context_guard_bytecode_present")
+                continue
+            relative = path.relative_to(site).as_posix()
+            if path.suffix.lower() in {".pyc", ".pyo"}:
+                raise GuardFailure("context_guard_bytecode_present")
+            if distribution == "aether-context" and path.suffix.lower() in {
+                ".so",
+                ".pyd",
+                ".dll",
+                ".dylib",
+            }:
+                raise GuardFailure("context_guard_package_import_collision")
+            if relative not in records:
+                raise GuardFailure("context_guard_untracked_import_artifact")
+            if path.suffix.lower() in {".so", ".pyd", ".dll", ".dylib"} and not records[
+                relative
+            ]:
+                raise GuardFailure("context_guard_unpinned_native_artifact")
+
+
+def verify_environment(
+    site_packages: str | Path,
+    manifest_path: str | Path,
+    manifest_keys_path: str | Path,
+    *,
+    owner_uid: int = 0,
+    trust_root: str | Path = "/",
+) -> None:
+    site = _secure_path(
+        site_packages, owner_uid=owner_uid, trust_root=trust_root
+    )
+    manifest_file = _secure_path(
+        manifest_path, owner_uid=owner_uid, trust_root=trust_root
+    )
+    key_file = _secure_path(
+        manifest_keys_path, owner_uid=owner_uid, trust_root=trust_root
+    )
+    _secure_path(sys.executable, owner_uid=owner_uid, trust_root=trust_root)
+    try:
+        payload = _verified_manifest_payload(manifest_file, key_file)
+        environment = payload["runtime_environment"]
+        closure = environment["dependency_import_closure"]
+    except (OSError, ValueError, KeyError, TypeError, GuardFailure) as exc:
+        if isinstance(exc, GuardFailure):
+            raise
+        raise GuardFailure("context_guard_manifest_invalid") from exc
+    if (
+        payload.get("schema_version") != "ContextRuntimeBuildManifestV3"
+        or environment.get("schema_version") != "ContextRuntimeEnvironmentV2"
+        or not _REQUIRED_DEPENDENCY_CLOSURE.issubset(set(closure))
+        or not set(closure).issubset(set(_IMPORT_ROOTS) - {"aether-context"})
+        or closure != sorted(set(closure))
+        or set(environment.get("dependency_versions", {})) != set(closure)
+        or set(environment.get("dependency_artifact_digests", {})) != set(closure)
+    ):
+        raise GuardFailure("context_guard_manifest_invalid")
+    _audit_site_import_surface(site, closure, owner_uid=owner_uid)
+    for optional in _OPTIONAL_IMPORT_DISTRIBUTIONS - set(closure):
+        if any(
+            candidate.exists()
+            for root in _IMPORT_ROOTS[optional]
+            for candidate in (site / root, *site.glob(root + ".*"))
+        ):
+            raise GuardFailure("context_guard_unlocked_optional_import")
+    artifacts = {}
+    versions = {}
+    for name in ("aether-context", *closure):
+        metadata, records = _distribution(site, name, owner_uid=owner_uid)
+        _audit_import_roots(site, name, records, owner_uid=owner_uid)
+        artifact_digest = _record_artifact_digest(site, records, owner_uid=owner_uid)
+        if name != "aether-context":
+            versions[name] = metadata.get("Version")
+            artifacts[name] = artifact_digest
+    package_root = (site / "aether_context").resolve(strict=True)
+    package_entries = []
+    for path in sorted(package_root.rglob("*")):
+        if path.is_dir():
+            continue
+        if path.suffix in {".py", ".json", ".typed"}:
+            package_entries.append(
+                {
+                    "path": path.relative_to(package_root).as_posix(),
+                    "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                }
+            )
+    abi = sysconfig.get_config_var("SOABI") or getattr(
+        sys.implementation, "cache_tag", None
+    )
+    observed_environment = {
+        "schema_version": "ContextRuntimeEnvironmentV2",
+        "python_implementation": sys.implementation.name,
+        "python_version": platform.python_version(),
+        "python_abi": abi,
+        "python_executable_digest": hashlib.sha256(
+            Path(sys.executable).resolve(strict=True).read_bytes()
+        ).hexdigest(),
+        "dependency_import_closure": closure,
+        "dependency_versions": versions,
+        "dependency_artifact_digests": artifacts,
+        "sqlite_version": sqlite3.sqlite_version,
+        "package_import_root_digest": _digest(str(package_root.parent)),
+        "bytecode_policy": "preimport-guard/source-only/v2",
+    }
+    if (
+        payload.get("package_tree_digest") != _digest(package_entries)
+        or environment != observed_environment
+        or payload.get("locked_environment_digest") != _digest(observed_environment)
+    ):
+        raise GuardFailure("context_guard_runtime_mismatch")
+
+
+def _site_packages() -> Path:
+    guard = Path(__file__).absolute()
+    if guard.parent.name != "aether_context":
+        raise GuardFailure("context_guard_site_packages_ambiguous")
+    return guard.parent.parent
+
+
+def _argument(name: str) -> str:
+    try:
+        index = sys.argv.index(name)
+        value = sys.argv[index + 1]
+    except (ValueError, IndexError):
+        raise GuardFailure("context_guard_argument_required") from None
+    if not value or value.startswith("--"):
+        raise GuardFailure("context_guard_argument_required")
+    return value
+
+
+def main() -> None:
+    if not sys.flags.isolated or not sys.flags.no_site or not sys.dont_write_bytecode:
+        raise SystemExit("context_guard_flags_required")
+    try:
+        site = _site_packages()
+        credentials = Path(_argument("--credentials"))
+        manifest_path = _argument("--runtime-build-manifest")
+        verify_environment(
+            site,
+            manifest_path,
+            credentials / "context-runtime-build-keys.json",
+        )
+    except GuardFailure as exc:
+        raise SystemExit(str(exc)) from None
+    sys.path.append(str(site.resolve(strict=True)))
+    from aether_context.service import main as service_main
+
+    service_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/aether_context/retention.py
+++ b/aether_context/retention.py
@@ -15,6 +15,9 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .contracts import (
+    ContextDeletionReceiptV1,
+    ContextDeletionReceiptV2,
+    ContextRetentionReceiptV1,
     KeyDestructionReceiptV1,
     RemoteDeletionReceiptV1,
     RetentionCommandV1,
@@ -225,6 +228,202 @@ class RetentionManager:
                 )
             ]
 
+    def _deletion_replay(
+        self,
+        db,
+        row,
+        command: RetentionCommandV1,
+        request_digest: str,
+        stored_result: str,
+    ) -> dict:
+        try:
+            envelope = json.loads(stored_result)
+            payload = verify(
+                envelope,
+                {self.engine.signer.key_id: self.engine.signer.key.public_key()},
+            )
+            if payload.get("schema_version") == "ContextDeletionReceiptV2":
+                receipt: ContextDeletionReceiptV1 | ContextDeletionReceiptV2 = (
+                    ContextDeletionReceiptV2.model_validate(payload)
+                )
+            else:
+                receipt = ContextDeletionReceiptV1.model_validate(payload)
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        operation = db.execute(
+            "SELECT request_digest,result FROM retention_operations "
+            "WHERE cycle=? AND operation='expire' AND key=?",
+            (row["id"], command.idempotency_key),
+        ).fetchone()
+        if (
+            payload != receipt.model_dump(mode="json")
+            or row["state"] != "EXPIRED"
+            or row["cleanup_state"] != "COMPLETE"
+            or row["cleanup_operation_key"] != command.idempotency_key
+            or row["cleanup_request_digest"] != request_digest
+            or row["deletion_receipt"] != canonical(envelope).decode()
+            or receipt.context_cycle_id != row["id"]
+            or receipt.segment_chain_root != row["root"]
+            or receipt.context_seal_digest != row["seal_digest"]
+            or receipt.retention_class != row["retention_class"]
+            or receipt.retention_expired_at != row["expires"]
+            or receipt.retention_operation_key != command.idempotency_key
+            or receipt.retention_request_digest != request_digest
+            or operation is None
+            or operation["request_digest"] != request_digest
+            or operation["result"] != canonical(envelope).decode()
+        ):
+            raise ContextFault("context_integrity_failure")
+        remote_envelope = (
+            json.loads(row["cleanup_remote_receipt"])
+            if row["cleanup_remote_receipt"] is not None
+            else None
+        )
+        if receipt.remote_deletion_receipt_digest != (
+            digest(remote_envelope) if remote_envelope is not None else None
+        ):
+            raise ContextFault("context_integrity_failure")
+        try:
+            namespace = json.loads(row["binding"])["namespace"]
+        except (TypeError, ValueError, KeyError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        if remote_envelope is not None:
+            try:
+                self._verify_remote_deletion(
+                    remote_envelope,
+                    row,
+                    namespace,
+                    row["checkpoint_object_ref_digest"],
+                    now=self.engine.now(),
+                    require_fresh=False,
+                )
+            except ContextFault as exc:
+                raise ContextFault("context_integrity_failure") from exc
+        if receipt.key_destruction_receipt is not None:
+            try:
+                self._verify_key_destruction(
+                    receipt.key_destruction_receipt.model_dump(mode="json"),
+                    row["key_ref"],
+                    row["key_version"],
+                    namespace,
+                    self.engine.now(),
+                    command_issued_at=command.issued_at,
+                    require_fresh=False,
+                )
+            except ContextFault as exc:
+                raise ContextFault("context_integrity_failure") from exc
+            # The service-signed terminal receipt records the provider
+            # qualification used at the effect, while the embedded KMS receipt
+            # remains independently verifiable. Exact lost-ACK replay must not
+            # depend on a short-lived provider qualification that is correctly
+            # retired after its last non-expired cycle is deleted.
+        elif receipt.local_key_destruction is not None:
+            local = (
+                receipt.local_key_destruction.model_dump(mode="json")
+                if hasattr(receipt.local_key_destruction, "model_dump")
+                else receipt.local_key_destruction
+            )
+            if (
+                set(local)
+                != {
+                    "schema_version",
+                    "provider",
+                    "key_ref",
+                    "key_version",
+                    "namespace_digest",
+                    "wrapped_key_digest",
+                    "destroyed_at",
+                    "verified",
+                }
+                or local["schema_version"] != "ContextLocalKeyDestructionV1"
+                or local["provider"] != FileCycleKeyProvider.provider
+                or local["key_ref"] != row["key_ref"]
+                or local["key_version"] != row["key_version"]
+                or local["namespace_digest"] != digest(namespace)
+                or local["verified"] is not True
+            ):
+                raise ContextFault("context_integrity_failure")
+        if isinstance(receipt, ContextDeletionReceiptV2):
+            registration_digest = (
+                digest(json.loads(row["checkpoint_durability_receipt"]))
+                if row["checkpoint_durability_receipt"] is not None
+                else None
+            )
+            if (
+                row["checkpoint_durability_legacy"]
+                or receipt.checkpoint_durability_mode
+                != row["checkpoint_durability_mode"]
+                or receipt.checkpoint_durability_registration_receipt_digest
+                != registration_digest
+                or receipt.checkpoint_manifest_checksum
+                != row["checkpoint_manifest_checksum"]
+                or receipt.checkpoint_object_ref_digest
+                != row["checkpoint_object_ref_digest"]
+            ):
+                raise ContextFault("context_integrity_failure")
+        elif not row["checkpoint_durability_legacy"]:
+            raise ContextFault("context_integrity_failure")
+        return envelope
+
+    def _hold_replay(
+        self,
+        db,
+        row,
+        command: RetentionCommandV1,
+        request_digest: str,
+        stored_result: str,
+    ) -> dict:
+        try:
+            envelope = json.loads(stored_result)
+            payload = verify(
+                envelope,
+                {self.engine.signer.key_id: self.engine.signer.key.public_key()},
+            )
+            receipt = ContextRetentionReceiptV1.model_validate(payload)
+        except (ContextFault, TypeError, ValueError) as exc:
+            raise ContextFault("context_integrity_failure") from exc
+        operation = db.execute(
+            "SELECT request_digest,result FROM retention_operations "
+            "WHERE cycle=? AND operation=? AND key=?",
+            (row["id"], command.operation, command.idempotency_key),
+        ).fetchone()
+        event_type = (
+            "context.retention_held"
+            if command.operation == "hold"
+            else "context.retention_released"
+        )
+        historical_event = False
+        for event_row in db.execute(
+            "SELECT body FROM events WHERE cycle=?", (row["id"],)
+        ):
+            try:
+                event = json.loads(event_row["body"])
+            except (TypeError, ValueError):
+                continue
+            if (
+                event.get("type") == event_type
+                and event.get("context_cycle_id") == row["id"]
+                and event.get("state_revision") == receipt.revision
+                and event.get("reason") == receipt.reason_code
+                and event.get("timestamp") == receipt.effective_at
+            ):
+                historical_event = True
+                break
+        if (
+            payload != receipt.model_dump(mode="json")
+            or receipt.operation != command.operation
+            or receipt.context_cycle_id != row["id"]
+            or receipt.reason_code != command.reason_code
+            or not command.issued_at <= receipt.effective_at < command.expires_at
+            or receipt.revision != command.expected_revision + 1
+            or operation is None
+            or operation["request_digest"] != request_digest
+            or operation["result"] != canonical(envelope).decode()
+            or not historical_event
+        ):
+            raise ContextFault("context_integrity_failure")
+        return envelope
+
     def apply(self, capability: dict, signed_command: dict) -> dict:
         raw = verify(signed_command, self.engine.authority_keys)
         command = RetentionCommandV1.model_validate(raw)
@@ -244,7 +443,13 @@ class RetentionManager:
                 if replay["request_digest"] != request_digest:
                     raise ContextFault("context_idempotency_conflict")
                 if replay["result"] is not None:
-                    return json.loads(replay["result"])
+                    if command.operation == "expire":
+                        return self._deletion_replay(
+                            db, row, command, request_digest, replay["result"]
+                        )
+                    return self._hold_replay(
+                        db, row, command, request_digest, replay["result"]
+                    )
             else:
                 if not command.issued_at <= now < command.expires_at:
                     raise ContextFault("context_retention_authority_expired")
@@ -365,9 +570,29 @@ class RetentionManager:
             root = row["root"]
             seal_digest = row["seal_digest"]
             retention_class = row["retention_class"]
+            checkpoint_durability_mode = row["checkpoint_durability_mode"]
+            if checkpoint_durability_mode == "unregistered":
+                if (
+                    row["checkpoint"] != 0
+                    or row["checkpoint_manifest_checksum"] is not None
+                    or row["checkpoint_durability_command_digest"] is not None
+                    or row["checkpoint_durability_receipt"] is not None
+                ):
+                    raise ContextFault("context_integrity_failure")
+            elif checkpoint_durability_mode in {
+                "local_ephemeral",
+                "remote_registered",
+            }:
+                self.engine._verify_checkpoint_durability_registration(row)
+            else:
+                raise ContextFault("context_integrity_failure")
+            remote_checkpoint_registered = (
+                row["checkpoint_manifest_checksum"] is not None
+                and checkpoint_durability_mode == "remote_registered"
+            )
             object_ref_digest = command.checkpoint_object_ref_digest
             if row["cleanup_state"] == "NONE":
-                if row["checkpoint_manifest_checksum"] is not None:
+                if remote_checkpoint_registered:
                     if (
                         command.remote_deletion_receipt is None
                         or object_ref_digest is None
@@ -411,7 +636,7 @@ class RetentionManager:
                     db, row["id"], "context.cleanup_started", reason=command.reason_code
                 )
             else:
-                if row["checkpoint_manifest_checksum"] is not None:
+                if remote_checkpoint_registered:
                     try:
                         remote_envelope = json.loads(row["cleanup_remote_receipt"])
                     except (TypeError, ValueError) as exc:
@@ -483,6 +708,7 @@ class RetentionManager:
                     key_destruction_proof
                     and (
                         row["checkpoint_manifest_checksum"] is None
+                        or checkpoint_durability_mode == "local_ephemeral"
                         or remote_proof is not None
                     )
                 )
@@ -499,7 +725,9 @@ class RetentionManager:
             if replay is None or replay["request_digest"] != request_digest:
                 raise ContextFault("context_idempotency_conflict")
             if replay["result"] is not None:
-                return json.loads(replay["result"])
+                return self._deletion_replay(
+                    db, row, command, request_digest, replay["result"]
+                )
             if row["state"] not in {"SEALED", "ABORTED"} or row[
                 "cleanup_state"
             ] != "PENDING":
@@ -507,13 +735,13 @@ class RetentionManager:
             if (
                 row["cleanup_operation_key"] != command.idempotency_key
                 or row["cleanup_request_digest"] != request_digest
+                or row["checkpoint_durability_mode"] != checkpoint_durability_mode
             ):
                 raise ContextFault("context_cleanup_in_progress")
             db.execute("DELETE FROM postings WHERE cycle=?", (row["id"],))
             db.execute("DELETE FROM segments WHERE cycle=?", (row["id"],))
             db.execute("DELETE FROM operations WHERE cycle=?", (row["id"],))
-            receipt = self.engine.signer.sign(
-                {
+            deletion_payload = {
                     "schema_version": "ContextDeletionReceiptV1",
                     "context_cycle_id": row["id"],
                     "segment_chain_root": root,
@@ -548,7 +776,24 @@ class RetentionManager:
                         remote_proof.object_ref_digest if remote_proof is not None else None
                     ),
                 }
-            )
+            if not row["checkpoint_durability_legacy"]:
+                registration_receipt_digest = (
+                    digest(json.loads(row["checkpoint_durability_receipt"]))
+                    if row["checkpoint_durability_receipt"] is not None
+                    else None
+                )
+                deletion_payload.update(
+                    schema_version="ContextDeletionReceiptV2",
+                    checkpoint_manifest_checksum=row["checkpoint_manifest_checksum"],
+                    checkpoint_durability_mode=checkpoint_durability_mode,
+                    checkpoint_durability_registration_receipt_digest=(
+                        registration_receipt_digest
+                    ),
+                )
+                deletion_payload = ContextDeletionReceiptV2.model_validate(
+                    deletion_payload
+                ).model_dump(mode="json")
+            receipt = self.engine.signer.sign(deletion_payload)
             db.execute(
                 "UPDATE cycles SET state='EXPIRED',authority=NULL,snapshot=NULL,"
                 "cleanup_state='COMPLETE',deletion_receipt=?,revision=revision+1 WHERE id=?",
@@ -586,6 +831,7 @@ class RetentionManager:
             raise ContextFault("context_remote_deletion_proof_invalid") from exc
         if (
             proof.namespace.model_dump() != namespace
+            or row["checkpoint_durability_mode"] != "remote_registered"
             or row["checkpoint_manifest_checksum"] is None
             or proof.manifest_checksum != row["checkpoint_manifest_checksum"]
             or proof.object_ref_digest != object_ref_digest

--- a/aether_context/scale.py
+++ b/aether_context/scale.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
+import importlib.metadata
+import platform
+import sqlite3
+import sys
+import sysconfig
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -13,6 +19,10 @@ from .contracts import (
     ExecutorStabilityReceiptV1,
     HostedScaleReceiptV1,
     RuntimeBuildManifestV1,
+    RuntimeBuildManifestV2,
+    RuntimeBuildManifestV3,
+    RuntimeEnvironmentV1,
+    RuntimeEnvironmentV2,
     canonical,
     digest,
 )
@@ -21,18 +31,47 @@ from .policy import namespace_matches, visible_values
 
 MAX_HOSTED_PROCESS_BYTES = 536_870_912
 MIN_RECALL_BASIS_POINTS = 8000
+HOSTED_RUNTIME_DISTRIBUTIONS = (
+    "annotated-types",
+    "cffi",
+    "cryptography",
+    "numpy",
+    "pydantic",
+    "pydantic_core",
+    "pycparser",
+    "typing-inspection",
+    "typing_extensions",
+)
 
 
-def runtime_package_tree_digest(root: str | Path | None = None) -> str:
-    """Hash every shipped runtime source/schema byte under the imported package."""
+def runtime_package_tree_digest(
+    root: str | Path | None = None, *, require_source_only: bool = False
+) -> str:
+    """Hash shipped source/schema bytes and reject executable shadow artifacts.
+
+    A qualified hosted deployment is source-only: bytecode generation is disabled,
+    no cache directory exists, and every regular package file is an expected wheel
+    payload.  This closes Python's extension/bytecode precedence paths rather than
+    claiming a source digest for bytes the interpreter may not execute.
+    """
 
     package_root = Path(root) if root is not None else Path(__file__).resolve().parent
     package_root = package_root.resolve(strict=True)
+    if require_source_only and not sys.dont_write_bytecode:
+        raise ContextFault("context_runtime_bytecode_enabled")
     entries: list[dict[str, str]] = []
     for path in sorted(package_root.rglob("*")):
         if path.is_symlink():
             raise ContextFault("context_runtime_build_invalid")
-        if not path.is_file() or path.suffix not in {".py", ".json", ".typed"}:
+        if path.is_dir():
+            if require_source_only and path.name == "__pycache__":
+                raise ContextFault("context_runtime_import_artifact")
+            continue
+        if not path.is_file():
+            continue
+        if path.suffix not in {".py", ".json", ".typed"}:
+            if require_source_only:
+                raise ContextFault("context_runtime_import_artifact")
             continue
         entries.append(
             {
@@ -43,6 +82,77 @@ def runtime_package_tree_digest(root: str | Path | None = None) -> str:
     if not entries:
         raise ContextFault("context_runtime_build_invalid")
     return hashlib.sha256(canonical(entries)).hexdigest()
+
+
+def runtime_environment_identity(
+    root: str | Path | None = None,
+    *,
+    distributions: tuple[str, ...] = HOSTED_RUNTIME_DISTRIBUTIONS,
+) -> RuntimeEnvironmentV2:
+    """Measure the interpreter, hosted dependencies, and actual import root."""
+
+    package_root = Path(root) if root is not None else Path(__file__).resolve().parent
+    package_root = package_root.resolve(strict=True)
+    try:
+        executable = Path(sys.executable).resolve(strict=True)
+        executable_digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+        versions = {
+            name: importlib.metadata.version(name)
+            for name in distributions
+        }
+        artifacts = {
+            name: _distribution_artifact_digest(name)
+            for name in distributions
+        }
+    except (OSError, importlib.metadata.PackageNotFoundError) as exc:
+        raise ContextFault("context_runtime_environment_unavailable") from exc
+    abi = sysconfig.get_config_var("SOABI") or getattr(
+        sys.implementation, "cache_tag", None
+    )
+    if not isinstance(abi, str) or not abi:
+        raise ContextFault("context_runtime_environment_unavailable")
+    return RuntimeEnvironmentV2(
+        python_implementation=sys.implementation.name,
+        python_version=platform.python_version(),
+        python_abi=abi,
+        python_executable_digest=executable_digest,
+        dependency_import_closure=sorted(distributions),
+        dependency_versions=versions,
+        dependency_artifact_digests=artifacts,
+        sqlite_version=sqlite3.sqlite_version,
+        package_import_root_digest=digest(str(package_root.parent)),
+    )
+
+
+def _distribution_artifact_digest(name: str) -> str:
+    """Hash and RECORD-verify every installed file owned by one dependency."""
+
+    distribution = importlib.metadata.distribution(name)
+    files = distribution.files
+    if not files:
+        raise ContextFault("context_runtime_environment_unavailable")
+    entries: list[dict[str, str]] = []
+    for entry in sorted(files, key=lambda item: str(item)):
+        path = Path(str(distribution.locate_file(entry)))
+        if path.is_symlink() or not path.is_file():
+            raise ContextFault("context_runtime_environment_unavailable")
+        sha256 = hashlib.sha256()
+        recorded = entry.hash
+        recorded_hash = hashlib.new(recorded.mode) if recorded is not None else None
+        try:
+            with path.open("rb") as stream:
+                while chunk := stream.read(1_048_576):
+                    sha256.update(chunk)
+                    if recorded_hash is not None:
+                        recorded_hash.update(chunk)
+        except OSError as exc:
+            raise ContextFault("context_runtime_environment_unavailable") from exc
+        if recorded is not None and recorded_hash is not None:
+            observed = base64.urlsafe_b64encode(recorded_hash.digest()).rstrip(b"=").decode()
+            if observed != recorded.value:
+                raise ContextFault("context_runtime_dependency_artifact_mismatch")
+        entries.append({"path": str(entry).replace("\\", "/"), "sha256": sha256.hexdigest()})
+    return digest(entries)
 
 
 def profile_benchmark_digest(profile: ContextProfileV1) -> str:
@@ -72,6 +182,16 @@ class BuildQualification:
     recall_dataset_digest: str | None
     data_plane_case_generator_digest: str | None
     manifest_digest: str | None
+    locked_environment_digest: str | None
+    python_implementation: str | None
+    python_version: str | None
+    python_abi: str | None
+    python_executable_digest: str | None
+    dependency_versions: dict[str, str]
+    dependency_artifact_digests: dict[str, str]
+    sqlite_version: str | None
+    package_import_root_digest: str | None
+    bytecode_policy: str | None
 
 
 def qualify_runtime_build(
@@ -80,15 +200,43 @@ def qualify_runtime_build(
     *,
     expected_version: str,
     package_tree_digest: str,
+    runtime_environment: RuntimeEnvironmentV1 | RuntimeEnvironmentV2 | None = None,
 ) -> BuildQualification:
     """Verify signed build identity against the bytes of this imported package."""
 
     if envelope is None or not keys:
         return BuildQualification(
-            False, ("runtime_build_manifest_missing",), None, None, None, None
+            valid=False,
+            failures=("runtime_build_manifest_missing",),
+            source_revision=None,
+            recall_dataset_digest=None,
+            data_plane_case_generator_digest=None,
+            manifest_digest=None,
+            locked_environment_digest=None,
+            python_implementation=None,
+            python_version=None,
+            python_abi=None,
+            python_executable_digest=None,
+            dependency_versions={},
+            dependency_artifact_digests={},
+            sqlite_version=None,
+            package_import_root_digest=None,
+            bytecode_policy=None,
         )
     try:
-        manifest = RuntimeBuildManifestV1.model_validate(verify(envelope, keys))
+        payload = verify(envelope, keys)
+        if payload.get("schema_version") == "ContextRuntimeBuildManifestV3":
+            manifest: RuntimeBuildManifestV1 | RuntimeBuildManifestV2 | RuntimeBuildManifestV3 = (
+                RuntimeBuildManifestV3.model_validate(payload)
+            )
+        elif payload.get("schema_version") == "ContextRuntimeBuildManifestV2":
+            manifest = RuntimeBuildManifestV2.model_validate(payload)
+        else:
+            manifest = RuntimeBuildManifestV1.model_validate(payload)
+        if isinstance(manifest, (RuntimeBuildManifestV2, RuntimeBuildManifestV3)) and (
+            payload != manifest.model_dump(mode="json")
+        ):
+            raise ValueError("runtime build manifest is not exact")
     except (ValueError, TypeError) as exc:
         raise ContextFault("context_runtime_build_manifest_invalid") from exc
     failures: list[str] = []
@@ -96,13 +244,46 @@ def qualify_runtime_build(
         failures.append("runtime_version_mismatch")
     if manifest.package_tree_digest != package_tree_digest:
         failures.append("runtime_package_tree_mismatch")
+    locked_environment_digest: str | None = None
+    environment: RuntimeEnvironmentV1 | RuntimeEnvironmentV2 | None = None
+    if isinstance(manifest, RuntimeBuildManifestV3):
+        environment = manifest.runtime_environment
+        locked_environment_digest = manifest.locked_environment_digest
+        if runtime_environment is None:
+            failures.append("runtime_environment_unavailable")
+        elif runtime_environment != environment:
+            failures.append("runtime_environment_mismatch")
+        elif digest(runtime_environment) != locked_environment_digest:
+            failures.append("runtime_environment_digest_mismatch")
+    elif isinstance(manifest, RuntimeBuildManifestV2):
+        environment = manifest.runtime_environment
+        locked_environment_digest = manifest.locked_environment_digest
+        failures.append("runtime_environment_contract_legacy")
+    else:
+        failures.append("runtime_environment_unbound")
     return BuildQualification(
-        not failures,
-        tuple(failures),
-        manifest.source_revision,
-        manifest.recall_dataset_digest,
-        manifest.data_plane_case_generator_digest,
-        digest(envelope),
+        valid=not failures,
+        failures=tuple(failures),
+        source_revision=manifest.source_revision,
+        recall_dataset_digest=manifest.recall_dataset_digest,
+        data_plane_case_generator_digest=manifest.data_plane_case_generator_digest,
+        manifest_digest=digest(envelope),
+        locked_environment_digest=locked_environment_digest,
+        python_implementation=(environment.python_implementation if environment else None),
+        python_version=(environment.python_version if environment else None),
+        python_abi=(environment.python_abi if environment else None),
+        python_executable_digest=(
+            environment.python_executable_digest if environment else None
+        ),
+        dependency_versions=(dict(environment.dependency_versions) if environment else {}),
+        dependency_artifact_digests=(
+            dict(environment.dependency_artifact_digests) if environment else {}
+        ),
+        sqlite_version=(environment.sqlite_version if environment else None),
+        package_import_root_digest=(
+            environment.package_import_root_digest if environment else None
+        ),
+        bytecode_policy=(environment.bytecode_policy if environment else None),
     )
 
 
@@ -138,6 +319,7 @@ def qualify_scale_receipt(
         and receipt.storage_version == profile.storage_version
         and receipt.configured_max_records == profile.max_records
         and receipt.configured_max_indexed_bytes == profile.max_indexed_bytes
+        and receipt.target_concurrency == profile.max_concurrent_cycles
     )
     if not exact:
         raise ContextFault("context_benchmark_profile_mismatch")
@@ -294,5 +476,6 @@ __all__ = [
     "qualify_runtime_build",
     "qualify_scale_receipt",
     "run_namespace_isolation",
+    "runtime_environment_identity",
     "runtime_package_tree_digest",
 ]

--- a/aether_context/service/__init__.py
+++ b/aether_context/service/__init__.py
@@ -4,33 +4,655 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hmac
 import json
 import os
 import errno
+import secrets
 import socket
 import stat
 from pathlib import Path
 
 from pydantic import ValidationError
 
-from ..contracts import AppendRequestV1, RetrieveRequestV1, canonical
-from ..crypto import ContextFault
+from ..contracts import (
+    AppendRequestV1,
+    ContextHydrateReceiptV1,
+    ContextHydrateReceiptV2,
+    LIVE_IPC_MAX_CHECKPOINT_BYTES,
+    RetrieveRequestV1,
+    canonical,
+)
+from ..crypto import ContextFault, verify
 from ..engine import ContextEngine
 
 MAX_REQUEST = 24_000_000
+MAX_RESTORE_RESULT = 64_000
+MAX_SIGNED_HYDRATE_ENVELOPE = 64_000
+MAX_LIVE_HYDRATE_PACK_BYTES = LIVE_IPC_MAX_CHECKPOINT_BYTES
+MAX_LIVE_CHECKPOINT_SNAPSHOT_BYTES = 16_000_000
+LIVE_PROCESS_MEMORY_LIMIT_BYTES = 512 * 1024 * 1024
+LIVE_MEMORY_SAFETY_BYTES = 32 * 1024 * 1024
+MIN_LOCAL_IO_BYTES_PER_SECOND = 1_048_576
+MIN_LOCAL_IO_TIMEOUT_SECONDS = 10
+MAX_LOCAL_IO_TIMEOUT_SECONDS = 180
+_EMPTY_CANONICAL_OBJECT_BYTES = len(canonical({}))
+_HYDRATE_REQUEST_FIXED_BYTES = len(
+    canonical(
+        {
+            "operation": "hydrate",
+            "grant": {},
+            "checkpoint_receipt": {},
+            "pack": "",
+        }
+    )
+) - (2 * _EMPTY_CANONICAL_OBJECT_BYTES)
+# Valid hydrate headers fit in two signed-envelope bounds; valid bind headers
+# may additionally contain a max-sized authority before project_snapshot.
+HEADER_LIMIT = 600_000
+SMALL_REQUEST_LIMIT = 400_000
+_HEAVY_OPERATIONS = {"hydrate", "checkpoint"}
+_BIND_OPERATIONS = {"bind", "bind_v2", "bind_v3"}
+_SECURE_DIR_FD_AVAILABLE = (
+    os.name != "nt"
+    and all(hasattr(os, name) for name in ("O_DIRECTORY", "O_NOFOLLOW"))
+    and all(
+        call in os.supports_dir_fd
+        for call in (os.open, os.stat, os.link, os.unlink)
+    )
+)
+
+
+def _hydrate_request_limit(max_checkpoint_bytes: int) -> int:
+    encoded_pack_bytes = 4 * ((max_checkpoint_bytes + 2) // 3)
+    return (
+        encoded_pack_bytes
+        + (2 * MAX_SIGNED_HYDRATE_ENVELOPE)
+        + _HYDRATE_REQUEST_FIXED_BYTES
+    )
+
+
+def _local_io_timeout_seconds(max_request_bytes: int) -> int:
+    transfer_seconds = (
+        max_request_bytes + MIN_LOCAL_IO_BYTES_PER_SECOND - 1
+    ) // MIN_LOCAL_IO_BYTES_PER_SECOND
+    timeout = max(MIN_LOCAL_IO_TIMEOUT_SECONDS, transfer_seconds + 5)
+    if timeout > MAX_LOCAL_IO_TIMEOUT_SECONDS:
+        raise ContextFault("context_profile_transport_limit")
+    return timeout
+
+
+def _resident_bytes() -> int:
+    """Return current RSS on the production Linux host, failing closed elsewhere."""
+
+    if os.name == "nt":
+        # Unit tests on Windows do not host the Unix daemon. Keep construction
+        # deterministic while serve() continues to reject this platform.
+        return 0
+    try:
+        for line in Path("/proc/self/status").read_text().splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError) as exc:
+        raise ContextFault("context_transport_memory_unavailable") from exc
+    raise ContextFault("context_transport_memory_unavailable")
+
+
+def _live_hydrate_peak_estimate(
+    max_pack_bytes: int,
+    *,
+    max_snapshot_bytes: int,
+    resident_cache_bytes: int,
+    baseline_rss_bytes: int,
+    max_records: int,
+    max_operations: int,
+    max_connections: int,
+) -> int:
+    """Conservative whole-object transport bound pending streaming framing."""
+
+    return (
+        baseline_rss_bytes
+        + resident_cache_bytes
+        + LIVE_MEMORY_SAFETY_BYTES
+        + (8 * max_pack_bytes)
+        + (4 * max_snapshot_bytes)
+        + (2_048 * max_records)
+        + (1_024 * max_operations)
+        + (HEADER_LIMIT * max_connections)
+    )
+
+
+async def _read_request_frame(reader, *, max_request: int, timeout: int) -> bytes:
+    line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+    if not line or not line.endswith(b"\n"):
+        raise ContextFault("context_request_framing")
+    if len(line) > max_request + 1:
+        raise ContextFault("context_request_limit")
+    frame = line[:-1]
+    if b"\n" in frame or b"\r" in frame:
+        raise ContextFault("context_request_framing")
+    return frame
+
+
+def _json_no_duplicates(raw: bytes | bytearray) -> object:
+    def closed_object(pairs):
+        value = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError("duplicate JSON key")
+            value[key] = item
+        return value
+
+    return json.loads(raw, object_pairs_hook=closed_object)
+
+
+def _json_string_end(raw: bytes | bytearray, start: int) -> int | None:
+    escaped = False
+    for index in range(start + 1, len(raw)):
+        value = raw[index]
+        if escaped:
+            escaped = False
+        elif value == 0x5C:
+            escaped = True
+        elif value == 0x22:
+            return index
+    return None
+
+
+def _top_level_operation(raw: bytes | bytearray) -> str | None:
+    """Read only the depth-one operation key from an incomplete JSON object."""
+
+    depth = 0
+    index = 0
+    while index < len(raw):
+        value = raw[index]
+        if value in (0x7B, 0x5B):  # { [
+            depth += 1
+            index += 1
+            continue
+        if value in (0x7D, 0x5D):  # } ]
+            depth -= 1
+            index += 1
+            continue
+        if value != 0x22:
+            index += 1
+            continue
+        end = _json_string_end(raw, index)
+        if end is None:
+            return None
+        if depth == 1:
+            cursor = end + 1
+            while cursor < len(raw) and raw[cursor] in b" \t":
+                cursor += 1
+            if cursor < len(raw) and raw[cursor] == 0x3A:  # :
+                try:
+                    key = json.loads(bytes(raw[index : end + 1]))
+                except (UnicodeDecodeError, ValueError):
+                    return ""
+                if key == "operation":
+                    cursor += 1
+                    while cursor < len(raw) and raw[cursor] in b" \t":
+                        cursor += 1
+                    if cursor >= len(raw):
+                        return None
+                    if raw[cursor] != 0x22:
+                        return ""
+                    value_end = _json_string_end(raw, cursor)
+                    if value_end is None:
+                        return None
+                    try:
+                        operation = json.loads(bytes(raw[cursor : value_end + 1]))
+                    except (UnicodeDecodeError, ValueError):
+                        return ""
+                    return operation if isinstance(operation, str) else ""
+        index = end + 1
+    return None
+
+
+def _restore_requested(*paths: str | None) -> bool:
+    """A recovery start is all-or-nothing, including its durable result path."""
+
+    if any(paths) and not all(paths):
+        raise SystemExit("context_restore_config_incomplete")
+    return bool(paths[0])
+
+
+def _safe_restore_result_path(value: str | Path) -> Path:
+    path = Path(value).absolute()
+    parent = path.parent
+    try:
+        for current in (parent, *parent.parents):
+            info = current.lstat()
+            if (
+                stat.S_ISLNK(info.st_mode)
+                or bool(getattr(info, "st_file_attributes", 0) & 0x400)
+                or not stat.S_ISDIR(info.st_mode)
+            ):
+                raise ContextFault("context_restore_result_path_invalid")
+    except (FileNotFoundError, NotADirectoryError, PermissionError) as exc:
+        raise ContextFault("context_restore_result_path_invalid") from exc
+    return path
+
+
+def _open_restore_parent(path: Path) -> int | None:
+    """Open the parent through stable, no-follow directory handles on Unix."""
+
+    if os.name == "nt":
+        return None
+    if not _SECURE_DIR_FD_AVAILABLE:
+        raise ContextFault("context_restore_result_path_invalid")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    parts = path.parent.parts
+    if not path.is_absolute() or not parts:
+        raise ContextFault("context_restore_result_path_invalid")
+    current = os.open(path.anchor, flags)
+    try:
+        for component in parts[1:]:
+            next_fd = os.open(component, flags, dir_fd=current)
+            os.close(current)
+            current = next_fd
+        info = os.fstat(current)
+        getuid = getattr(os, "getuid", None)
+        if (
+            not stat.S_ISDIR(info.st_mode)
+            or getuid is None
+            or info.st_uid != getuid()
+            or stat.S_IMODE(info.st_mode) & 0o022
+        ):
+            raise ContextFault("context_restore_result_path_invalid")
+        return current
+    except BaseException:
+        os.close(current)
+        raise
+
+
+def _parent_path_matches(path: Path, parent_fd: int) -> bool:
+    try:
+        by_path = path.lstat()
+        by_fd = os.fstat(parent_fd)
+    except OSError:
+        return False
+    return (
+        stat.S_ISDIR(by_path.st_mode)
+        and not stat.S_ISLNK(by_path.st_mode)
+        and by_path.st_dev == by_fd.st_dev
+        and by_path.st_ino == by_fd.st_ino
+    )
+
+
+def _read_restore_result(path: Path, *, parent_fd: int | None = None) -> bytes:
+    try:
+        path_info = (
+            path.lstat()
+            if parent_fd is None
+            else os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        )
+    except FileNotFoundError:
+        raise
+    if (
+        not stat.S_ISREG(path_info.st_mode)
+        or stat.S_ISLNK(path_info.st_mode)
+        or bool(getattr(path_info, "st_file_attributes", 0) & 0x400)
+    ):
+        raise ContextFault("context_restore_result_path_invalid")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        fd = os.open(path if parent_fd is None else path.name, flags, dir_fd=parent_fd)
+    except (FileNotFoundError, FileExistsError):
+        raise
+    except OSError as exc:
+        raise ContextFault("context_restore_result_path_invalid") from exc
+    try:
+        info = os.fstat(fd)
+        getuid = getattr(os, "getuid", None)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or bool(getattr(info, "st_file_attributes", 0) & 0x400)
+            or info.st_dev != path_info.st_dev
+            or info.st_ino != path_info.st_ino
+            or info.st_size > MAX_RESTORE_RESULT
+            or (
+                os.name != "nt"
+                and (
+                    stat.S_IMODE(info.st_mode) != 0o600
+                    or getuid is None
+                    or info.st_uid != getuid()
+                )
+            )
+        ):
+            raise ContextFault("context_restore_result_path_invalid")
+        chunks: list[bytes] = []
+        remaining = MAX_RESTORE_RESULT + 1
+        while remaining:
+            chunk = os.read(fd, min(65_536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        if len(raw) > MAX_RESTORE_RESULT:
+            raise ContextFault("context_restore_result_path_invalid")
+        return raw
+    finally:
+        os.close(fd)
+
+
+def _read_bounded_regular_file(
+    value: str | Path,
+    limit: int,
+    *,
+    failure: str,
+) -> bytes:
+    """Read one stable regular-file identity without allocating past its limit."""
+
+    path = Path(value)
+    try:
+        path_info = path.lstat()
+    except OSError as exc:
+        raise ContextFault(failure) from exc
+    if (
+        not stat.S_ISREG(path_info.st_mode)
+        or stat.S_ISLNK(path_info.st_mode)
+        or bool(getattr(path_info, "st_file_attributes", 0) & 0x400)
+    ):
+        raise ContextFault(failure)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise ContextFault(failure) from exc
+    try:
+        info = os.fstat(fd)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_dev != path_info.st_dev
+            or info.st_ino != path_info.st_ino
+        ):
+            raise ContextFault(failure)
+        chunks: list[bytes] = []
+        remaining = limit + 1
+        while remaining:
+            chunk = os.read(fd, min(65_536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        if len(raw) > limit:
+            raise ContextFault(failure)
+        return raw
+    except OSError as exc:
+        raise ContextFault(failure) from exc
+    finally:
+        os.close(fd)
+
+
+def _sync_directory(path: Path) -> None:
+    if os.name == "nt":
+        return
+    fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _write_restore_result_once(value: str | Path, receipt: dict) -> None:
+    """Publish one complete signed hydrate receipt without replacing prior evidence."""
+
+    target = _safe_restore_result_path(value)
+    raw = canonical(receipt) + b"\n"
+    if len(raw) > MAX_RESTORE_RESULT:
+        raise ContextFault("context_restore_result_invalid")
+    parent_fd = _open_restore_parent(target)
+    try:
+        try:
+            existing = _read_restore_result(target, parent_fd=parent_fd)
+        except FileNotFoundError:
+            existing = None
+        if existing is not None:
+            if hmac.compare_digest(existing, raw):
+                return
+            raise ContextFault("context_restore_result_conflict")
+
+        temporary_name = "." + target.name + "." + secrets.token_hex(16) + ".tmp"
+        temporary = target.parent / temporary_name
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+        )
+        linked = False
+        try:
+            if parent_fd is not None and not _parent_path_matches(target.parent, parent_fd):
+                raise ContextFault("context_restore_result_path_invalid")
+            if parent_fd is None:
+                fd = os.open(temporary, flags, 0o600)
+            else:
+                fd = os.open(temporary_name, flags, 0o600, dir_fd=parent_fd)
+            try:
+                if os.name != "nt":
+                    os.fchmod(fd, 0o600)
+                info = os.fstat(fd)
+                getuid = getattr(os, "getuid", None)
+                if (
+                    not stat.S_ISREG(info.st_mode)
+                    or (
+                        os.name != "nt"
+                        and (
+                            stat.S_IMODE(info.st_mode) != 0o600
+                            or getuid is None
+                            or info.st_uid != getuid()
+                        )
+                    )
+                ):
+                    raise ContextFault("context_restore_result_path_invalid")
+                offset = 0
+                while offset < len(raw):
+                    written = os.write(fd, raw[offset:])
+                    if written <= 0:
+                        raise OSError("short restore-result write")
+                    offset += written
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            try:
+                if parent_fd is None:
+                    os.link(temporary, target, follow_symlinks=False)
+                else:
+                    os.link(
+                        temporary_name,
+                        target.name,
+                        src_dir_fd=parent_fd,
+                        dst_dir_fd=parent_fd,
+                        follow_symlinks=False,
+                    )
+                linked = True
+            except FileExistsError:
+                existing = _read_restore_result(target, parent_fd=parent_fd)
+                if not hmac.compare_digest(existing, raw):
+                    raise ContextFault("context_restore_result_conflict") from None
+            if parent_fd is None:
+                _sync_directory(target.parent)
+            else:
+                os.fsync(parent_fd)
+                if not _parent_path_matches(target.parent, parent_fd):
+                    raise ContextFault("context_restore_result_path_invalid")
+        except ContextFault:
+            raise
+        except OSError as exc:
+            raise ContextFault("context_restore_result_unavailable") from exc
+        finally:
+            try:
+                if parent_fd is None:
+                    temporary.unlink(missing_ok=True)
+                else:
+                    try:
+                        os.unlink(temporary_name, dir_fd=parent_fd)
+                    except FileNotFoundError:
+                        pass
+            except OSError:
+                if not linked:
+                    raise ContextFault("context_restore_result_unavailable") from None
+        if parent_fd is None:
+            _sync_directory(target.parent)
+        else:
+            os.fsync(parent_fd)
+    except ContextFault:
+        raise
+    except OSError as exc:
+        raise ContextFault("context_restore_result_unavailable") from exc
+    finally:
+        if parent_fd is not None:
+            os.close(parent_fd)
+
+
+def _restore_engine(
+    engine: ContextEngine,
+    *,
+    profile,
+    pack_path: str,
+    grant_path: str,
+    receipt_path: str,
+    result_path: str,
+    receipt_keys: dict,
+) -> dict:
+    pack_limit = min(
+        profile.max_checkpoint_bytes, MAX_LIVE_HYDRATE_PACK_BYTES
+    )
+    pack_bytes = _read_bounded_regular_file(
+        pack_path, pack_limit, failure="context_pack_limit"
+    )
+    grant_bytes = _read_bounded_regular_file(
+        grant_path,
+        MAX_SIGNED_HYDRATE_ENVELOPE,
+        failure="context_restore_input_invalid",
+    )
+    receipt_bytes = _read_bounded_regular_file(
+        receipt_path,
+        MAX_SIGNED_HYDRATE_ENVELOPE,
+        failure="context_restore_input_invalid",
+    )
+    try:
+        grant = _json_no_duplicates(grant_bytes)
+        checkpoint_receipt = _json_no_duplicates(receipt_bytes)
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise ContextFault("context_restore_input_invalid") from exc
+    if not isinstance(grant, dict) or not isinstance(checkpoint_receipt, dict):
+        raise ContextFault("context_restore_input_invalid")
+    result = engine.hydrate(
+        grant,
+        checkpoint_receipt,
+        pack_bytes,
+        receipt_keys,
+        snapshot_max_bytes=min(
+            profile.max_checkpoint_bytes, MAX_LIVE_CHECKPOINT_SNAPSHOT_BYTES
+        ),
+    )
+    try:
+        payload = verify(
+            result,
+            {engine.signer.key_id: engine.signer.key.public_key()},
+        )
+        receipt_model = (
+            ContextHydrateReceiptV2
+            if payload.get("schema_version") == "ContextHydrateReceiptV2"
+            else ContextHydrateReceiptV1
+        )
+        validated = receipt_model.model_validate(payload).model_dump(mode="json")
+    except (ContextFault, TypeError, ValueError) as exc:
+        raise ContextFault("context_restore_result_invalid") from exc
+    if payload != validated:
+        raise ContextFault("context_restore_result_invalid")
+    _write_restore_result_once(result_path, result)
+    return result
 
 
 class ContextService:
-    def __init__(self, engine: ContextEngine):
+    def __init__(
+        self,
+        engine: ContextEngine,
+        *,
+        checkpoint_receipt_keys: dict | None = None,
+    ):
         self.engine = engine
-        self.gate = asyncio.Semaphore(8)
+        self.checkpoint_receipt_keys = dict(checkpoint_receipt_keys or {})
+        self.max_small_operations = engine.profile.max_concurrent_cycles
+        # One active heavy frame, one prefix-only heavy waiter, and a small
+        # operation for every concurrency lane. Two slots cover health/control.
+        self.max_accepted_connections = self.max_small_operations + 4
+        self.max_live_hydrate_pack_bytes = min(
+            engine.profile.max_checkpoint_bytes,
+            MAX_LIVE_HYDRATE_PACK_BYTES,
+        )
+        self.max_live_checkpoint_snapshot_bytes = min(
+            engine.profile.max_checkpoint_bytes,
+            MAX_LIVE_CHECKPOINT_SNAPSHOT_BYTES,
+        )
+        self.max_hydrate_request = _hydrate_request_limit(
+            self.max_live_hydrate_pack_bytes
+        )
+        self.baseline_rss_bytes = _resident_bytes()
+        self.estimated_peak_rss_bytes = _live_hydrate_peak_estimate(
+            self.max_live_hydrate_pack_bytes,
+            max_snapshot_bytes=self.max_live_checkpoint_snapshot_bytes,
+            resident_cache_bytes=engine.profile.resident_cache_bytes,
+            baseline_rss_bytes=self.baseline_rss_bytes,
+            max_records=engine.profile.max_records,
+            max_operations=engine.profile.max_operations_per_cycle,
+            max_connections=self.max_accepted_connections,
+        )
+        if self.estimated_peak_rss_bytes > LIVE_PROCESS_MEMORY_LIMIT_BYTES:
+            raise ContextFault("context_profile_transport_limit")
+        self.max_request = max(MAX_REQUEST, self.max_hydrate_request)
+        self.io_timeout_seconds = _local_io_timeout_seconds(self.max_request)
+        self.heavy_gate = asyncio.Semaphore(1)
+        self.bind_gate = asyncio.Semaphore(1)
+        self.small_gate = asyncio.Semaphore(self.max_small_operations)
+        self._heavy_admitted = 0
+        self._connection_tasks: set[asyncio.Task] = set()
 
     def dispatch(self, request: dict) -> dict:
+        return self._dispatch(request, consume_hydrate_pack=False)
+
+    def _dispatch(self, request: dict, *, consume_hydrate_pack: bool) -> dict:
         operation = request.get("operation")
         fields = {
             "health": {"operation"},
+            "health_v2": {"operation"},
+            "health_v3": {"operation"},
             "reserve": {"operation", "reservation"},
+            "reserve_v2": {"operation", "reservation"},
+            "reserve_v3": {"operation", "reservation"},
+            "release_reservation": {"operation", "command"},
+            "expire_reservation": {"operation", "command"},
+            "abort_reservation": {"operation", "command"},
+            "expire_aborted_reservation": {"operation", "command"},
             "bind": {"operation", "binding", "authority", "project_snapshot"},
+            "bind_v2": {"operation", "binding", "authority", "project_snapshot"},
+            "bind_v3": {"operation", "binding", "authority", "project_snapshot"},
+            "checkpoint_durability": {"operation", "command"},
+            "hydrate": {"operation", "grant", "checkpoint_receipt", "pack"},
             "append": {"operation", "capability", "request"},
             "retrieve": {"operation", "capability", "request"},
             "checkpoint": {"operation", "capability", "idempotency_key"},
@@ -43,15 +665,92 @@ class ContextService:
         }
         if operation not in fields or set(request) != fields[operation]:
             raise ContextFault("context_request_schema")
-        if len(canonical(request)) > (MAX_REQUEST if operation == "bind" else 400_000):
+        request_limit = (
+            self.max_hydrate_request
+            if operation == "hydrate"
+            else MAX_REQUEST
+            if operation in {"bind", "bind_v2", "bind_v3"}
+            else 400_000
+        )
+        if operation != "hydrate" and len(canonical(request)) > request_limit:
             raise ContextFault("context_request_limit")
         if operation == "health":
             return self.engine.health()
+        if operation == "health_v2":
+            return self.engine.health_v2()
+        if operation == "health_v3":
+            return self.engine.health_v3()
         if operation == "reserve":
             return self.engine.reserve(request["reservation"])
+        if operation == "reserve_v2":
+            return self.engine.reserve_v2(request["reservation"])
+        if operation == "reserve_v3":
+            return self.engine.reserve_v3(request["reservation"])
+        if operation == "release_reservation":
+            return self.engine.release_reservation(request["command"])
+        if operation == "expire_reservation":
+            return self.engine.expire_reservation(request["command"])
+        if operation == "abort_reservation":
+            return self.engine.abort_reservation(request["command"])
+        if operation == "expire_aborted_reservation":
+            return self.engine.expire_aborted_reservation(request["command"])
         if operation == "bind":
             return self.engine.bind(
                 request["binding"], request["authority"], request["project_snapshot"]
+            )
+        if operation == "bind_v2":
+            return self.engine.bind_v2(
+                request["binding"], request["authority"], request["project_snapshot"]
+            )
+        if operation == "bind_v3":
+            return self.engine.bind_v3(
+                request["binding"], request["authority"], request["project_snapshot"]
+            )
+        if operation == "hydrate":
+            if not self.checkpoint_receipt_keys:
+                raise ContextFault("context_hydrate_unavailable")
+            encoded_pack = request["pack"]
+            if (
+                not isinstance(request["grant"], dict)
+                or not isinstance(request["checkpoint_receipt"], dict)
+                or not isinstance(encoded_pack, str)
+            ):
+                raise ContextFault("context_request_schema")
+            grant_bytes = canonical(request["grant"])
+            checkpoint_receipt_bytes = canonical(request["checkpoint_receipt"])
+            if (
+                len(grant_bytes) > MAX_SIGNED_HYDRATE_ENVELOPE
+                or len(checkpoint_receipt_bytes) > MAX_SIGNED_HYDRATE_ENVELOPE
+                or _HYDRATE_REQUEST_FIXED_BYTES
+                + len(grant_bytes)
+                + len(checkpoint_receipt_bytes)
+                + len(encoded_pack)
+                > request_limit
+            ):
+                raise ContextFault("context_request_limit")
+            if len(encoded_pack) > 4 * ((self.max_live_hydrate_pack_bytes + 2) // 3):
+                raise ContextFault("context_request_limit")
+            try:
+                pack = base64.b64decode(encoded_pack, validate=True)
+            except (TypeError, ValueError) as exc:
+                raise ContextFault("context_request_schema") from exc
+            if (
+                len(pack) > self.max_live_hydrate_pack_bytes
+                or base64.b64encode(pack).decode("ascii") != encoded_pack
+            ):
+                raise ContextFault("context_request_limit")
+            if consume_hydrate_pack:
+                # handle() owns its parsed request. Release the large base64
+                # string before decrypting/materializing the checkpoint while
+                # keeping the public in-process dispatch() API non-mutating.
+                request.pop("pack")
+            del encoded_pack
+            return self.engine.hydrate(
+                request["grant"],
+                request["checkpoint_receipt"],
+                pack,
+                self.checkpoint_receipt_keys,
+                snapshot_max_bytes=self.max_live_checkpoint_snapshot_bytes,
             )
         if operation == "append":
             return self.engine.append(
@@ -62,7 +761,16 @@ class ContextService:
                 request["capability"], RetrieveRequestV1.model_validate(request["request"])
             )
         if operation == "checkpoint":
-            return self.engine.checkpoint(request["capability"], request["idempotency_key"])
+            return self.engine.checkpoint(
+                request["capability"],
+                request["idempotency_key"],
+                transport_max_bytes=self.max_live_hydrate_pack_bytes,
+                transport_snapshot_max_bytes=(
+                    self.max_live_checkpoint_snapshot_bytes
+                ),
+            )
+        if operation == "checkpoint_durability":
+            return self.engine.register_checkpoint_durability(request["command"])
         if operation == "seal":
             return self.engine.seal(
                 request["capability"], request["proof"], request["checkpoint_receipt"]
@@ -77,17 +785,102 @@ class ContextService:
             return self.engine.freeze(request["capability"])
         return self.engine.status(request["capability"], request["after"])
 
-    async def handle(self, reader, writer):
+    async def _acquire_request_gate(self, operation: str, writer) -> str:
+        transport = writer.transport
+        transport.pause_reading()
+        if operation in _HEAVY_OPERATIONS:
+            # One active and at most one prefix-only waiter. A third large caller
+            # is rejected before it can fill a StreamReader.
+            if self._heavy_admitted >= 2:
+                raise ContextFault("context_service_busy")
+            self._heavy_admitted += 1
+            try:
+                await self.heavy_gate.acquire()
+            except BaseException:
+                self._heavy_admitted -= 1
+                raise
+            transport.resume_reading()
+            return "heavy"
+        if operation in _BIND_OPERATIONS:
+            if self.bind_gate.locked():
+                raise ContextFault("context_service_busy")
+            await self.bind_gate.acquire()
+            transport.resume_reading()
+            return "bind"
+        await self.small_gate.acquire()
+        transport.resume_reading()
+        return "small"
+
+    def _release_request_gate(self, gate: str | None) -> None:
+        if gate == "heavy":
+            self.heavy_gate.release()
+            self._heavy_admitted -= 1
+        elif gate == "bind":
+            self.bind_gate.release()
+        elif gate == "small":
+            self.small_gate.release()
+
+    async def _read_classified_request(self, reader, writer) -> tuple[bytearray, str, str]:
+        buffer = bytearray()
+        operation: str | None = None
+        gate: str | None = None
+        limit = HEADER_LIMIT
+        deadline = asyncio.get_running_loop().time() + self.io_timeout_seconds
         try:
-            async with self.gate:
-                line = await asyncio.wait_for(reader.readline(), timeout=5)
-                if len(line) > MAX_REQUEST:
+            while True:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise TimeoutError
+                chunk = await asyncio.wait_for(reader.read(65_536), timeout=remaining)
+                if not chunk:
+                    raise ContextFault("context_request_framing")
+                buffer.extend(chunk)
+                if b"\r" in chunk:
+                    raise ContextFault("context_request_framing")
+                newline = buffer.find(b"\n")
+                if newline >= 0 and newline != len(buffer) - 1:
+                    raise ContextFault("context_request_framing")
+                if operation is None:
+                    observed_operation = _top_level_operation(buffer)
+                    if observed_operation is not None:
+                        operation = observed_operation
+                        gate = await self._acquire_request_gate(operation, writer)
+                        limit = (
+                            self.max_hydrate_request
+                            if operation == "hydrate"
+                            else MAX_REQUEST
+                            if operation in _BIND_OPERATIONS
+                            else SMALL_REQUEST_LIMIT
+                        )
+                if len(buffer) > limit + 1:
                     raise ContextFault("context_request_limit")
-                request = json.loads(line)
-                if not isinstance(request, dict):
-                    raise ContextFault("context_request_schema")
-                result = await asyncio.to_thread(self.dispatch, request)
-                response = {"ok": True, "result": result}
+                if newline >= 0:
+                    if operation is None or gate is None:
+                        raise ContextFault("context_request_schema")
+                    return buffer[:-1], operation, gate
+                if operation is None and len(buffer) > HEADER_LIMIT:
+                    raise ContextFault("context_request_limit")
+        except BaseException:
+            self._release_request_gate(gate)
+            raise
+
+    async def handle(self, reader, writer):
+        gate: str | None = None
+        try:
+            frame, classified_operation, gate = await self._read_classified_request(
+                reader, writer
+            )
+            request = _json_no_duplicates(frame)
+            del frame
+            if (
+                not isinstance(request, dict)
+                or request.get("operation") != classified_operation
+            ):
+                raise ContextFault("context_request_schema")
+            result = await asyncio.to_thread(
+                self._dispatch, request, consume_hydrate_pack=True
+            )
+            response = {"ok": True, "result": result}
         except ContextFault as exc:
             response = {"ok": False, "error": exc.code}
         except (ValueError, KeyError, TypeError, ValidationError, TimeoutError):
@@ -97,10 +890,33 @@ class ContextService:
             response = {"ok": False, "error": "context_service_failure"}
         try:
             writer.write(canonical(response) + b"\n")
-            await asyncio.wait_for(writer.drain(), timeout=10)
+            await asyncio.wait_for(
+                writer.drain(), timeout=self.io_timeout_seconds
+            )
         finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            finally:
+                self._release_request_gate(gate)
+
+    def _accept_connection(self, reader, writer) -> None:
+        """Pause at accept time so excess peers cannot fill StreamReader buffers."""
+
+        writer.transport.pause_reading()
+        if len(self._connection_tasks) >= self.max_accepted_connections:
+            writer.write(
+                canonical({"ok": False, "error": "context_service_busy"}) + b"\n"
+            )
             writer.close()
-            await writer.wait_closed()
+            return
+        task = asyncio.create_task(self._handle_accepted_connection(reader, writer))
+        self._connection_tasks.add(task)
+        task.add_done_callback(self._connection_tasks.discard)
+
+    async def _handle_accepted_connection(self, reader, writer) -> None:
+        writer.transport.resume_reading()
+        await self.handle(reader, writer)
 
     async def serve(self, socket_path: str):
         if os.name == "nt":
@@ -125,7 +941,7 @@ class ContextService:
         old = os.umask(0o077)
         try:
             server = await getattr(asyncio, "start_unix_server")(
-                self.handle, path=str(path), limit=MAX_REQUEST + 1
+                self._accept_connection, path=str(path), limit=HEADER_LIMIT
             )
         finally:
             os.umask(old)
@@ -162,11 +978,18 @@ def main() -> None:
     parser.add_argument("--restore-pack")
     parser.add_argument("--restore-grant")
     parser.add_argument("--restore-receipt")
+    parser.add_argument("--restore-result")
     parser.add_argument("--cycle-key-directory")
     parser.add_argument("--benchmark-receipt")
     parser.add_argument("--runtime-build-manifest")
     parser.add_argument("--managed-key-provider-receipt")
     args = parser.parse_args()
+    restore = _restore_requested(
+        args.restore_pack,
+        args.restore_grant,
+        args.restore_receipt,
+        args.restore_result,
+    )
     root = Path(args.credentials)
 
     def public_keys(filename):
@@ -263,17 +1086,19 @@ def main() -> None:
             else None
         ),
     )
-    restore = (args.restore_pack, args.restore_grant, args.restore_receipt)
-    if any(restore):
-        if not all(restore):
-            raise SystemExit("context_restore_config_incomplete")
-        pack_path = Path(args.restore_pack)
-        if pack_path.stat().st_size > profile.max_checkpoint_bytes:
-            raise SystemExit("context_pack_limit")
-        engine.hydrate(
-            json.loads(Path(args.restore_grant).read_text()),
-            json.loads(Path(args.restore_receipt).read_text()),
-            pack_path.read_bytes(),
-            public_keys("context-checkpoint-keys.json"),
+    checkpoint_receipt_keys = public_keys("context-checkpoint-keys.json")
+    if restore:
+        _restore_engine(
+            engine,
+            profile=profile,
+            pack_path=args.restore_pack,
+            grant_path=args.restore_grant,
+            receipt_path=args.restore_receipt,
+            result_path=args.restore_result,
+            receipt_keys=checkpoint_receipt_keys,
         )
-    asyncio.run(ContextService(engine).serve(args.socket))
+    asyncio.run(
+        ContextService(
+            engine, checkpoint_receipt_keys=checkpoint_receipt_keys
+        ).serve(args.socket)
+    )

--- a/aether_context/storage_v2/__init__.py
+++ b/aether_context/storage_v2/__init__.py
@@ -26,8 +26,19 @@ CREATE TABLE IF NOT EXISTS cycles (
  key_ref TEXT, key_version TEXT, retention_class TEXT NOT NULL DEFAULT 'ephemeral',
  hold_reason TEXT, cleanup_state TEXT NOT NULL DEFAULT 'NONE',
  seal_digest TEXT, checkpoint_manifest_checksum TEXT, checkpoint_object_ref_digest TEXT,
+ checkpoint_durability_mode TEXT NOT NULL DEFAULT 'unregistered',
+ checkpoint_durability_legacy INTEGER NOT NULL DEFAULT 0,
+ checkpoint_durability_command_digest TEXT, checkpoint_durability_receipt TEXT,
  cleanup_remote_receipt TEXT, cleanup_operation_key TEXT, cleanup_request_digest TEXT,
- deletion_receipt TEXT,
+ deletion_receipt TEXT, reservation_release_digest TEXT, reservation_release_receipt TEXT,
+ reservation_abort_digest TEXT, reservation_abort_receipt TEXT,
+ reservation_expiry_digest TEXT, reservation_expiry_receipt TEXT,
+ hydrate_command_digest TEXT, hydrate_request_digest TEXT, hydrate_receipt TEXT,
+ reservation_revival_from_revision INTEGER, reservation_revival_kind TEXT,
+ reservation_revival_command_digest TEXT, reservation_revival_receipt_digest TEXT,
+ reservation_revival_no_dispatch_receipt_digest TEXT,
+ reservation_binding_receipt_digest TEXT, reservation_binding_revision INTEGER,
+ reservation_protocol_version INTEGER NOT NULL DEFAULT 1,
  UNIQUE(owner,project,request_key));
 CREATE TABLE IF NOT EXISTS segments (
  cycle TEXT NOT NULL REFERENCES cycles(id), seq INTEGER NOT NULL,
@@ -68,10 +79,31 @@ _CYCLE_COLUMNS = {
     "seal_digest": "TEXT",
     "checkpoint_manifest_checksum": "TEXT",
     "checkpoint_object_ref_digest": "TEXT",
+    "checkpoint_durability_mode": "TEXT NOT NULL DEFAULT 'unregistered'",
+    "checkpoint_durability_legacy": "INTEGER NOT NULL DEFAULT 0",
+    "checkpoint_durability_command_digest": "TEXT",
+    "checkpoint_durability_receipt": "TEXT",
     "cleanup_remote_receipt": "TEXT",
     "cleanup_operation_key": "TEXT",
     "cleanup_request_digest": "TEXT",
     "deletion_receipt": "TEXT",
+    "reservation_release_digest": "TEXT",
+    "reservation_release_receipt": "TEXT",
+    "reservation_abort_digest": "TEXT",
+    "reservation_abort_receipt": "TEXT",
+    "reservation_expiry_digest": "TEXT",
+    "reservation_expiry_receipt": "TEXT",
+    "hydrate_command_digest": "TEXT",
+    "hydrate_request_digest": "TEXT",
+    "hydrate_receipt": "TEXT",
+    "reservation_revival_from_revision": "INTEGER",
+    "reservation_revival_kind": "TEXT",
+    "reservation_revival_command_digest": "TEXT",
+    "reservation_revival_receipt_digest": "TEXT",
+    "reservation_revival_no_dispatch_receipt_digest": "TEXT",
+    "reservation_binding_receipt_digest": "TEXT",
+    "reservation_binding_revision": "INTEGER",
+    "reservation_protocol_version": "INTEGER NOT NULL DEFAULT 1",
 }
 
 
@@ -84,19 +116,71 @@ class SegmentStoreV2:
         with self.connection() as db:
             db.execute("PRAGMA journal_mode=WAL")
             db.executescript(SCHEMA)
-            columns = {row[1] for row in db.execute("PRAGMA table_info(cycles)")}
-            if "snapshot" not in columns:
-                db.execute("ALTER TABLE cycles ADD COLUMN snapshot BLOB")
-                columns.add("snapshot")
-            # SQLite has no transactional ALTER COLUMN operation. Additive,
-            # constant-default columns keep databases created by 0.3.1 readable.
-            for name, declaration in _CYCLE_COLUMNS.items():
-                if name not in columns:
-                    db.execute(f"ALTER TABLE cycles ADD COLUMN {name} {declaration}")
+            # DDL is transactional in SQLite. The durability columns and the
+            # semantic legacy backfill must commit together: after a power loss,
+            # a pre-V2 row is either wholly old or wholly classified as legacy.
+            db.execute("BEGIN IMMEDIATE")
+            try:
+                self._migrate_cycles(db)
+                db.execute("COMMIT")
+            except BaseException:
+                db.execute("ROLLBACK")
+                raise
             if db.execute("PRAGMA quick_check").fetchone()[0] != "ok":
                 raise ContextFault("context_storage_corrupt")
         if os.name != "nt":
             os.chmod(self.path, 0o600)
+
+    @staticmethod
+    def _migrate_cycles(db: sqlite3.Connection) -> None:
+        columns = {row[1] for row in db.execute("PRAGMA table_info(cycles)")}
+        if "snapshot" not in columns:
+            db.execute("ALTER TABLE cycles ADD COLUMN snapshot BLOB")
+            columns.add("snapshot")
+        legacy_durability = "checkpoint_durability_mode" not in columns
+        if legacy_durability:
+            db.execute(
+                "ALTER TABLE cycles ADD COLUMN checkpoint_durability_mode "
+                "TEXT NOT NULL DEFAULT 'unregistered'"
+            )
+            columns.add("checkpoint_durability_mode")
+        if "checkpoint_durability_legacy" not in columns:
+            db.execute(
+                "ALTER TABLE cycles ADD COLUMN checkpoint_durability_legacy "
+                "INTEGER NOT NULL DEFAULT 0"
+            )
+            columns.add("checkpoint_durability_legacy")
+        if legacy_durability:
+            # Rows present before this contract may already reference remote
+            # packs, so only these pre-migration rows receive the legacy marker.
+            db.execute(
+                "UPDATE cycles SET checkpoint_durability_mode='remote_registered',"
+                "checkpoint_durability_legacy=1"
+            )
+        # Additive, constant-default columns keep databases created by 0.3.1
+        # readable by the new daemon.
+        for name, declaration in _CYCLE_COLUMNS.items():
+            if name not in columns:
+                db.execute(f"ALTER TABLE cycles ADD COLUMN {name} {declaration}")
+                columns.add(name)
+        # An old daemon inserting after migration omits the protocol column and
+        # therefore enters the explicit V1 drain path. V1 keeps its historical
+        # remote durability semantics; V2/V3 stay unregistered until a signed
+        # registration is persisted.
+        db.execute("DROP TRIGGER IF EXISTS cycles_unregistered_old_writer")
+        db.execute("DROP TRIGGER IF EXISTS cycles_protocol_durability_default")
+        db.execute(
+            "CREATE TRIGGER cycles_protocol_durability_default "
+            "AFTER INSERT ON cycles WHEN "
+            "NEW.checkpoint_durability_command_digest IS NULL AND "
+            "NEW.checkpoint_durability_receipt IS NULL "
+            "BEGIN UPDATE cycles SET checkpoint_durability_mode="
+            "CASE WHEN NEW.reservation_protocol_version=1 "
+            "THEN 'remote_registered' ELSE 'unregistered' END,"
+            "checkpoint_durability_legacy="
+            "CASE WHEN NEW.reservation_protocol_version=1 THEN 1 ELSE 0 END "
+            "WHERE id=NEW.id; END"
+        )
 
     @contextmanager
     def connection(self):

--- a/bench/hosted_scale.py
+++ b/bench/hosted_scale.py
@@ -9,6 +9,7 @@ envelope and the daemon must trust its independent benchmark key.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import base64
 from concurrent.futures import ThreadPoolExecutor
 import inspect
@@ -18,6 +19,9 @@ import os
 from pathlib import Path
 import sqlite3
 import subprocess
+import socket
+import tempfile
+import threading
 import time
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -29,8 +33,14 @@ import aether_context
 from aether_context.contracts import (
     AppendRequestV1,
     CapabilityV1,
+    ContextBindingCommandV2,
     ContextBindingV1,
+    ContextCheckpointDurabilityCommandV1,
+    ContextHydrateCommandV2,
     ContextProfileV1,
+    ContextReservationCommandV2,
+    ContextReservationReceiptV2,
+    DataPlaneIsolationReceiptV1,
     ExecutorStabilityReceiptV1,
     HostedScaleReceiptV1,
     NamespaceV1,
@@ -46,7 +56,111 @@ from aether_context.crypto import (
 )
 from aether_context.engine import ContextEngine
 from aether_context.retention import FileCycleKeyProvider
-from aether_context.scale import profile_benchmark_digest, run_namespace_isolation
+from aether_context.service import ContextService
+from aether_context.scale import (
+    profile_benchmark_digest,
+    qualify_scale_receipt,
+    run_namespace_isolation,
+)
+from aether_context.scale import runtime_environment_identity, runtime_package_tree_digest
+
+
+class _UnixServiceClient:
+    """Run the real Unix service/parser and issue canonical one-line requests."""
+
+    def __init__(self, service: ContextService):
+        if os.name == "nt":
+            raise RuntimeError("Unix service client is unavailable on Windows")
+        self.service = service
+        self.directory = Path(tempfile.mkdtemp(prefix="aether-context-scale-"))
+        self.path = self.directory / "context.sock"
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.task: asyncio.Task | None = None
+        self.error: BaseException | None = None
+        self.thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        self.loop = loop
+        asyncio.set_event_loop(loop)
+        self.task = loop.create_task(self.service.serve(str(self.path)))
+        try:
+            loop.run_until_complete(self.task)
+        except asyncio.CancelledError:
+            pass
+        except BaseException as exc:  # surfaced synchronously by start()/close()
+            self.error = exc
+        finally:
+            loop.close()
+
+    def start(self) -> "_UnixServiceClient":
+        self.thread.start()
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if self.error is not None:
+                raise SystemExit("live context service failed to start") from self.error
+            if self.path.exists():
+                return self
+            time.sleep(0.01)
+        self.close()
+        raise SystemExit("live context service did not become ready")
+
+    def dispatch(
+        self,
+        request: dict,
+        *,
+        read_chunk_size: int = 1_048_576,
+        read_delay_seconds: float = 0,
+    ) -> dict:
+        frame = canonical(request) + b"\n"
+        chunks: list[bytes] = []
+        size = 0
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(self.service.io_timeout_seconds)
+            client.connect(str(self.path))
+            client.sendall(frame)
+            client.shutdown(socket.SHUT_WR)
+            while True:
+                chunk = client.recv(read_chunk_size)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                size += len(chunk)
+                if size > self.service.max_request + 1_000_000:
+                    raise SystemExit("live context response exceeded its transport bound")
+                if read_delay_seconds:
+                    time.sleep(read_delay_seconds)
+        raw = b"".join(chunks)
+        if not raw.endswith(b"\n") or b"\n" in raw[:-1]:
+            raise SystemExit("live context response framing is invalid")
+        response = json.loads(raw)
+        if not isinstance(response, dict) or set(response) != {"ok", "result"}:
+            if isinstance(response, dict) and response.get("ok") is False:
+                raise SystemExit(f"live context operation failed: {response.get('error')}")
+            raise SystemExit("live context response schema is invalid")
+        if response["ok"] is not True:
+            raise SystemExit("live context operation was not accepted")
+        return response["result"]
+
+    def close(self) -> None:
+        if self.loop is not None and self.task is not None and not self.task.done():
+            self.loop.call_soon_threadsafe(self.task.cancel)
+        if self.thread.is_alive():
+            self.thread.join(timeout=10)
+        if self.thread.is_alive():
+            raise SystemExit("live context service did not stop")
+        if self.error is not None:
+            raise SystemExit("live context service failed") from self.error
+        try:
+            self.directory.rmdir()
+        except FileNotFoundError:
+            pass
+
+    def __enter__(self) -> "_UnixServiceClient":
+        return self.start()
+
+    def __exit__(self, *_exc) -> None:
+        self.close()
 
 
 def _percentile(values: list[int], percentile: int) -> int:
@@ -75,8 +189,17 @@ def _peak_rss_bytes() -> int:
 
         counters = ProcessMemoryCounters()
         counters.cb = ctypes.sizeof(counters)
-        if not ctypes.windll.psapi.GetProcessMemoryInfo(
-            ctypes.windll.kernel32.GetCurrentProcess(),
+        get_current_process = ctypes.windll.kernel32.GetCurrentProcess
+        get_current_process.restype = wintypes.HANDLE
+        get_process_memory_info = ctypes.windll.psapi.GetProcessMemoryInfo
+        get_process_memory_info.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(ProcessMemoryCounters),
+            wintypes.DWORD,
+        ]
+        get_process_memory_info.restype = wintypes.BOOL
+        if not get_process_memory_info(
+            get_current_process(),
             ctypes.byref(counters),
             counters.cb,
         ):
@@ -197,6 +320,22 @@ def run(args: argparse.Namespace) -> dict:
     ):
         target_payload["benchmark_receipt"] = "0" * 64
     target = ContextProfileV1.model_validate(target_payload)
+    if args.receipt_bound_profile_output and (
+        os.name == "nt"
+        or
+        not args.executor_stability_receipt
+        or not args.executor_stability_keys
+        or not getattr(args, "data_plane_isolation_receipt", None)
+        or not getattr(args, "data_plane_isolation_keys", None)
+    ):
+        raise SystemExit(
+            "receipt-bound profile output requires live Unix IPC plus independent "
+            "executor and data-plane isolation receipts"
+        )
+    if args.concurrency != target.max_concurrent_cycles:
+        raise SystemExit(
+            "benchmark concurrency must equal profile max_concurrent_cycles"
+        )
     if target.index_version != sqlite3.sqlite_version:
         raise SystemExit("profile index_version does not match this benchmark runtime")
     # Admission requires evidence, so measurement uses the same limits and
@@ -216,9 +355,34 @@ def run(args: argparse.Namespace) -> dict:
     authority = ReceiptSigner("benchmark-gateway", Ed25519PrivateKey.generate())
     proof = ReceiptSigner("benchmark-proof", Ed25519PrivateKey.generate())
     service = ReceiptSigner("benchmark-contextd", Ed25519PrivateKey.generate())
+    runtime_build = ReceiptSigner(
+        "benchmark-runtime-build", Ed25519PrivateKey.generate()
+    )
     wrapper = EnvelopeCipher(os.urandom(32), domain=b"benchmark-cycle-wrapper/v1")
     provider = FileCycleKeyProvider(args.work_directory / "cycle-keys", wrapper)
     clock = [int(time.time())]
+
+    environment = runtime_environment_identity()
+    data_plane_case_generator_digest = digest(
+        "benchmark-data-plane-case-generator"
+    )
+    runtime_build_manifest = runtime_build.sign(
+        {
+            "schema_version": "ContextRuntimeBuildManifestV3",
+            "distribution": "aether-context",
+            "version": aether_context.__version__,
+            "source_revision": source_revision,
+            "package_tree_digest": runtime_package_tree_digest(
+                require_source_only=True
+            ),
+            "wheel_digest": digest("benchmark-installed-wheel"),
+            "recall_dataset_digest": dataset_digest,
+            "data_plane_case_generator_digest": data_plane_case_generator_digest,
+            "built_at": clock[0],
+            "runtime_environment": environment.model_dump(mode="json"),
+            "locked_environment_digest": digest(environment),
+        }
+    )
 
     def make(path: Path) -> ContextEngine:
         return ContextEngine(
@@ -230,22 +394,31 @@ def run(args: argparse.Namespace) -> dict:
             {proof.key_id: proof.key.public_key()},
             clock=lambda: clock[0],
             cycle_keys=provider,
+            runtime_build_manifest=runtime_build_manifest,
+            runtime_build_keys={runtime_build.key_id: runtime_build.key.public_key()},
         )
 
     started_at = int(time.time())
+    benchmark_signer = ReceiptSigner(
+        args.key_id,
+        Ed25519PrivateKey.from_private_bytes(args.signing_key.read_bytes()),
+    )
     engine = make(database)
-    reservation = engine.reserve(
+    reservation_payload = ContextReservationCommandV2(
+        owner_id="benchmark-owner",
+        project_id="benchmark-project",
+        idempotency_key="hosted-scale",
+        request_digest=digest("hosted-scale"),
+        profile_digest=digest(measured),
+        expires_at=clock[0] + 3600,
+    ).model_dump(mode="json")
+    reservation = engine.reserve_v2(
         authority.sign(
-            {
-                "operation": "reserve",
-                "owner_id": "benchmark-owner",
-                "project_id": "benchmark-project",
-                "idempotency_key": "hosted-scale",
-                "request_digest": digest("hosted-scale"),
-                "profile_digest": digest(measured),
-                "expires_at": clock[0] + 3600,
-            }
+            reservation_payload
         )
+    )
+    reservation_claim = ContextReservationReceiptV2.model_validate(
+        verify(reservation, {service.key_id: service.key.public_key()})
     )
     cycle = reservation["payload"]["context_cycle_id"]
     namespace = NamespaceV1(
@@ -281,7 +454,33 @@ def run(args: argparse.Namespace) -> dict:
         created_at=clock[0],
         expires_at=clock[0] + 604800,
     )
-    engine.bind(authority.sign(binding.model_dump()), authority_payload, project_snapshot)
+    binding_command = ContextBindingCommandV2(
+        binding=binding,
+        reservation_receipt=reservation,
+        expected_reservation_revision=reservation_claim.revision,
+    )
+    engine.bind_v2(
+        authority.sign(binding_command.model_dump(mode="json")),
+        authority_payload,
+        project_snapshot,
+    )
+    with engine.store.connection() as db:
+        durability_revision = db.execute(
+            "SELECT revision FROM cycles WHERE id=?", (cycle,)
+        ).fetchone()[0]
+    durability_command = authority.sign(
+        ContextCheckpointDurabilityCommandV1(
+            namespace=namespace,
+            idempotency_key="hosted-scale-durability",
+            expected_revision=durability_revision,
+            mode="remote_registered",
+            issued_at=clock[0],
+            expires_at=clock[0] + 900,
+        ).model_dump(mode="json")
+    )
+    durability_receipt = engine.register_checkpoint_durability(
+        durability_command
+    )
 
     def capability(role: str = "worker", fence: int = 1) -> dict:
         return authority.sign(
@@ -304,6 +503,18 @@ def run(args: argparse.Namespace) -> dict:
         )
 
     cap = capability()
+    source_service = ContextService(engine)
+    source_ipc = (
+        _UnixServiceClient(source_service).start() if os.name != "nt" else None
+    )
+
+    def source_dispatch(request: dict) -> dict:
+        return (
+            source_ipc.dispatch(request)
+            if source_ipc is not None
+            else source_service.dispatch(request)
+        )
+
     target_records = max(math.ceil(measured.max_records * 0.9), len(dataset["records"]))
     target_bytes = math.ceil(measured.max_indexed_bytes * 0.9)
     if target_records > measured.max_records:
@@ -330,13 +541,17 @@ def run(args: argparse.Namespace) -> dict:
         nonlocal appended_count
         if appended_count and appended_count % max(1, measured.max_calls_per_minute - 1) == 0:
             clock[0] += 60
-        result = engine.append(
-            cap,
-            AppendRequestV1(
+        append_request = AppendRequestV1(
                 idempotency_key=f"measure-{identifier}",
                 text=text,
                 action_ref=f"measure-{identifier}",
-            ),
+            )
+        result = source_dispatch(
+            {
+                "operation": "append",
+                "capability": cap,
+                "request": append_request.model_dump(mode="json"),
+            }
         )
         appended_count += 1
         return result["payload"]["record_id"]
@@ -354,14 +569,18 @@ def run(args: argparse.Namespace) -> dict:
     def retrieve(item: tuple[int, dict]) -> tuple[int, bool]:
         index, query = item
         began = time.perf_counter_ns()
-        result = engine.retrieve(
-            cap,
-            RetrieveRequestV1(
+        retrieve_request = RetrieveRequestV1(
                 turn_id="dataset-" + query["id"],
                 query=query["query"],
                 native_window=max(1024, measured.max_capsule_tokens * 8),
                 remaining_prompt_budget=measured.max_capsule_tokens,
-            ),
+            )
+        result = source_dispatch(
+            {
+                "operation": "retrieve",
+                "capability": cap,
+                "request": retrieve_request.model_dump(mode="json"),
+            }
         )["payload"]
         elapsed = math.ceil((time.perf_counter_ns() - began) / 1_000_000)
         found_ids = {entry["metadata"]["record_id"] for entry in result["entries"]}
@@ -377,36 +596,108 @@ def run(args: argparse.Namespace) -> dict:
     recall = sum(1 for _, found in samples if found)
 
     checkpoint_started = time.perf_counter_ns()
-    checkpoint = engine.checkpoint(capability("durability"), "hosted-scale-checkpoint")
+    checkpoint = source_dispatch(
+        {
+            "operation": "checkpoint",
+            "capability": capability("durability"),
+            "idempotency_key": "hosted-scale-checkpoint",
+        }
+    )
     checkpoint_ms = math.ceil((time.perf_counter_ns() - checkpoint_started) / 1_000_000)
+    if source_ipc is not None:
+        source_ipc.close()
     receipt_payload = checkpoint["receipt"]["payload"]
     grant = authority.sign(
-        {
-            "operation": "hydrate",
-            "namespace": namespace.model_dump(),
-            "manifest_checksum": receipt_payload["manifest_checksum"],
-            "key_ref": receipt_payload["key_ref"],
-            "key_provider": receipt_payload["key_provider"],
-            "key_version": receipt_payload["key_version"],
-            "fence": 2,
-            "expires_at": clock[0] + 3600,
-        }
+        ContextHydrateCommandV2(
+            namespace=namespace,
+            manifest_checksum=receipt_payload["manifest_checksum"],
+            key_ref=receipt_payload["key_ref"],
+            key_provider=receipt_payload["key_provider"],
+            key_version=receipt_payload["key_version"],
+            fence=2,
+            expected_source_revision=source_revision,
+            issued_at=clock[0],
+            expires_at=clock[0] + 900,
+        ).model_dump(mode="json")
     )
     replacement = make(replacement_database)
     hydrate_started = time.perf_counter_ns()
-    hydrate_receipt = replacement.hydrate(
-        grant,
-        checkpoint["receipt"],
-        base64.b64decode(checkpoint["pack"], validate=True),
-        {service.key_id: service.key.public_key()},
+    replacement_service = ContextService(
+        replacement,
+        checkpoint_receipt_keys={service.key_id: service.key.public_key()},
     )
+    hydrate_request = {
+        "operation": "hydrate",
+        "grant": grant,
+        "checkpoint_receipt": checkpoint["receipt"],
+        "pack": checkpoint["pack"],
+    }
+    if os.name == "nt":
+        hydrate_receipt = replacement_service.dispatch(hydrate_request)
+    else:
+        with _UnixServiceClient(replacement_service) as replacement_ipc:
+            hydrate_receipt = replacement_ipc.dispatch(hydrate_request)
     hydrate_ms = math.ceil((time.perf_counter_ns() - hydrate_started) / 1_000_000)
+    hydrate_payload = verify(
+        hydrate_receipt, {service.key_id: service.key.public_key()}
+    )
+    if (
+        hydrate_payload.get("schema_version") != "ContextHydrateReceiptV2"
+        or hydrate_payload.get("checkpoint_durability_registration_receipt_digest")
+        != digest(
+            hydrate_payload.get("checkpoint_durability_registration_receipt")
+        )
+        or hydrate_payload.get("checkpoint_durability_registration_receipt") is None
+        or digest(durability_receipt)
+        != hydrate_payload["checkpoint_durability_registration_receipt"]["payload"].get(
+            "source_registration_receipt_digest"
+        )
+    ):
+        raise SystemExit("hydrate did not return the exact durability re-attestation chain")
     rebuild_started = time.perf_counter_ns()
     rebuild_receipt = replacement.rebuild_index(
         capability("durability", fence=2), "hosted-scale-index-rebuild"
     )
     rebuild_ms = math.ceil((time.perf_counter_ns() - rebuild_started) / 1_000_000)
-    isolation = run_namespace_isolation()
+    isolation_envelope = None
+    isolation_keys = None
+    isolation_receipt_path = getattr(args, "data_plane_isolation_receipt", None)
+    isolation_keys_path = getattr(args, "data_plane_isolation_keys", None)
+    if isolation_receipt_path:
+        isolation_envelope = json.loads(
+            isolation_receipt_path.read_text(encoding="utf-8")
+        )
+        isolation_keys = _public_keys(isolation_keys_path)
+        require_disjoint_keys(
+            {benchmark_signer.key_id: benchmark_signer.key.public_key()},
+            isolation_keys,
+        )
+        try:
+            isolation_claim = DataPlaneIsolationReceiptV1.model_validate(
+                verify(isolation_envelope, isolation_keys)
+            )
+        except (ValueError, TypeError) as exc:
+            raise SystemExit("data-plane isolation receipt is invalid") from exc
+        if (
+            isolation_claim.source_revision != source_revision
+            or isolation_claim.profile_benchmark_digest
+            != profile_benchmark_digest(target)
+            or isolation_claim.case_generator_digest
+            != data_plane_case_generator_digest
+            or not isolation_claim.issued_at <= clock[0] < isolation_claim.expires_at
+        ):
+            raise SystemExit(
+                "data-plane isolation receipt does not bind this benchmark"
+            )
+        isolation = {
+            "cases": isolation_claim.cases,
+            "unauthorized_records": isolation_claim.unauthorized_records,
+            "result_digest": isolation_claim.result_digest,
+        }
+        isolation_evidence_class = "data_plane"
+    else:
+        isolation = run_namespace_isolation()
+        isolation_evidence_class = "predicate"
     with engine.store.connection() as db:
         indexed = db.execute(
             "SELECT cursor,bytes FROM cycles WHERE id=?", (cycle,)
@@ -415,9 +706,6 @@ def run(args: argparse.Namespace) -> dict:
     finished_at = int(time.time())
     if _git_source(repository) != source_revision:
         raise SystemExit("source revision changed during benchmark")
-    benchmark_signer = ReceiptSigner(
-        args.key_id, Ed25519PrivateKey.from_private_bytes(args.signing_key.read_bytes())
-    )
     stability_envelope = None
     executor_stable = False
     if args.executor_stability_receipt:
@@ -470,7 +758,8 @@ def run(args: argparse.Namespace) -> dict:
         isolation_cases=isolation["cases"],
         unauthorized_records=isolation["unauthorized_records"],
         isolation_result_digest=isolation["result_digest"],
-        isolation_evidence_class="predicate",
+        isolation_evidence_class=isolation_evidence_class,
+        data_plane_isolation_receipt=isolation_envelope,
         executor_stable=executor_stable,
         executor_stability_receipt=stability_envelope,
         started_at=started_at,
@@ -482,6 +771,28 @@ def run(args: argparse.Namespace) -> dict:
     args.output.write_bytes(canonical(envelope) + b"\n")
     if args.receipt_bound_profile_output:
         receipt_bound = target.model_copy(update={"benchmark_receipt": digest(envelope)})
+        qualification = qualify_scale_receipt(
+            receipt_bound,
+            envelope,
+            {benchmark_signer.key_id: benchmark_signer.key.public_key()},
+            now=finished_at,
+            expected_source_revision=source_revision,
+            expected_recall_dataset_digest=dataset_digest,
+            expected_data_plane_case_generator_digest=(
+                data_plane_case_generator_digest
+            ),
+            executor_stability_keys=(
+                _public_keys(args.executor_stability_keys)
+                if args.executor_stability_keys
+                else None
+            ),
+            data_plane_isolation_keys=isolation_keys,
+        )
+        if not qualification.valid:
+            raise SystemExit(
+                "receipt-bound profile requires fully qualifying evidence: "
+                + ",".join(qualification.failures)
+            )
         args.receipt_bound_profile_output.write_bytes(
             canonical(receipt_bound.model_dump()) + b"\n"
         )
@@ -500,6 +811,8 @@ def main() -> None:
     parser.add_argument("--receipt-bound-profile-output", type=Path)
     parser.add_argument("--executor-stability-receipt", type=Path)
     parser.add_argument("--executor-stability-keys", type=Path)
+    parser.add_argument("--data-plane-isolation-receipt", type=Path)
+    parser.add_argument("--data-plane-isolation-keys", type=Path)
     parser.add_argument("--retrieval-samples", type=int, default=20)
     parser.add_argument("--concurrency", type=int, default=8)
     parser.add_argument("--validity-seconds", type=int, default=604800)
@@ -510,6 +823,8 @@ def main() -> None:
         parser.error("--validity-seconds must be between 60 and 604800")
     if bool(args.executor_stability_receipt) != bool(args.executor_stability_keys):
         parser.error("executor stability receipt and key map must be supplied together")
+    if bool(args.data_plane_isolation_receipt) != bool(args.data_plane_isolation_keys):
+        parser.error("data-plane isolation receipt and key map must be supplied together")
     run(args)
 
 

--- a/deploy/aether-contextd.service
+++ b/deploy/aether-contextd.service
@@ -11,6 +11,7 @@ RuntimeDirectoryMode=0750
 StateDirectory=aether-context
 StateDirectoryMode=0700
 UMask=0077
+Environment=PYTHONDONTWRITEBYTECODE=1
 LoadCredential=context-dek:/etc/aether/context/credentials/context-dek
 LoadCredential=context-cycle-wrapper-key:/etc/aether/context/credentials/context-cycle-wrapper-key
 LoadCredential=context-signing-key:/etc/aether/context/credentials/context-signing-key
@@ -24,7 +25,7 @@ LoadCredential=context-data-plane-isolation-keys.json:/etc/aether/context/creden
 LoadCredential=context-benchmark-receipt.json:/etc/aether/context/credentials/context-benchmark-receipt.json
 LoadCredential=context-runtime-build-keys.json:/etc/aether/context/credentials/context-runtime-build-keys.json
 LoadCredential=context-runtime-build-manifest.json:/etc/aether/context/credentials/context-runtime-build-manifest.json
-ExecStart=/opt/aether-context/venv/bin/aether-contextd --socket /run/aether-context/context.sock --database /var/lib/aether-context/context.sqlite3 --profile /etc/aether/context/profile.json --credentials ${CREDENTIALS_DIRECTORY} --cycle-key-directory /var/lib/aether-context/cycle-keys --benchmark-receipt ${CREDENTIALS_DIRECTORY}/context-benchmark-receipt.json --runtime-build-manifest ${CREDENTIALS_DIRECTORY}/context-runtime-build-manifest.json
+ExecStart=/opt/aether-context/venv/bin/python -I -S -B /opt/aether-context/venv/lib/python3.12/site-packages/aether_context/guard.py --socket /run/aether-context/context.sock --database /var/lib/aether-context/context.sqlite3 --profile /etc/aether/context/profile.json --credentials ${CREDENTIALS_DIRECTORY} --cycle-key-directory /var/lib/aether-context/cycle-keys --benchmark-receipt ${CREDENTIALS_DIRECTORY}/context-benchmark-receipt.json --runtime-build-manifest ${CREDENTIALS_DIRECTORY}/context-runtime-build-manifest.json
 Restart=on-failure
 RestartSec=5
 NoNewPrivileges=yes

--- a/docs/HOSTED_CONTEXT.md
+++ b/docs/HOSTED_CONTEXT.md
@@ -8,7 +8,7 @@ lexical implementation; it does not establish a billion-token capacity claim.
 
 Install this exact source revision with `pip install '.[dev]'`. Run `ruff check
 aether_context tests`, `python -m mypy aether_context`, and `python -m pytest -q`.
-Run `python -m scripts.export_hosted_schema` to regenerate the twenty-one closed wire
+Run `python -m scripts.export_hosted_schema` to regenerate the closed wire
 schemas. Signed interoperability fixtures are synthetic and never deployment
 or promotion credentials.
 
@@ -24,6 +24,36 @@ The daemon signs receipts. An independent verifier signs closure proofs. Each
 key has a distinct role; worker/model text cannot mint any of these identities.
 Ed25519 signatures cover canonical UTF-8 JSON with ASCII keys and safe integers.
 Floats, unknown fields and unpaired surrogates are rejected.
+
+A `reserve_v2` reservation receipt carries the current cycle revision. The
+original `reserve` operation and `ContextReservationReceiptV1` keep their exact
+rolling wire shape. If one-use
+authorization fails before objective dispatch starts, Gateway may submit a
+signed `ContextReservationReleaseCommandV1` through the
+`release_reservation` IPC operation. The closed command binds owner, project,
+idempotency key, request/profile digests, reservation revision, a digest of the
+authorization-failure receipt and the literal assertion `dispatch_started=false`.
+The daemon releases only an exact never-bound reservation. Exact retries return
+the persisted signed receipt, including after command expiry; a different proof
+conflicts. A new signed `ContextReservationCommandV2` may revive the same cycle
+only when it commits the exact released revision. The corresponding `bind_v2`
+command embeds that signed revisioned receipt, so a delayed pre-release bind
+cannot bind the revived attempt. Once binding exists, an old release cannot
+change the cycle.
+
+Two separate signed terminals cover the remaining never-bound cases. After
+objective dispatch starts, `abort_reservation` embeds the exact daemon-signed
+V2/V3 reservation receipt and the Gateway dispatch receipt digest, then moves
+only that clean reservation to `ABORTED`; `expire_aborted_reservation` later
+emits its unregistered V2 deletion receipt. If dispatch never starts, Cloud
+first atomically seals its generation-bound dispatch fence and signs the exact
+`ContextInvocationNoDispatchSnapshotV1`. `expire_reservation` verifies that
+snapshot, its digest, the exact V2/V3 reservation receipt and current revision
+before moving the empty row to `EXPIRED`. Only this no-dispatch terminal is
+revivable: `reserve_v3` embeds the prior expiry receipt and returns a signed V3
+receipt carrying the expiry, fence and revival-command digests; `bind_v3`
+requires that exact receipt. Delayed commands from any earlier generation fail
+their revision or lineage checks.
 
 SQLite WAL/FULL transactions commit encrypted segments, HMAC lexical postings,
 chain roots, operations and content-free events together. AES-GCM binds each
@@ -49,6 +79,28 @@ receipt, and receive a new fence. Its signed hydrate receipt binds the manifest,
 checkpoint number, cursor, chain root, key reference, replay digest and fence.
 Legacy unkeyed packs remain readable with the original context key. A restored
 SEALING cycle cannot reopen worker writes.
+
+Gateway registers one immutable checkpoint policy before the first pack with
+the `checkpoint_durability` IPC operation and a signed
+`ContextCheckpointDurabilityCommandV1`. `local_ephemeral` is the Gate 8 steps
+1–3 mode: the separate signed registration receipt carries that mode, hydrate is denied, and expiry
+rejects remote-deletion evidence because the pack was never registered for
+remote persistence. Fresh V2/V3 cycles remain `unregistered` and cannot
+checkpoint until this signed registration is stored. The unchanged V1 reserve
+path deliberately creates `remote_registered` legacy rows so an old client can
+checkpoint, seal and restart while a deployment drains it. Rows that existed
+before the durability column, including inserts from an old V1 writer, are
+conservatively classified the same way. V1 is deprecated and cannot qualify the
+new hosted protocol gates: deploy the new daemon first, drain or upgrade every
+V1 client, and only then require V2/V3 capability negotiation. `remote_registered` is the
+step 4+ mode: any checkpoint requires an exact,
+independently signed remote-deletion receipt before managed-key destruction.
+The registration is revision-bound, idempotent and immutable for the cycle. A
+new checkpoint pack carries the exact signed registration evidence. Hydrate
+verifies that evidence with the checkpoint trust roots, then stores a
+replacement-host reattestation. A V2 deletion receipt for any nonlegacy cycle
+binds that stored registration-receipt digest; only truly old remote rows emit
+the original V1 deletion shape.
 
 The V1 rolling boundary is deliberate. A pre-retention V1 binding that omits
 `retention_class` is interpreted as `ephemeral`, while its original signed JSON
@@ -80,13 +132,42 @@ Credential names: `context-dek`, `context-cycle-wrapper-key` (32 bytes each),
 `context-executor-stability-keys.json`, and
 `context-data-plane-isolation-keys.json` (key-ID to base64 public-key maps).
 `context-runtime-build-keys.json` verifies
-`context-runtime-build-manifest.json`, which binds the source revision, wheel
-digest, approved recall-dataset digest and a digest of every installed runtime
-source/schema byte. `wheel_digest` is signed supply-chain provenance; the daemon
-enforces a digest of the exact imported package-tree bytes because it does not
-independently retain or reconstruct the wheel archive. A deployment that needs
-wheel-byte enforcement must supply a separately authenticated wheel artifact and
-verifier.
+`context-runtime-build-manifest.json`. Production uses
+`ContextRuntimeBuildManifestV3`, which binds the source revision, wheel digest,
+approved recall-dataset digest, imported package-tree digest, actual import-root
+digest, Python executable digest and ABI, SQLite version, and exact versions and
+RECORD-verified artifact digests for the complete hosted import closure:
+annotated-types, cffi, cryptography, numpy, pydantic, pydantic-core, pycparser,
+typing-inspection, and typing-extensions. Generate the `RuntimeEnvironmentV2`
+payload after installing the final wheel in its final
+immutable virtual environment with `runtime_environment_identity()`, set
+`locked_environment_digest` to `digest(environment)`, and sign the complete V3
+manifest with the independent build key. V1/V2 manifests remain parseable for
+rollback, but `runtime_environment_unbound` keeps hosted readiness off.
+
+The qualified virtual environment is an intentionally minimal runtime, not an
+ordinary development venv. Create it with `python3.12 -m venv --copies` so the
+qualified interpreter path is not a symlink. Install the final wheel with `--no-compile`, remove
+installer-only distributions such as pip, setuptools, and wheel, remove every
+`__pycache__`, and make the interpreter, virtual-environment parents, package
+tree, metadata, and manifest credentials root-owned and non-writable by the
+service user before signing. Every importable top-level path must belong to the
+signed closure; an optional dependency must either be absent or appear in that
+closure with its exact version and complete RECORD artifact digest. The system
+Python standard-library and dynamic-library roots are part of the host trust
+base: they must also be root-owned, non-writable, and supplied by the approved
+immutable host image because the guard necessarily imports stdlib code while
+bootstrapping.
+
+The systemd unit executes the installed `aether_context/guard.py` directly with
+`python -I -S -B`. That stdlib-only guard authenticates the V3 manifest with its
+Ed25519 build key before trusting the declared closure, checks the immutable
+path and wheel RECORDs, rejects bytecode, package/native collisions, symlinks,
+unlocked import roots, and artifact drift, and only then adds site-packages and
+imports the daemon. Startup and explicit health or reservation admission
+remeasure the complete environment. Other admission paths reuse that full
+attestation for at most 60 seconds, remeasure it after expiry, and still check
+disk headroom on every call.
 The manifest also pins the approved hosted data-plane case-generator digest;
 older manifests without that field remain readable but cannot enable reach. An
 operator environment string cannot qualify a build.
@@ -94,17 +175,36 @@ operator environment string cannot qualify a build.
 benchmark, executor-stability, deletion, Gateway, verifier and service keys
 must be cryptographically distinct, including when their key IDs differ. The
 profile JSON must pin the deployed SQLite version and benchmark-envelope digest.
-Supply all three
-`--restore-pack`, `--restore-grant`, and `--restore-receipt` options together
-for a recovery start; none of these paths may be chosen by a worker.
+Supply all four `--restore-pack`, `--restore-grant`, `--restore-receipt`, and
+`--restore-result` options together for a recovery start; none of these paths
+may be chosen by a worker. The result is the signed `ContextHydrateReceiptV1`
+for a legacy grant or `ContextHydrateReceiptV2` for the closed, source-bound V2
+hydrate command, encoded as one canonical JSON line. It is published atomically with mode 0600
+before the daemon begins serving. Replaying the same recovery accepts the exact
+existing result, while a different pre-existing result fails closed.
+
+An already running replacement daemon exposes the same operation through the
+private socket as the exact request `{"operation":"hydrate","grant":...,
+"checkpoint_receipt":...,"pack":"<canonical-base64>"}`. Checkpoint signer
+keys come only from the daemon's `context-checkpoint-keys.json`; the caller
+cannot supply trust roots. `ContextHealthV3` advertises the active emitted-pack
+ceiling. The current copy-based transport admits at most 13,000,000 decoded
+bytes and separately bounds decrypted checkpoint materialization at 16,000,000
+bytes. Both the socket and startup recovery paths enforce those limits before
+any database effect; the unchanged V1 profile can remain wider for direct,
+non-daemon use. The encoded request uses the daemon's derived large-request limit. Exact
+retries return the same signed hydrate receipt. A terminal, advanced or
+incomplete restored cycle conflicts instead of reporting recovery success.
 
 Do not delete an active or unsealed pool for disk reclamation. Freeze, checkpoint,
 remotely verify, fence and restore according to the cloud runbook. The signed
 retention API supports idempotent legal/audit holds, releases and expiry. Default
 raw retention is 24 hours after seal and the profile rejects values above seven
-days. When a checkpoint exists, secure expiry first verifies an independently
-signed, short-lived remote object deletion receipt against the exact namespace,
-latest checkpoint checksum and authority-bound object reference. It then destroys
+days. When a remotely registered checkpoint exists, secure expiry first verifies
+an independently signed, short-lived remote object deletion receipt against the
+exact namespace, latest checkpoint checksum and authority-bound object reference.
+A locally ephemeral checkpoint rejects remote evidence and proceeds directly to
+local cleanup and managed-key destruction. It then destroys
 the managed cycle key only through a currently qualified shared provider. A
 closed, independently signed KMS destruction receipt must bind the exact
 provider, opaque key reference, namespace digest, key version and destroyed
@@ -137,12 +237,23 @@ cross that gate.
 Health reports `managed_key_provider_receipt_digests` keyed by qualified key
 version. The older singular `managed_key_provider_receipt_digest` remains
 populated only when exactly one version is qualified.
+`ContextHealthV1` preserves its original rolling response. `ContextHealthV2`
+adds the observed package-tree digest, locked environment digest, Python
+executable/ABI identity, dependency versions and artifact digests, SQLite
+version, import-root digest and bytecode policy. Admission can compare those
+values with the signed build manifest and data-plane case-generator identity as
+one exact build tuple; a live measurement error returns a closed `ready=false`
+V2 response. `ContextHealthV3` adds the guarded deployment-lock import closure,
+the exact ordered protocol capability set, protocol version 3 and the active
+live IPC checkpoint-pack ceiling. New Cloud callers negotiate this V3 evidence
+before sending V2/V3 lifecycle or hydrate operations.
 
 ## Measured limits and remaining release gates
 
 Defaults: 10,000 records, 64 MB indexed plaintext, 32 KiB per record, 8 MB pinned
 snapshot, 4,096 capsule tokens, 256 candidates, four active cycles per owner and
-600 append/retrieve calls per minute. The profile is immutable after binding.
+600 append/retrieve calls per minute. The V1 checkpoint default remains 64 MB;
+live IPC uses the smaller health-advertised ceiling above. The profile is immutable after binding.
 Operation and checkpoint quotas are independent; snapshots are full bounded
 packs rather than streaming deltas. Larger profiles require new measurements.
 
@@ -163,13 +274,17 @@ python -m bench.hosted_scale \
   --signing-key /run/credentials/scale-signing-key --key-id scale-v1 \
   --executor-stability-receipt /run/evidence/executor-stability.json \
   --executor-stability-keys /run/credentials/executor-stability-keys.json \
+  --data-plane-isolation-receipt /run/evidence/data-plane-isolation.json \
+  --data-plane-isolation-keys /run/credentials/data-plane-isolation-keys.json \
   --output /run/evidence/hosted-scale-receipt.json \
   --receipt-bound-profile-output /run/evidence/hosted-profile.json
 ```
 
-The harness never manufactures executor stability. Without a separately signed
-`ContextExecutorStabilityReceiptV1`, it records `executor_stable=false`, so the
-result cannot enable reach. Qualification verifies that independent receipt,
+The harness never manufactures executor stability or data-plane isolation.
+Without both separately signed receipts, it emits provisional evidence and
+refuses `--receipt-bound-profile-output`, so the result cannot enable reach. On
+Linux, checkpoint and replacement hydrate measurements traverse the real private
+Unix socket and its JSON/base64 framing. Qualification verifies those independent receipts,
 the signed runtime build, approved dataset digest, representative capacity,
 memory, latency, recovery and recall thresholds. The local million-case result
 is labeled `predicate` and is deliberately nonqualifying. A separate randomized,

--- a/scripts/export_hosted_schema.py
+++ b/scripts/export_hosted_schema.py
@@ -1,35 +1,95 @@
-"""Regenerate the closed hosted wire schemas."""
+"""Regenerate or verify the closed hosted wire schemas."""
 
+from __future__ import annotations
+
+import argparse
 import json
 from pathlib import Path
+
 from aether_context import contracts
 
-names = [
+
+NAMES = [
     "NamespaceV1",
     "ContextRequestV1",
+    "ContextReservationReceiptV1",
+    "ContextReservationCommandV2",
+    "ContextReservationReceiptV2",
+    "ContextReservationCommandV3",
+    "ContextReservationReceiptV3",
+    "ContextReservationReleaseCommandV1",
+    "ContextReservationReleaseReceiptV1",
+    "ContextReservationAbortCommandV1",
+    "ContextReservationAbortReceiptV1",
+    "ContextReservationAbortExpiryCommandV1",
+    "ContextInvocationNoDispatchSnapshotV1",
+    "ContextInvocationNoDispatchReceiptV1",
+    "ContextReservationExpiryCommandV1",
+    "ContextReservationExpiryReceiptV1",
+    "ContextCheckpointDurabilityCommandV1",
+    "ContextCheckpointDurabilityReceiptV1",
+    "ContextCheckpointDurabilityReceiptV2",
     "ContextProfileV1",
     "ContextBindingV1",
     "CapabilityV1",
     "SignedV1",
+    "ContextBindingCommandV2",
+    "ContextBindingCommandV3",
     "PromotionCandidateV1",
     "ContextCheckpointReceiptV1",
+    "ContextHydrateCommandV2",
+    "ContextHealthV1",
+    "ContextHealthV2",
+    "ContextHealthV3",
     "ContextHydrateReceiptV1",
+    "ContextHydrateReceiptV2",
     "ContextFreezeReceiptV1",
     "AppendRequestV1",
     "RetrieveRequestV1",
     "RemoteDeletionReceiptV1",
     "RetentionCommandV1",
+    "ContextRetentionReceiptV1",
     "ManagedKeyProviderReceiptV1",
     "KeyDestructionReceiptV1",
+    "ContextLocalKeyDestructionV1",
+    "ContextDeletionReceiptV1",
+    "ContextDeletionReceiptV2",
     "RuntimeBuildManifestV1",
+    "RuntimeEnvironmentV1",
+    "RuntimeBuildManifestV2",
+    "RuntimeEnvironmentV2",
+    "RuntimeBuildManifestV3",
     "ExecutorStabilityReceiptV1",
     "DataPlaneIsolationReceiptV1",
     "HostedScaleReceiptV1",
     "ClosureProofV1",
 ]
-path = Path(__file__).resolve().parents[1] / "aether_context/contracts/schema-v1.json"
-path.write_text(
-    json.dumps({name: getattr(contracts, name).model_json_schema() for name in names}, indent=2)
-    + "\n",
-    encoding="utf-8",
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1] / "aether_context/contracts/schema-v1.json"
 )
+
+
+def render_schema() -> str:
+    return (
+        json.dumps(
+            {name: getattr(contracts, name).model_json_schema() for name in NAMES},
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    rendered = render_schema()
+    if args.check:
+        if SCHEMA_PATH.read_text(encoding="utf-8") != rendered:
+            raise SystemExit("hosted schema is stale")
+        return
+    SCHEMA_PATH.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_context_restore_result.py
+++ b/tests/test_context_restore_result.py
@@ -1,0 +1,654 @@
+"""Crash-safe handoff of startup hydrate evidence to the host coordinator."""
+
+from concurrent.futures import ThreadPoolExecutor
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import stat
+
+import pytest
+
+from aether_context.contracts import (
+    AppendRequestV1,
+    ContextHydrateReceiptV1,
+    LIVE_IPC_MAX_CHECKPOINT_BYTES,
+    canonical,
+)
+from aether_context.crypto import ContextFault, verify
+from aether_context.service import (
+    SMALL_REQUEST_LIMIT,
+    MAX_SIGNED_HYDRATE_ENVELOPE,
+    MAX_LOCAL_IO_TIMEOUT_SECONDS,
+    MIN_LOCAL_IO_BYTES_PER_SECOND,
+    ContextService,
+    _restore_engine,
+    _restore_requested,
+    _write_restore_result_once,
+)
+from test_hosted_context import hosted  # noqa: F401
+
+
+def _restore_material(hosted, tmp_path):  # noqa: F811
+    engine, cap, _, binding, authority, _, make, _ = hosted
+    engine.append(
+        cap(),
+        AppendRequestV1(
+            idempotency_key="restore-result-record",
+            text="needle durable recovery result",
+            action_ref="restore-result-test",
+        ),
+    )
+    checkpoint = engine.checkpoint(cap(role="durability"), "restore-result-checkpoint")
+    claim = checkpoint["receipt"]["payload"]
+    grant = authority.sign(
+        {
+            "operation": "hydrate",
+            "namespace": binding.namespace.model_dump(),
+            "manifest_checksum": claim["manifest_checksum"],
+            "fence": 2,
+            "expires_at": 1900,
+        }
+    )
+    pack_path = tmp_path / "checkpoint.enc"
+    grant_path = tmp_path / "grant.json"
+    receipt_path = tmp_path / "checkpoint-receipt.json"
+    pack_path.write_bytes(base64.b64decode(checkpoint["pack"], validate=True))
+    grant_path.write_bytes(canonical(grant))
+    receipt_path.write_bytes(canonical(checkpoint["receipt"]))
+    return {
+        "original": engine,
+        "replacement": make(tmp_path / "replacement.sqlite3"),
+        "profile": engine.profile,
+        "pack_path": pack_path,
+        "grant_path": grant_path,
+        "receipt_path": receipt_path,
+        "result_path": tmp_path / "hydrate-result.json",
+        "receipt_keys": {engine.signer.key_id: engine.signer.key.public_key()},
+    }
+
+
+def _restore(item):
+    return _restore_engine(
+        item["replacement"],
+        profile=item["profile"],
+        pack_path=str(item["pack_path"]),
+        grant_path=str(item["grant_path"]),
+        receipt_path=str(item["receipt_path"]),
+        result_path=str(item["result_path"]),
+        receipt_keys=item["receipt_keys"],
+    )
+
+
+def test_restore_requires_all_input_paths_and_result_path():
+    assert _restore_requested(None, None, None, None) is False
+    assert _restore_requested("pack", "grant", "receipt", "result") is True
+    for missing in range(4):
+        paths = ["pack", "grant", "receipt", "result"]
+        paths[missing] = None
+        with pytest.raises(SystemExit, match="context_restore_config_incomplete"):
+            _restore_requested(*paths)
+
+
+def test_signed_restore_result_is_atomic_and_lost_ack_replay_is_exact(hosted, tmp_path):  # noqa: F811
+    item = _restore_material(hosted, tmp_path)
+
+    first = _restore(item)
+    first_info = item["result_path"].stat()
+    first_bytes = item["result_path"].read_bytes()
+    assert first_bytes == canonical(first) + b"\n"
+    if os.name != "nt":
+        assert stat.S_IMODE(first_info.st_mode) == 0o600
+    payload = verify(first, item["receipt_keys"])
+    assert ContextHydrateReceiptV1.model_validate(payload).model_dump(mode="json") == payload
+    assert payload["manifest_checksum"] == json.loads(
+        item["receipt_path"].read_text()
+    )["payload"]["manifest_checksum"]
+    assert payload["checkpoint_number"] == 1
+    assert payload["fence"] == 2
+
+    # Simulate Cloud losing the first acknowledgement and issuing the exact
+    # recovery start again. The engine and write-once file both replay.
+    second = _restore(item)
+    assert second == first
+    assert item["result_path"].read_bytes() == first_bytes
+    assert item["result_path"].stat().st_ino == first_info.st_ino
+    with item["replacement"].store.connection() as db:
+        events = [json.loads(row[0]) for row in db.execute("SELECT body FROM events")]
+    assert sum(event["type"] == "context.recovered" for event in events) == 1
+
+
+def test_hydrate_ipc_is_closed_configured_and_lost_ack_safe(hosted, tmp_path):  # noqa: F811
+    item = _restore_material(hosted, tmp_path)
+    request = {
+        "operation": "hydrate",
+        "grant": json.loads(item["grant_path"].read_text()),
+        "checkpoint_receipt": json.loads(item["receipt_path"].read_text()),
+        "pack": base64.b64encode(item["pack_path"].read_bytes()).decode("ascii"),
+    }
+    service = ContextService(
+        item["replacement"], checkpoint_receipt_keys=item["receipt_keys"]
+    )
+    before = canonical(request)
+    first = service.dispatch(request)
+    assert service.dispatch(request) == first
+    assert canonical(request) == before
+    owned_request = json.loads(before)
+    assert service._dispatch(owned_request, consume_hydrate_pack=True) == first
+    assert "pack" not in owned_request
+    assert ContextHydrateReceiptV1.model_validate(
+        verify(first, item["receipt_keys"])
+    )
+    with pytest.raises(ContextFault, match="context_request_schema"):
+        service.dispatch({**request, "receipt_keys": item["receipt_keys"]})
+    with pytest.raises(ContextFault, match="context_request_schema"):
+        service.dispatch({**request, "pack": "not canonical base64"})
+    with pytest.raises(ContextFault, match="context_hydrate_unavailable"):
+        ContextService(item["replacement"]).dispatch(request)
+
+
+def test_hydrate_ipc_accepts_pack_near_live_service_cap(hosted, tmp_path, monkeypatch):  # noqa: F811
+    item = _restore_material(hosted, tmp_path)
+    observed = {}
+
+    def hydrate(grant, receipt, pack, receipt_keys, *, snapshot_max_bytes):
+        observed.update(
+            grant=grant,
+            receipt=receipt,
+            pack=pack,
+            receipt_keys=receipt_keys,
+            snapshot_max_bytes=snapshot_max_bytes,
+        )
+        return {"accepted": True}
+
+    monkeypatch.setattr(item["replacement"], "hydrate", hydrate)
+    service = ContextService(
+        item["replacement"], checkpoint_receipt_keys=item["receipt_keys"]
+    )
+    pack = b"x" * (service.max_live_hydrate_pack_bytes - 1)
+    request = {
+        "operation": "hydrate",
+        "grant": {"signed": "grant"},
+        "checkpoint_receipt": {"signed": "checkpoint"},
+        "pack": base64.b64encode(pack).decode("ascii"),
+    }
+    encoded_size = len(canonical(request))
+    assert encoded_size <= service.max_hydrate_request
+    assert service.dispatch(request) == {"accepted": True}
+    assert observed == {
+        "grant": request["grant"],
+        "receipt": request["checkpoint_receipt"],
+        "pack": pack,
+        "receipt_keys": item["receipt_keys"],
+        "snapshot_max_bytes": service.max_live_checkpoint_snapshot_bytes,
+    }
+
+
+def test_hydrate_ipc_rejects_pack_above_configured_checkpoint_bound(
+    hosted, tmp_path, monkeypatch  # noqa: F811
+):
+    item = _restore_material(hosted, tmp_path)
+    item["replacement"].profile = item["profile"].model_copy(
+        update={"max_checkpoint_bytes": 1024}
+    )
+    service = ContextService(
+        item["replacement"], checkpoint_receipt_keys=item["receipt_keys"]
+    )
+    monkeypatch.setattr(
+        item["replacement"],
+        "hydrate",
+        lambda *_args, **_kwargs: pytest.fail("oversized pack reached the engine"),
+    )
+    request = {
+        "operation": "hydrate",
+        "grant": {"signed": "grant"},
+        "checkpoint_receipt": {"signed": "checkpoint"},
+        "pack": base64.b64encode(b"x" * 1025).decode("ascii"),
+    }
+    with pytest.raises(ContextFault, match="context_request_limit"):
+        service.dispatch(request)
+
+
+def test_live_hydrate_bounds_decompressed_snapshot_before_db_effect(
+    hosted, tmp_path  # noqa: F811
+):
+    engine, cap, _, binding, authority, _, make, _ = hosted
+    checkpoint = engine.checkpoint(
+        cap(role="durability"), "hydrate-snapshot-ceiling-source"
+    )
+    checkpoint_pack = base64.b64decode(checkpoint["pack"], validate=True)
+    namespace = binding.namespace.model_dump(mode="json")
+    snapshot = engine.cipher.decrypt(
+        checkpoint_pack,
+        {"namespace": namespace, "domain": "checkpoint/v1"},
+        engine.profile.max_checkpoint_bytes,
+    )
+    snapshot["oversized_transport_padding"] = "x" * 16_100_000
+    oversized_pack = engine.cipher.encrypt(
+        snapshot, {"namespace": namespace, "domain": "checkpoint/v1"}
+    )
+    replacement = make(tmp_path / "hydrate-snapshot-ceiling.sqlite3")
+    service = ContextService(
+        replacement,
+        checkpoint_receipt_keys={
+            engine.signer.key_id: engine.signer.key.public_key()
+        },
+    )
+    assert len(oversized_pack) < service.max_live_hydrate_pack_bytes
+    oversized_checksum = hashlib.sha256(oversized_pack).hexdigest()
+    receipt_payload = {
+        **checkpoint["receipt"]["payload"],
+        "manifest_checksum": oversized_checksum,
+        "bytes": len(oversized_pack),
+    }
+    oversized_receipt = engine.signer.sign(receipt_payload)
+    oversized_grant = authority.sign(
+        {
+            "operation": "hydrate",
+            "namespace": namespace,
+            "manifest_checksum": oversized_checksum,
+            "fence": 2,
+            "expires_at": 1900,
+        }
+    )
+    with pytest.raises(ContextFault, match="context_pack_limit"):
+        service.dispatch(
+            {
+                "operation": "hydrate",
+                "grant": oversized_grant,
+                "checkpoint_receipt": oversized_receipt,
+                "pack": base64.b64encode(oversized_pack).decode("ascii"),
+            }
+        )
+    with replacement.store.connection() as db:
+        assert db.execute("SELECT count(*) FROM cycles").fetchone()[0] == 0
+
+    startup_replacement = make(
+        tmp_path / "hydrate-startup-snapshot-ceiling.sqlite3"
+    )
+    pack_path = tmp_path / "oversized-compressed-checkpoint.enc"
+    grant_path = tmp_path / "oversized-compressed-grant.json"
+    receipt_path = tmp_path / "oversized-compressed-receipt.json"
+    pack_path.write_bytes(oversized_pack)
+    grant_path.write_bytes(canonical(oversized_grant))
+    receipt_path.write_bytes(canonical(oversized_receipt))
+    with pytest.raises(ContextFault, match="context_pack_limit"):
+        _restore_engine(
+            startup_replacement,
+            profile=engine.profile,
+            pack_path=str(pack_path),
+            grant_path=str(grant_path),
+            receipt_path=str(receipt_path),
+            result_path=str(tmp_path / "oversized-compressed-result.json"),
+            receipt_keys={
+                engine.signer.key_id: engine.signer.key.public_key()
+            },
+        )
+    with startup_replacement.store.connection() as db:
+        assert db.execute("SELECT count(*) FROM cycles").fetchone()[0] == 0
+
+    source_checksum = checkpoint["receipt"]["payload"]["manifest_checksum"]
+    accepted = service.dispatch(
+        {
+            "operation": "hydrate",
+            "grant": authority.sign(
+                {
+                    "operation": "hydrate",
+                    "namespace": namespace,
+                    "manifest_checksum": source_checksum,
+                    "fence": 2,
+                    "expires_at": 1900,
+                }
+            ),
+            "checkpoint_receipt": checkpoint["receipt"],
+            "pack": checkpoint["pack"],
+        }
+    )
+    assert accepted["payload"]["schema_version"] == "ContextHydrateReceiptV1"
+
+
+def test_startup_restore_bounds_actual_pack_and_closed_header_files(
+    hosted, tmp_path  # noqa: F811
+):
+    item = _restore_material(hosted, tmp_path)
+    original_pack = item["pack_path"].read_bytes()
+    original_grant = item["grant_path"].read_bytes()
+
+    item["pack_path"].write_bytes(b"x" * 1025)
+    narrow_profile = item["profile"].model_copy(
+        update={"max_checkpoint_bytes": 1024}
+    )
+    with pytest.raises(ContextFault, match="context_pack_limit"):
+        _restore_engine(
+            item["replacement"],
+            profile=narrow_profile,
+            pack_path=str(item["pack_path"]),
+            grant_path=str(item["grant_path"]),
+            receipt_path=str(item["receipt_path"]),
+            result_path=str(item["result_path"]),
+            receipt_keys=item["receipt_keys"],
+        )
+
+    item["pack_path"].write_bytes(original_pack)
+    item["grant_path"].write_bytes(b"x" * (MAX_SIGNED_HYDRATE_ENVELOPE + 1))
+    with pytest.raises(ContextFault, match="context_restore_input_invalid"):
+        _restore(item)
+
+    item["grant_path"].write_bytes(b'{"payload":{},"payload":{}}')
+    with pytest.raises(ContextFault, match="context_restore_input_invalid"):
+        _restore(item)
+
+    item["grant_path"].write_bytes(original_grant)
+    with item["replacement"].store.connection() as db:
+        assert db.execute("SELECT count(*) FROM cycles").fetchone()[0] == 0
+
+
+class _Reader:
+    def __init__(self, value):
+        self.value = value
+
+    async def read(self, _size):
+        value, self.value = self.value, b""
+        return value
+
+
+class _Transport:
+    def pause_reading(self):
+        pass
+
+    def resume_reading(self):
+        pass
+
+
+class _Writer:
+    def __init__(self):
+        self.transport = _Transport()
+        self.output = bytearray()
+
+    def write(self, value):
+        self.output.extend(value)
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        pass
+
+    async def wait_closed(self):
+        pass
+
+
+class _BlockingWriter(_Writer):
+    def __init__(self, draining, release):
+        super().__init__()
+        self.draining = draining
+        self.release = release
+
+    async def drain(self):
+        self.draining.set()
+        await self.release.wait()
+
+
+def _handle(service, frame):
+    writer = _Writer()
+    asyncio.run(service.handle(_Reader(frame), writer))
+    return json.loads(writer.output)
+
+
+def test_live_ipc_frame_exact_bound_overflow_eof_crlf_and_duplicate_newline(hosted):  # noqa: F811
+    service = ContextService(hosted[0])
+    prefix = canonical({"operation": "health", "padding": ""})
+    exact = canonical(
+        {
+            "operation": "health",
+            "padding": "x" * (SMALL_REQUEST_LIMIT - len(prefix)),
+        }
+    )
+    assert len(exact) == SMALL_REQUEST_LIMIT
+    assert _handle(service, exact + b"\n")["error"] == "context_request_schema"
+    assert _handle(service, exact[:-2] + b"xxx\n")["error"] == "context_request_limit"
+    assert _handle(service, b'{"operation":"health"}')["error"] == (
+        "context_request_framing"
+    )
+    assert _handle(service, b'{"operation":"health"}\r\n')["error"] == (
+        "context_request_framing"
+    )
+    assert _handle(service, b'{"operation":"health"}\n\n')["error"] == (
+        "context_request_framing"
+    )
+
+
+def test_live_ipc_uses_only_top_level_operation_for_admission(
+    hosted, monkeypatch  # noqa: F811
+):
+    engine = hosted[0]
+    service = ContextService(engine, checkpoint_receipt_keys={"unused": object()})
+    monkeypatch.setattr(
+        engine, "hydrate", lambda *_, **__: {"classified": "hydrate"}
+    )
+    request = {
+        "checkpoint_receipt": {"payload": {"operation": "health"}},
+        "grant": {"payload": {"operation": "bind"}},
+        "operation": "hydrate",
+        "pack": base64.b64encode(b"pack").decode(),
+    }
+    assert _handle(service, canonical(request) + b"\n") == {
+        "ok": True,
+        "result": {"classified": "hydrate"},
+    }
+
+
+def test_live_ipc_large_response_does_not_block_profile_small_call_pool(
+    hosted, monkeypatch  # noqa: F811
+):
+    engine = hosted[0]
+    service = ContextService(engine, checkpoint_receipt_keys={"unused": object()})
+    monkeypatch.setattr(engine, "hydrate", lambda *_, **__: {"accepted": True})
+    monkeypatch.setattr(engine, "health", lambda: {"ready": True})
+    hydrate = canonical(
+        {
+            "checkpoint_receipt": {"signed": "checkpoint"},
+            "grant": {"signed": "grant"},
+            "operation": "hydrate",
+            "pack": base64.b64encode(b"pack").decode(),
+        }
+    ) + b"\n"
+
+    async def scenario():
+        draining = asyncio.Event()
+        release = asyncio.Event()
+        first_writer = _BlockingWriter(draining, release)
+        first = asyncio.create_task(
+            service.handle(_Reader(hydrate), first_writer)
+        )
+        await asyncio.wait_for(draining.wait(), timeout=2)
+
+        small_writers = [_Writer() for _ in range(service.max_small_operations)]
+        await asyncio.gather(
+            *(
+                service.handle(
+                    _Reader(b'{"operation":"health"}\n'), writer
+                )
+                for writer in small_writers
+            )
+        )
+        assert all(json.loads(writer.output)["ok"] for writer in small_writers)
+
+        second_writer = _Writer()
+        second = asyncio.create_task(
+            service.handle(_Reader(hydrate), second_writer)
+        )
+        for _ in range(10):
+            if service._heavy_admitted == 2:
+                break
+            await asyncio.sleep(0)
+        assert service._heavy_admitted == 2
+        third_writer = _Writer()
+        await service.handle(_Reader(hydrate), third_writer)
+        assert json.loads(third_writer.output) == {
+            "ok": False,
+            "error": "context_service_busy",
+        }
+        release.set()
+        await asyncio.gather(first, second)
+        assert json.loads(first_writer.output)["ok"] is True
+        assert json.loads(second_writer.output)["ok"] is True
+        assert service._heavy_admitted == 0
+
+    asyncio.run(scenario())
+
+
+def test_ipc_timeout_covers_advertised_profile_size(hosted, tmp_path):  # noqa: F811
+    item = _restore_material(hosted, tmp_path)
+    service = ContextService(
+        item["replacement"], checkpoint_receipt_keys=item["receipt_keys"]
+    )
+    assert service.io_timeout_seconds <= MAX_LOCAL_IO_TIMEOUT_SECONDS
+    assert (
+        service.io_timeout_seconds * MIN_LOCAL_IO_BYTES_PER_SECOND
+        >= service.max_request
+    )
+    assert service.estimated_peak_rss_bytes <= 512 * 1024 * 1024
+
+
+def test_live_ipc_rejects_profiles_outside_checkpoint_or_memory_envelope(
+    hosted, tmp_path  # noqa: F811
+):
+    item = _restore_material(hosted, tmp_path)
+    item["replacement"].profile = item["profile"].model_copy(
+        update={"max_checkpoint_bytes": 64_000_000}
+    )
+    legacy_wide_service = ContextService(
+        item["replacement"], checkpoint_receipt_keys=item["receipt_keys"]
+    )
+    assert (
+        legacy_wide_service.max_live_hydrate_pack_bytes
+        == LIVE_IPC_MAX_CHECKPOINT_BYTES
+    )
+    assert legacy_wide_service.engine.health_v3()["live_ipc_checkpoint_bytes"] == (
+        LIVE_IPC_MAX_CHECKPOINT_BYTES
+    )
+
+    item["replacement"].profile = item["profile"].model_copy(
+        update={
+            "max_checkpoint_bytes": 16_000_000,
+            "max_records": 200_000,
+            "max_operations_per_cycle": 200_000,
+        }
+    )
+    with pytest.raises(ContextFault, match="profile_transport_limit"):
+        ContextService(item["replacement"], checkpoint_receipt_keys=item["receipt_keys"])
+
+
+def test_concurrent_same_receipt_publication_converges(tmp_path):
+    target = tmp_path / "hydrate-result.json"
+    receipt = {"payload": {"fence": 2}, "key_id": "contextd", "signature": "a" * 88}
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(lambda _: _write_restore_result_once(target, receipt), range(32)))
+    assert target.read_bytes() == canonical(receipt) + b"\n"
+    assert not list(tmp_path.glob(".hydrate-result.json.*.tmp"))
+
+
+def test_existing_different_result_is_never_replaced(tmp_path):
+    target = tmp_path / "hydrate-result.json"
+    first = {"payload": {"fence": 2}, "key_id": "contextd", "signature": "a" * 88}
+    second = {"payload": {"fence": 3}, "key_id": "contextd", "signature": "b" * 88}
+    _write_restore_result_once(target, first)
+    before = target.read_bytes()
+    with pytest.raises(ContextFault, match="context_restore_result_conflict"):
+        _write_restore_result_once(target, second)
+    assert target.read_bytes() == before
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable")
+def test_restore_result_rejects_target_and_parent_symlinks(tmp_path):
+    victim = tmp_path / "victim.json"
+    victim.write_text("unchanged")
+    target = tmp_path / "hydrate-result.json"
+    linked_parent = tmp_path / "linked-parent"
+    actual_parent = tmp_path / "actual-parent"
+    actual_parent.mkdir()
+    try:
+        target.symlink_to(victim)
+        linked_parent.symlink_to(actual_parent, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlink creation is not permitted")
+    receipt = {"payload": {}, "key_id": "contextd", "signature": "a" * 88}
+    with pytest.raises(ContextFault, match="context_restore_result_path_invalid"):
+        _write_restore_result_once(target, receipt)
+    with pytest.raises(ContextFault, match="context_restore_result_path_invalid"):
+        _write_restore_result_once(linked_parent / "result.json", receipt)
+    assert victim.read_text() == "unchanged"
+    assert not (actual_parent / "result.json").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+def test_restore_result_rejects_preexisting_group_readable_file(tmp_path):
+    target = tmp_path / "hydrate-result.json"
+    receipt = {"payload": {}, "key_id": "contextd", "signature": "a" * 88}
+    target.write_bytes(canonical(receipt) + b"\n")
+    target.chmod(0o640)
+    with pytest.raises(ContextFault, match="context_restore_result_path_invalid"):
+        _write_restore_result_once(target, receipt)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory-descriptor contract")
+def test_restore_result_parent_swap_never_redirects_publish(tmp_path, monkeypatch):
+    from aether_context import service
+
+    parent = tmp_path / "result-parent"
+    held = tmp_path / "held-parent"
+    redirected = tmp_path / "redirected-parent"
+    parent.mkdir(mode=0o700)
+    redirected.mkdir(mode=0o700)
+    target = parent / "hydrate-result.json"
+    receipt = {"payload": {}, "key_id": "contextd", "signature": "a" * 88}
+    real_open = service.os.open
+    swapped = False
+
+    def swap_before_temp_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if (
+            not swapped
+            and isinstance(path, str)
+            and path.startswith(".hydrate-result.json.")
+        ):
+            swapped = True
+            parent.rename(held)
+            parent.symlink_to(redirected, target_is_directory=True)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(service.os, "open", swap_before_temp_open)
+    with pytest.raises(ContextFault, match="context_restore_result_path_invalid"):
+        _write_restore_result_once(target, receipt)
+    assert swapped is True
+    assert not (redirected / target.name).exists()
+    # A publish already linked through the stable descriptor remains confined to
+    # the original directory and startup fails because its path identity changed.
+    assert (held / target.name).read_bytes() == canonical(receipt) + b"\n"
+
+
+@pytest.mark.skipif(os.name == "nt" or not hasattr(os, "mkfifo"), reason="POSIX FIFO")
+def test_restore_result_rejects_fifo_before_open(tmp_path):
+    target = tmp_path / "hydrate-result.json"
+    os.mkfifo(target, 0o600)
+    receipt = {"payload": {}, "key_id": "contextd", "signature": "a" * 88}
+    with pytest.raises(ContextFault, match="context_restore_result_path_invalid"):
+        _write_restore_result_once(target, receipt)
+
+
+def test_failed_publish_never_exposes_partial_result(tmp_path, monkeypatch):
+    from aether_context import service
+
+    target = tmp_path / "hydrate-result.json"
+    receipt = {"payload": {}, "key_id": "contextd", "signature": "a" * 88}
+
+    def fail_link(*_args, **_kwargs):
+        raise OSError("simulated link failure")
+
+    monkeypatch.setattr(service.os, "link", fail_link)
+    with pytest.raises(ContextFault, match="context_restore_result_unavailable"):
+        _write_restore_result_once(target, receipt)
+    assert not target.exists()
+    assert not list(tmp_path.glob(".hydrate-result.json.*.tmp"))

--- a/tests/test_hosted_context.py
+++ b/tests/test_hosted_context.py
@@ -11,6 +11,7 @@ from aether_context.contracts import (
     AppendRequestV1,
     CapabilityV1,
     ContextBindingV1,
+    ContextCheckpointDurabilityCommandV1,
     ContextProfileV1,
     NamespaceV1,
     RetrieveRequestV1,
@@ -36,6 +37,7 @@ def hosted(tmp_path):
         index_version=sqlite3.sqlite_version,
         max_capsule_tokens=12000,
         max_records=1000,
+        max_checkpoint_bytes=16_000_000,
         disk_free_floor=0,
     )
     cipher = EnvelopeCipher(os.urandom(32))
@@ -104,6 +106,22 @@ def hosted(tmp_path):
             expires_at=500000,
         )
         engine.bind(authority.sign(binding.model_dump()), p0, p1)
+        with engine.store.connection() as db:
+            revision = db.execute(
+                "SELECT revision FROM cycles WHERE id=?", (cycle,)
+            ).fetchone()[0]
+        engine.register_checkpoint_durability(
+            authority.sign(
+                ContextCheckpointDurabilityCommandV1(
+                    namespace=ns,
+                    idempotency_key="durability-" + key,
+                    expected_revision=revision,
+                    mode="remote_registered",
+                    issued_at=clock[0],
+                    expires_at=clock[0] + 100,
+                ).model_dump(mode="json")
+            )
+        )
         return binding
 
     binding = bind()
@@ -231,7 +249,7 @@ def test_encryption_checkpoint_restart_and_host_hydration(hosted, tmp_path):
             "namespace": binding.namespace.model_dump(),
             "manifest_checksum": checkpoint["receipt"]["payload"]["manifest_checksum"],
             "fence": 2,
-            "expires_at": 2000,
+            "expires_at": 1900,
         }
     )
     keys = {engine.signer.key_id: engine.signer.key.public_key()}
@@ -241,6 +259,26 @@ def test_encryption_checkpoint_restart_and_host_hydration(hosted, tmp_path):
         recall(replacement, cap(), "stale")
     with pytest.raises(ContextFault, match="integrity_failure"):
         replacement.hydrate(grant, checkpoint["receipt"], pack[:-1] + bytes([pack[-1] ^ 1]), keys)
+    far_future_grant = authority.sign(
+        {**grant["payload"], "expires_at": 999999999999}
+    )
+    with pytest.raises(ContextFault, match="capability_denied"):
+        replacement.hydrate(far_future_grant, checkpoint["receipt"], pack, keys)
+    restored = replacement.status(cap(fence=2))["payload"]
+    replacement.control(
+        authority.sign(
+            {
+                "operation": "abort",
+                "context_cycle_id": binding.namespace.context_cycle_id,
+                "binding_digest": digest(binding),
+                "expected_revision": restored["revision"],
+                "fence": restored["fence"],
+                "expires_at": 1100,
+            }
+        )
+    )
+    with pytest.raises(ContextFault, match="hydrate_conflict"):
+        replacement.hydrate(grant, checkpoint["receipt"], pack, keys)
 
 
 def test_concurrent_writers_are_serialized(hosted):
@@ -407,7 +445,7 @@ def test_hydration_during_seal_never_reopens_worker_writes(hosted, tmp_path):
             "namespace": binding.namespace.model_dump(),
             "manifest_checksum": checkpoint["receipt"]["payload"]["manifest_checksum"],
             "fence": 2,
-            "expires_at": 2000,
+            "expires_at": 1900,
         }
     )
     replacement.hydrate(

--- a/tests/test_hosted_scale_harness.py
+++ b/tests/test_hosted_scale_harness.py
@@ -1,0 +1,138 @@
+import argparse
+import json
+from pathlib import Path
+import sqlite3
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+import pytest
+
+from aether_context.contracts import ContextProfileV1, RuntimeEnvironmentV2, canonical, digest
+from bench import hosted_scale
+
+
+def test_bounded_harness_registers_durability_and_hydrates_v2(
+    tmp_path, monkeypatch
+):
+    source_revision = "a" * 40
+    dependencies = [
+        "annotated-types",
+        "cffi",
+        "cryptography",
+        "numpy",
+        "pycparser",
+        "pydantic",
+        "pydantic_core",
+        "typing-inspection",
+        "typing_extensions",
+    ]
+    environment = RuntimeEnvironmentV2(
+        python_implementation="cpython",
+        python_version="3.13.0",
+        python_abi="cp313-test",
+        python_executable_digest=digest("python"),
+        dependency_import_closure=dependencies,
+        dependency_versions={name: "1.0" for name in dependencies},
+        dependency_artifact_digests={name: digest(name) for name in dependencies},
+        sqlite_version=sqlite3.sqlite_version,
+        package_import_root_digest=digest("site-packages"),
+    )
+    package_digest = digest("package-tree")
+    monkeypatch.setattr(hosted_scale, "_assert_module_origins", lambda _: None)
+    monkeypatch.setattr(hosted_scale, "_git_source", lambda _: source_revision)
+    monkeypatch.setattr(
+        hosted_scale, "runtime_environment_identity", lambda: environment
+    )
+    monkeypatch.setattr(
+        hosted_scale,
+        "runtime_package_tree_digest",
+        lambda **_: package_digest,
+    )
+    monkeypatch.setattr(
+        "aether_context.engine.runtime_environment_identity",
+        lambda **_: environment,
+    )
+    monkeypatch.setattr(
+        "aether_context.engine.runtime_package_tree_digest",
+        lambda **_: package_digest,
+    )
+    monkeypatch.setattr(
+        hosted_scale,
+        "run_namespace_isolation",
+        lambda: {
+            "cases": 1_000_000,
+            "unauthorized_records": 0,
+            "result_digest": digest("bounded-isolation"),
+        },
+    )
+
+    profile = ContextProfileV1(
+        index_version=sqlite3.sqlite_version,
+        max_records=20,
+        max_indexed_bytes=1024,
+        max_record_bytes=256,
+        max_operations_per_cycle=64,
+        max_concurrent_cycles=1,
+        disk_free_floor=0,
+    )
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_bytes(canonical(profile.model_dump(mode="json")))
+    records = []
+    queries = []
+    for index in range(20):
+        token = f"unique{index:02d}"
+        text = (token + " " + ("x" * 80))[:47]
+        records.append({"id": f"record-{index}", "text": text})
+        queries.append(
+            {
+                "id": f"query-{index}",
+                "query": token,
+                "expected_record_ids": [f"record-{index}"],
+            }
+        )
+    dataset_path = tmp_path / "recall.json"
+    dataset_path.write_bytes(
+        canonical(
+            {
+                "schema_version": "HostedRecallDatasetV1",
+                "name": "bounded-harness/v1",
+                "records": records,
+                "queries": queries,
+            }
+        )
+    )
+    signing_key = tmp_path / "benchmark.key"
+    signing_key.write_bytes(Ed25519PrivateKey.generate().private_bytes_raw())
+    output = tmp_path / "receipt.json"
+    work = tmp_path / "work"
+    args = argparse.Namespace(
+        repository=Path(__file__).resolve().parents[1],
+        profile=profile_path,
+        recall_dataset=dataset_path,
+        work_directory=work,
+        signing_key=signing_key,
+        key_id="bounded-benchmark",
+        output=output,
+        receipt_bound_profile_output=None,
+        executor_stability_receipt=None,
+        executor_stability_keys=None,
+        data_plane_isolation_receipt=None,
+        data_plane_isolation_keys=None,
+        retrieval_samples=20,
+        concurrency=1,
+        validity_seconds=3600,
+    )
+    envelope = hosted_scale.run(args)
+    assert json.loads(output.read_text()) == envelope
+    assert envelope["payload"]["checkpoint_receipt_digest"]
+    assert envelope["payload"]["hydrate_receipt_digest"]
+    with sqlite3.connect(work / "replacement.sqlite3") as db:
+        restored = db.execute(
+            "SELECT checkpoint_durability_mode,checkpoint_durability_legacy,"
+            "checkpoint_durability_receipt FROM cycles"
+        ).fetchone()
+    assert restored[:2] == ("remote_registered", 0)
+    assert restored[2] is not None
+    args.receipt_bound_profile_output = tmp_path / "qualified-profile.json"
+    with pytest.raises(SystemExit, match="independent executor and data-plane"):
+        hosted_scale.run(args)
+    assert not args.receipt_bound_profile_output.exists()

--- a/tests/test_hosted_schema_export.py
+++ b/tests/test_hosted_schema_export.py
@@ -1,0 +1,9 @@
+import json
+
+from scripts.export_hosted_schema import NAMES, SCHEMA_PATH, render_schema
+
+
+def test_hosted_schema_export_is_byte_reproducible_and_complete():
+    checked_in = SCHEMA_PATH.read_text(encoding="utf-8")
+    assert checked_in == render_schema()
+    assert list(json.loads(checked_in)) == NAMES

--- a/tests/test_preimport_guard.py
+++ b/tests/test_preimport_guard.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+import py_compile
+import subprocess
+import sys
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+import pytest
+
+from aether_context.guard import (
+    GuardFailure,
+    _audit_import_roots,
+    _audit_site_import_surface,
+    _canonical,
+    _verified_manifest_payload,
+    _verify_ed25519,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD = ROOT / "aether_context" / "guard.py"
+
+
+def _lock_tree(root: Path) -> None:
+    for path in sorted(root.rglob("*"), reverse=True):
+        path.chmod(0o555 if path.is_dir() else 0o444)
+    root.chmod(0o555)
+
+
+def _signed_files(tmp_path, payload):
+    key = Ed25519PrivateKey.generate()
+    key_id = "runtime-build-test"
+    signature = key.sign(_canonical({"key_id": key_id, "payload": payload}))
+    envelope = {
+        "payload": payload,
+        "key_id": key_id,
+        "signature": base64.b64encode(signature).decode("ascii"),
+    }
+    public = key.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    manifest = tmp_path / "manifest.json"
+    keys = tmp_path / "keys.json"
+    manifest.write_text(json.dumps(envelope), encoding="utf-8")
+    keys.write_text(
+        json.dumps({key_id: base64.b64encode(public).decode("ascii")}),
+        encoding="utf-8",
+    )
+    return manifest, keys, envelope
+
+
+def test_manifest_is_authenticated_before_any_payload_field_is_trusted(tmp_path):
+    payload = {
+        "schema_version": "ContextRuntimeBuildManifestV3",
+        "runtime_environment": {"dependency_import_closure": ["not-trusted-yet"]},
+    }
+    manifest, keys, envelope = _signed_files(tmp_path, payload)
+    assert _verified_manifest_payload(manifest, keys) == payload
+
+    envelope["payload"]["runtime_environment"]["dependency_import_closure"] = []
+    manifest.write_text(json.dumps(envelope), encoding="utf-8")
+    with pytest.raises(GuardFailure, match="context_guard_manifest_signature_invalid"):
+        _verified_manifest_payload(manifest, keys)
+
+
+def test_manifest_signature_verifier_rejects_noncanonical_and_small_order_keys():
+    key = Ed25519PrivateKey.generate()
+    public = key.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    message = b"guard-bootstrap-vector"
+    signature = key.sign(message)
+    _verify_ed25519(public, signature, message)
+    with pytest.raises(GuardFailure, match="context_guard_manifest_signature_invalid"):
+        _verify_ed25519(public, signature, message + b"-tampered")
+    with pytest.raises(GuardFailure, match="context_guard_manifest_signature_invalid"):
+        _verify_ed25519(b"\x01" + (b"\x00" * 31), b"\x00" * 64, message)
+
+
+@pytest.mark.parametrize(
+    ("distribution", "import_root"),
+    (("aether-context", "aether_context"), ("pydantic", "pydantic")),
+)
+def test_importable_timestamp_pyc_marker_is_rejected_in_isolated_subprocess(
+    tmp_path, distribution, import_root
+):
+    site = tmp_path / "site-packages"
+    package = site / import_root
+    package.mkdir(parents=True)
+    source = package / "__init__.py"
+    benign = "VALUE = 'SAFE'\n"
+    malicious = "VALUE = 'PWN!'\n"
+    assert len(benign) == len(malicious)
+    timestamp = 1_700_000_000
+    source.write_text(malicious, encoding="utf-8")
+    os.utime(source, (timestamp, timestamp))
+    py_compile.compile(
+        str(source),
+        doraise=True,
+        invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP,
+    )
+    source.write_text(benign, encoding="utf-8")
+    os.utime(source, (timestamp, timestamp))
+    _lock_tree(site)
+
+    imported = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            "-c",
+            "import sys;sys.path.append(sys.argv[1]);"
+            "print(__import__(sys.argv[2]).VALUE)",
+            str(site),
+            import_root,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert imported.stdout.strip() == "PWN!"
+
+    records = json.dumps({f"{import_root}/__init__.py": None})
+    audit_code = (
+        "import json,os,runpy,sys;"
+        "g=runpy.run_path(sys.argv[1],run_name='guard_test');"
+        "audit=g['_audit_import_roots'];failure=g['GuardFailure'];"
+        "site=__import__('pathlib').Path(sys.argv[2]);"
+        "\ntry:audit(site,sys.argv[3],json.loads(sys.argv[4]),owner_uid=os.stat(site).st_uid)"
+        "\nexcept failure as exc:print(str(exc));sys.exit(0)"
+        "\nsys.exit(9)"
+    )
+    guarded = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            "-c",
+            audit_code,
+            str(GUARD),
+            str(site),
+            distribution,
+            records,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert guarded.returncode == 0, guarded.stderr
+    assert guarded.stdout.strip() == "context_guard_bytecode_present"
+
+
+def test_extension_shadow_and_unlocked_site_module_are_rejected(tmp_path):
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    module = site / "typing_extensions.py"
+    module.write_text("VALUE = 'safe'\n", encoding="utf-8")
+    shadow = site / "typing_extensions.so"
+    shadow.write_bytes(b"native-shadow")
+    module.chmod(0o444)
+    shadow.chmod(0o444)
+    owner = site.stat().st_uid
+    with pytest.raises(GuardFailure, match="context_guard_untracked_import_artifact"):
+        _audit_import_roots(
+            site,
+            "typing_extensions",
+            {"typing_extensions.py": None},
+            owner_uid=owner,
+        )
+
+    shadow.chmod(0o666)
+    shadow.unlink()
+    unlocked = site / "sitecustomize.py"
+    unlocked.write_text("VALUE = 'unlocked'\n", encoding="utf-8")
+    unlocked.chmod(0o444)
+    with pytest.raises(GuardFailure, match="context_guard_unlocked_import_artifact"):
+        _audit_site_import_surface(
+            site, ["typing_extensions"], owner_uid=owner
+        )
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ("aether_context.so", "aether_context/__init__.so"),
+)
+def test_record_owned_native_package_collision_is_still_rejected(tmp_path, relative):
+    site = tmp_path / "site-packages"
+    package = site / "aether_context"
+    package.mkdir(parents=True)
+    source = package / "__init__.py"
+    source.write_text("MARKER = 'trusted-source'\n", encoding="utf-8")
+    collision = site / relative
+    collision.parent.mkdir(parents=True, exist_ok=True)
+    collision.write_bytes(b"record-owned-native-marker")
+    source.chmod(0o444)
+    collision.chmod(0o444)
+    package.chmod(0o555)
+    records = {
+        "aether_context/__init__.py": "sha256=placeholder",
+        relative: "sha256=placeholder",
+    }
+    with pytest.raises(GuardFailure, match="context_guard_package_import_collision"):
+        _audit_import_roots(
+            site,
+            "aether-context",
+            records,
+            owner_uid=site.stat().st_uid,
+        )
+
+
+def test_systemd_execs_guard_in_the_daemon_process_before_imports():
+    unit = (ROOT / "deploy" / "aether-contextd.service").read_text(encoding="utf-8")
+    exec_start = next(line for line in unit.splitlines() if line.startswith("ExecStart="))
+    assert "python -I -S -B" in exec_start
+    assert "/site-packages/aether_context/guard.py" in exec_start
+    assert "--runtime-build-manifest ${CREDENTIALS_DIRECTORY}/" in exec_start
+    assert "MemoryMax=512M" in unit

--- a/tests/test_reservation_release.py
+++ b/tests/test_reservation_release.py
@@ -1,0 +1,1133 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+import pytest
+
+from aether_context.contracts import (
+    CapabilityV1,
+    ClosureProofV1,
+    ContextBindingCommandV2,
+    ContextBindingCommandV3,
+    ContextBindingV1,
+    NamespaceV1,
+    ContextReservationAbortCommandV1,
+    ContextReservationAbortExpiryCommandV1,
+    ContextReservationAbortReceiptV1,
+    ContextReservationCommandV2,
+    ContextReservationCommandV3,
+    ContextReservationExpiryCommandV1,
+    ContextReservationExpiryReceiptV1,
+    ContextReservationReceiptV1,
+    ContextReservationReceiptV2,
+    ContextReservationReceiptV3,
+    ContextReservationReleaseCommandV1,
+    ContextReservationReleaseReceiptV1,
+    digest,
+)
+from aether_context.crypto import ContextFault, ReceiptSigner, verify
+from aether_context.service import ContextService
+from test_hosted_context import hosted  # noqa: F401
+
+
+def _reservation(engine, authority, clock, *, key="retry-reservation", ttl=100):
+    payload = ContextReservationCommandV2(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expires_at=clock[0] + ttl,
+        released_revision=None,
+    ).model_dump(mode="json")
+    signed = authority.sign(payload)
+    receipt = ContextService(engine).dispatch(
+        {"operation": "reserve_v2", "reservation": signed}
+    )
+    claim = ContextReservationReceiptV2.model_validate(
+        verify(receipt, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    return payload, signed, receipt, claim
+
+
+def _release_payload(engine, claim, clock, *, key="retry-reservation", **updates):
+    payload = ContextReservationReleaseCommandV1(
+        context_cycle_id=claim.context_cycle_id,
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expected_revision=claim.revision,
+        reason_code="pre_dispatch_authorization_failed",
+        dispatch_started=False,
+        authorization_failure_receipt_digest=digest("denied-one-use-authority"),
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    ).model_dump(mode="json")
+    payload.update(updates)
+    return payload
+
+
+def _abort_payload(
+    engine,
+    claim,
+    reservation_receipt,
+    clock,
+    *,
+    key="retry-reservation",
+    **updates,
+):
+    payload = ContextReservationAbortCommandV1(
+        context_cycle_id=claim.context_cycle_id,
+        owner_id="retry-owner",
+        project_id="retry-project",
+        objective_id="retry-objective",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expected_revision=claim.revision,
+        reason_code="timeout",
+        dispatch_started=True,
+        objective_dispatch_receipt_digest=digest("objective-dispatch-started"),
+        reservation_receipt=reservation_receipt,
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    ).model_dump(mode="json")
+    payload.update(updates)
+    return payload
+
+
+def _no_dispatch_receipt(
+    engine,
+    authority,
+    claim,
+    reservation_receipt,
+    clock,
+    *,
+    key="retry-reservation",
+    **updates,
+):
+    snapshot = {
+        "owner_user_id": "retry-owner",
+        "objective_id": "objective-" + key,
+        "idempotency_key": key,
+        "request_digest": "sha256:" + digest(key),
+        "context_cycle_id": claim.context_cycle_id,
+        "reservation_receipt_digest": digest(reservation_receipt),
+        "reservation_revision": claim.revision,
+        "state": "closed_without_dispatch",
+        "revision": 7,
+        "canonical_result_state": "planned",
+        "canonical_result_digest": digest(
+            {"canonical": key, "state": "planned"}
+        ),
+    }
+    snapshot.update(updates.pop("ledger_snapshot_updates", {}))
+    payload = {
+        "schema_version": "ContextInvocationNoDispatchReceiptV1",
+        "operation": "close_without_dispatch",
+        "ledger_snapshot": snapshot,
+        "ledger_snapshot_digest": digest(snapshot),
+        "issued_at": clock[0],
+        "expires_at": clock[0] + 100,
+    }
+    payload.update(updates)
+    return authority.sign(payload)
+
+
+def _expiry_payload(
+    engine,
+    authority,
+    claim,
+    reservation_receipt,
+    clock,
+    *,
+    key="retry-reservation",
+    **updates,
+):
+    no_dispatch = _no_dispatch_receipt(
+        engine, authority, claim, reservation_receipt, clock, key=key
+    )
+    payload = ContextReservationExpiryCommandV1(
+        context_cycle_id=claim.context_cycle_id,
+        context_bucket_id=claim.context_bucket_id,
+        objective_id="objective-" + key,
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expected_revision=claim.revision,
+        reason_code="reservation_timeout",
+        reservation_receipt=reservation_receipt,
+        invocation_no_dispatch_receipt=no_dispatch,
+        invocation_no_dispatch_receipt_digest=digest(no_dispatch),
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    ).model_dump(mode="json")
+    payload.update(updates)
+    return payload
+
+
+def _binding_command(engine, authority, reservation_receipt, claim, clock):
+    namespace = NamespaceV1(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        objective_id="retry-objective",
+        context_cycle_id=claim.context_cycle_id,
+    )
+    authority_payload = {"objective": "retry safely", "paths": ["src"]}
+    snapshot = {
+        "project_id": "retry-project",
+        "graph_id": "retry-graph",
+        "policy_digest": digest("retry-policy"),
+        "nodes": [],
+    }
+    binding = ContextBindingV1(
+        namespace=namespace,
+        context_bucket_id=claim.context_bucket_id,
+        repository_id="retry-repository",
+        repo_main_sha="a" * 40,
+        project_graph_id="retry-graph",
+        graph_revision=1,
+        graph_checksum=digest(snapshot),
+        plan_digest=digest("retry-plan"),
+        execution_profile_digest=digest("retry-execution-profile"),
+        shared_ir_digest=digest("retry-ir"),
+        authorization_receipt_ref="retry-authorization",
+        authorization_digest=digest(authority_payload),
+        policy_digest=digest("retry-policy"),
+        redaction_digest=digest("retry-redaction"),
+        profile_digest=digest(engine.profile),
+        captain_binding_id="retry-captain",
+        created_at=clock[0],
+        expires_at=clock[0] + 1000,
+    )
+    command_model = (
+        ContextBindingCommandV3
+        if isinstance(claim, ContextReservationReceiptV3)
+        else ContextBindingCommandV2
+    )
+    command = command_model(
+        binding=binding,
+        reservation_receipt=reservation_receipt,
+        expected_reservation_revision=claim.revision,
+    )
+    return authority.sign(command.model_dump(mode="json")), authority_payload, snapshot, binding
+
+
+def test_signed_release_lost_ack_concurrency_revival_and_post_bind_denial(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, original_reservation, reservation_receipt, claim = _reservation(
+        engine, authority, clock
+    )
+    delayed_binding = _binding_command(
+        engine, authority, reservation_receipt, claim, clock
+    )
+    command_payload = _release_payload(engine, claim, clock)
+    command = authority.sign(command_payload)
+    service = ContextService(engine)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(
+            pool.map(
+                lambda _: service.dispatch(
+                    {"operation": "release_reservation", "command": command}
+                ),
+                range(4),
+            )
+        )
+    assert all(item == results[0] for item in results)
+    released = results[0]
+    release_claim = ContextReservationReleaseReceiptV1.model_validate(
+        verify(released, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    assert release_claim.release_command_digest == digest(command_payload)
+    assert release_claim.revision == claim.revision + 1
+    # The original still-valid reserve authority cannot be replayed as a new attempt.
+    with pytest.raises(ContextFault, match="reservation_terminal"):
+        engine.reserve_v2(original_reservation)
+
+    # An exact retry remains recoverable after the short-lived command expires.
+    clock[0] += 101
+    assert engine.release_reservation(command) == released
+    conflicting_payload = dict(command_payload)
+    conflicting_payload["authorization_failure_receipt_digest"] = digest(
+        "different-auth-failure"
+    )
+    with pytest.raises(ContextFault, match="reservation_release_conflict"):
+        engine.release_reservation(authority.sign(conflicting_payload))
+    fresh_payload = {
+        **_reservation_payload_from_claim(engine, claim),
+        "expires_at": clock[0] + 100,
+        "released_revision": release_claim.revision,
+    }
+    signed_revival = authority.sign(fresh_payload)
+    revived = engine.reserve_v2(signed_revival)
+    revived_claim = ContextReservationReceiptV2.model_validate(
+        verify(revived, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    assert revived_claim.context_cycle_id == claim.context_cycle_id
+    assert revived_claim.revision == release_claim.revision + 1
+    assert engine.reserve_v2(signed_revival) == revived
+    stale_payload = dict(command_payload)
+    stale_payload.update(issued_at=clock[0], expires_at=clock[0] + 100)
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.release_reservation(authority.sign(stale_payload))
+
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.bind_v2(*delayed_binding[:3])
+    fresh_binding = _binding_command(engine, authority, revived, revived_claim, clock)
+    with pytest.raises(ContextFault, match="binding_revision_required"):
+        engine.bind(
+            authority.sign(fresh_binding[3].model_dump(mode="json")),
+            fresh_binding[1],
+            fresh_binding[2],
+        )
+    bound_receipt = ContextService(engine).dispatch(
+        {
+            "operation": "bind_v2",
+            "binding": fresh_binding[0],
+            "authority": fresh_binding[1],
+            "project_snapshot": fresh_binding[2],
+        }
+    )
+    with engine.store.connection() as db:
+        row = db.execute(
+            "SELECT state,revision,binding FROM cycles WHERE id=?",
+            (claim.context_cycle_id,),
+        ).fetchone()
+    assert row["state"] == "ACTIVE" and row["binding"] is not None
+    post_dispatch = _release_payload(
+        engine,
+        claim,
+        clock,
+        expected_revision=row["revision"],
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    )
+    with pytest.raises(ContextFault, match="reservation_release_denied"):
+        engine.release_reservation(authority.sign(post_dispatch))
+    assert bound_receipt["payload"]["binding_digest"] == digest(
+        fresh_binding[3]
+    )
+
+
+def test_signed_post_dispatch_abort_is_exact_replay_safe_and_terminal(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, original_reservation, reservation_receipt, claim = _reservation(
+        engine, authority, clock
+    )
+    delayed_binding = _binding_command(
+        engine, authority, reservation_receipt, claim, clock
+    )
+    command_payload = _abort_payload(
+        engine, claim, reservation_receipt, clock
+    )
+    command = authority.sign(command_payload)
+    service = ContextService(engine)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(
+            pool.map(
+                lambda _: service.dispatch(
+                    {"operation": "abort_reservation", "command": command}
+                ),
+                range(4),
+            )
+        )
+    assert all(item == results[0] for item in results)
+    aborted = results[0]
+    abort_claim = ContextReservationAbortReceiptV1.model_validate(
+        verify(aborted, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    assert abort_claim.abort_command_digest == digest(command_payload)
+    assert abort_claim.objective_id == "retry-objective"
+    assert abort_claim.objective_dispatch_receipt_digest == digest(
+        "objective-dispatch-started"
+    )
+    assert abort_claim.revision == claim.revision + 1
+    assert abort_claim.retention_expires_at == clock[0] + engine.profile.retention_seconds
+    with engine.store.connection() as db:
+        row = db.execute(
+            "SELECT state,revision,expires,binding,reservation_abort_digest "
+            "FROM cycles WHERE id=?",
+            (claim.context_cycle_id,),
+        ).fetchone()
+        events = [json[0] for json in db.execute(
+            "SELECT body FROM events WHERE cycle=?", (claim.context_cycle_id,)
+        )]
+    assert tuple(row) == (
+        "ABORTED",
+        abort_claim.revision,
+        abort_claim.retention_expires_at,
+        None,
+        digest(command_payload),
+    )
+    assert sum("context.reservation_aborted" in event for event in events) == 1
+
+    clock[0] += 101
+    assert engine.abort_reservation(command) == aborted
+    conflict = dict(command_payload)
+    conflict["reason_code"] = "cancel"
+    with pytest.raises(ContextFault, match="reservation_abort_conflict"):
+        engine.abort_reservation(authority.sign(conflict))
+    with pytest.raises(ContextFault, match="reservation_terminal"):
+        engine.reserve_v2(original_reservation)
+    revival = _reservation_payload_from_claim(engine, claim)
+    revival.update(
+        expires_at=clock[0] + 100,
+        released_revision=abort_claim.revision,
+    )
+    with pytest.raises(ContextFault, match="reservation_terminal"):
+        engine.reserve_v2(authority.sign(revival))
+    with pytest.raises(ContextFault, match="state_conflict"):
+        engine.bind_v2(*delayed_binding[:3])
+    release_after_abort = _release_payload(
+        engine,
+        claim,
+        clock,
+        expected_revision=abort_claim.revision,
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    )
+    with pytest.raises(ContextFault, match="reservation_release_denied"):
+        engine.release_reservation(authority.sign(release_after_abort))
+
+
+def test_abort_reservation_and_bind_are_mutually_exclusive(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, reservation_receipt, claim = _reservation(engine, authority, clock)
+    abort_command = authority.sign(
+        _abort_payload(engine, claim, reservation_receipt, clock)
+    )
+    binding = _binding_command(engine, authority, reservation_receipt, claim, clock)
+
+    def attempt(operation):
+        try:
+            if operation == "abort":
+                return operation, engine.abort_reservation(abort_command)
+            return operation, engine.bind_v2(*binding[:3])
+        except ContextFault as exc:
+            return operation, exc.code
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = dict(pool.map(attempt, ("abort", "bind")))
+    successes = [value for value in outcomes.values() if isinstance(value, dict)]
+    assert len(successes) == 1
+    with engine.store.connection() as db:
+        row = db.execute(
+            "SELECT state,binding FROM cycles WHERE id=?", (claim.context_cycle_id,)
+        ).fetchone()
+    if row["state"] == "ABORTED":
+        assert row["binding"] is None
+        assert outcomes["bind"] == "context_state_conflict"
+    else:
+        assert row["state"] == "ACTIVE" and row["binding"] is not None
+        assert outcomes["abort"] == "context_reservation_abort_denied"
+
+
+@pytest.mark.parametrize(
+    "mutation,error",
+    [
+        ({"dispatch_started": False}, "reservation_abort_schema"),
+        ({"unexpected": "field"}, "reservation_abort_schema"),
+        ({"reason_code": "unknown"}, "reservation_abort_schema"),
+        ({"objective_id": "x" * 201}, "reservation_abort_schema"),
+        ({"issued_at": 1000, "expires_at": 1901}, "reservation_abort_schema"),
+        ({"issued_at": 1100, "expires_at": 1200}, "reservation_abort_expired"),
+        ({"owner_id": "other-owner"}, "reservation_abort_denied"),
+        ({"expected_revision": 2}, "stale_state"),
+    ],
+)
+def test_abort_rejects_unclosed_unproven_mismatched_or_stale_commands(
+    hosted, mutation, error  # noqa: F811
+):
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, reservation_receipt, claim = _reservation(engine, authority, clock)
+    payload = _abort_payload(engine, claim, reservation_receipt, clock)
+    payload.update(mutation)
+    with pytest.raises(ContextFault, match=error):
+        engine.abort_reservation(authority.sign(payload))
+
+
+def test_abort_requires_gateway_signer_and_exact_v2_reservation_receipt(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, reservation_receipt, claim = _reservation(engine, authority, clock)
+    payload = _abort_payload(engine, claim, reservation_receipt, clock)
+    stranger = ReceiptSigner("abort-stranger", Ed25519PrivateKey.generate())
+    with pytest.raises(ContextFault, match="signature_invalid"):
+        engine.abort_reservation(stranger.sign(payload))
+
+    forged_receipt = stranger.sign(reservation_receipt["payload"])
+    with pytest.raises(ContextFault, match="reservation_abort_receipt_invalid"):
+        engine.abort_reservation(
+            authority.sign({**payload, "reservation_receipt": forged_receipt})
+        )
+
+    legacy_receipt = engine.reserve(
+        authority.sign(
+            {
+                "operation": "reserve",
+                "owner_id": "retry-owner",
+                "project_id": "retry-project",
+                "idempotency_key": "legacy-abort-ineligible",
+                "request_digest": digest("legacy-abort-ineligible"),
+                "profile_digest": digest(engine.profile),
+                "expires_at": clock[0] + 100,
+            }
+        )
+    )
+    with pytest.raises(ContextFault, match="reservation_abort_receipt_invalid"):
+        engine.abort_reservation(
+            authority.sign({**payload, "reservation_receipt": legacy_receipt})
+        )
+
+
+def test_abort_refuses_released_or_bound_reservations(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, released_receipt, released_claim = _reservation(
+        engine, authority, clock, key="abort-after-release"
+    )
+    release = authority.sign(
+        _release_payload(
+            engine,
+            released_claim,
+            clock,
+            key="abort-after-release",
+        )
+    )
+    released = engine.release_reservation(release)
+    released_abort = _abort_payload(
+        engine,
+        released_claim,
+        released_receipt,
+        clock,
+        key="abort-after-release",
+        expected_revision=released["payload"]["revision"],
+    )
+    with pytest.raises(ContextFault, match="reservation_abort_denied"):
+        engine.abort_reservation(authority.sign(released_abort))
+
+    _, _, bound_receipt, bound_claim = _reservation(
+        engine, authority, clock, key="abort-after-bind"
+    )
+    binding = _binding_command(engine, authority, bound_receipt, bound_claim, clock)
+    engine.bind_v2(*binding[:3])
+    with engine.store.connection() as db:
+        revision = db.execute(
+            "SELECT revision FROM cycles WHERE id=?", (bound_claim.context_cycle_id,)
+        ).fetchone()[0]
+    bound_abort = _abort_payload(
+        engine,
+        bound_claim,
+        bound_receipt,
+        clock,
+        key="abort-after-bind",
+        expected_revision=revision,
+    )
+    with pytest.raises(ContextFault, match="reservation_abort_denied"):
+        engine.abort_reservation(authority.sign(bound_abort))
+
+
+def test_no_dispatch_expiry_is_exact_revivable_and_excludes_release_abort(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, original, reservation_receipt, claim = _reservation(engine, authority, clock)
+    expiry_payload = _expiry_payload(
+        engine, authority, claim, reservation_receipt, clock
+    )
+    expiry_command = authority.sign(expiry_payload)
+    service = ContextService(engine)
+
+    expired = service.dispatch(
+        {"operation": "expire_reservation", "command": expiry_command}
+    )
+    expiry_claim = ContextReservationExpiryReceiptV1.model_validate(
+        verify(expired, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    assert expiry_claim.reservation_receipt_digest == digest(reservation_receipt)
+    assert expiry_claim.invocation_no_dispatch_receipt_digest == expiry_payload[
+        "invocation_no_dispatch_receipt_digest"
+    ]
+    assert expiry_claim.expiry_command_digest == digest(expiry_payload)
+    assert expiry_claim.revision == claim.revision + 1
+    assert engine.expire_reservation(expiry_command) == expired
+
+    release = _release_payload(
+        engine,
+        claim,
+        clock,
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    )
+    with pytest.raises(ContextFault, match="reservation_release_denied"):
+        engine.release_reservation(authority.sign(release))
+    abort = _abort_payload(
+        engine, claim, reservation_receipt, clock
+    )
+    with pytest.raises(ContextFault, match="reservation_abort_denied"):
+        engine.abort_reservation(authority.sign(abort))
+    with pytest.raises(ContextFault, match="reservation_terminal"):
+        engine.reserve_v2(
+            authority.sign(
+                {
+                    **original["payload"],
+                    "expires_at": clock[0] + 100,
+                }
+            )
+        )
+
+    revival_payload = ContextReservationCommandV3(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key="retry-reservation",
+        request_digest=digest("retry-reservation"),
+        profile_digest=digest(engine.profile),
+        expires_at=clock[0] + 100,
+        expired_reservation_receipt=expired,
+    ).model_dump(mode="json")
+    revival = authority.sign(revival_payload)
+    revived = service.dispatch({"operation": "reserve_v3", "reservation": revival})
+    revived_claim = ContextReservationReceiptV3.model_validate(
+        verify(revived, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    assert revived_claim.revision == expiry_claim.revision + 1
+    assert revived_claim.prior_expiry_receipt_digest == digest(expired)
+    assert revived_claim.prior_expiry_revision == expiry_claim.revision
+    assert revived_claim.invocation_no_dispatch_receipt_digest == (
+        expiry_claim.invocation_no_dispatch_receipt_digest
+    )
+    assert revived_claim.revival_command_digest == digest(revival_payload)
+    assert engine.reserve_v3(revival) == revived
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.expire_reservation(expiry_command)
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.reserve_v2(
+            authority.sign(
+                {
+                    **original["payload"],
+                    "expires_at": clock[0] + 100,
+                }
+            )
+        )
+    revived_binding = _binding_command(
+        engine, authority, revived, revived_claim, clock
+    )
+    with pytest.raises(ContextFault, match="binding_invalid"):
+        engine.bind_v2(*revived_binding[:3])
+    bound = service.dispatch(
+        {
+            "operation": "bind_v3",
+            "binding": revived_binding[0],
+            "authority": revived_binding[1],
+            "project_snapshot": revived_binding[2],
+        }
+    )
+    assert bound["payload"]["binding_digest"] == digest(revived_binding[3])
+
+
+def test_no_dispatch_expiry_accepts_natural_sweep_and_loses_bind_race(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, reservation_receipt, claim = _reservation(
+        engine, authority, clock, key="naturally-expired", ttl=10
+    )
+    expiry_payload = _expiry_payload(
+        engine,
+        authority,
+        claim,
+        reservation_receipt,
+        clock,
+        key="naturally-expired",
+    )
+    clock[0] += 11
+    _reservation(engine, authority, clock, key="natural-expiry-trigger")
+    expiry_payload.update(issued_at=clock[0], expires_at=clock[0] + 100)
+    expired = engine.expire_reservation(authority.sign(expiry_payload))
+    assert expired["payload"]["revision"] == claim.revision + 2
+
+    _, _, race_receipt, race_claim = _reservation(
+        engine, authority, clock, key="expiry-bind-race"
+    )
+    expiry_command = authority.sign(
+        _expiry_payload(
+            engine,
+            authority,
+            race_claim,
+            race_receipt,
+            clock,
+            key="expiry-bind-race",
+        )
+    )
+    binding = _binding_command(engine, authority, race_receipt, race_claim, clock)
+
+    def attempt(operation):
+        try:
+            if operation == "expire":
+                return operation, engine.expire_reservation(expiry_command)
+            return operation, engine.bind_v2(*binding[:3])
+        except ContextFault as exc:
+            return operation, exc.code
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        outcomes = dict(pool.map(attempt, ("expire", "bind")))
+    assert sum(isinstance(value, dict) for value in outcomes.values()) == 1
+    with engine.store.connection() as db:
+        row = db.execute(
+            "SELECT state,binding FROM cycles WHERE id=?",
+            (race_claim.context_cycle_id,),
+        ).fetchone()
+    if row["state"] == "EXPIRED":
+        assert row["binding"] is None
+        assert outcomes["bind"] == "context_state_conflict"
+    else:
+        assert row["state"] == "ACTIVE"
+        assert outcomes["expire"] == "context_reservation_expiry_denied"
+
+
+def test_v3_reservation_can_expire_and_revive_across_repeated_generations(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    key = "repeat-expiry"
+    _, _, first_receipt, first_claim = _reservation(
+        engine, authority, clock, key=key
+    )
+    first_expiry_command = authority.sign(
+        _expiry_payload(
+            engine, authority, first_claim, first_receipt, clock, key=key
+        )
+    )
+    first_expiry = engine.expire_reservation(first_expiry_command)
+    first_expiry_claim = ContextReservationExpiryReceiptV1.model_validate(
+        verify(first_expiry, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+
+    first_revival_payload = ContextReservationCommandV3(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expires_at=clock[0] + 100,
+        expired_reservation_receipt=first_expiry,
+    ).model_dump(mode="json")
+    first_revival_command = authority.sign(first_revival_payload)
+    first_revival = engine.reserve_v3(first_revival_command)
+    first_revival_claim = ContextReservationReceiptV3.model_validate(
+        verify(first_revival, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    stale_binding = _binding_command(
+        engine, authority, first_revival, first_revival_claim, clock
+    )
+    stale_abort = authority.sign(
+        _abort_payload(
+            engine,
+            first_revival_claim,
+            first_revival,
+            clock,
+            key=key,
+        )
+    )
+    second_expiry_command = authority.sign(
+        _expiry_payload(
+            engine,
+            authority,
+            first_revival_claim,
+            first_revival,
+            clock,
+            key=key,
+        )
+    )
+    second_expiry = engine.expire_reservation(second_expiry_command)
+    second_expiry_claim = ContextReservationExpiryReceiptV1.model_validate(
+        verify(second_expiry, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    assert second_expiry_claim.revision == first_revival_claim.revision + 1
+    assert second_expiry_claim.reservation_receipt_digest == digest(first_revival)
+
+    second_revival_payload = ContextReservationCommandV3(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expires_at=clock[0] + 100,
+        expired_reservation_receipt=second_expiry,
+    ).model_dump(mode="json")
+    second_revival = engine.reserve_v3(authority.sign(second_revival_payload))
+    second_revival_claim = ContextReservationReceiptV3.model_validate(
+        verify(second_revival, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    assert second_revival_claim.revision == second_expiry_claim.revision + 1
+    assert second_revival_claim.prior_expiry_receipt_digest == digest(second_expiry)
+    assert second_revival_claim.revival_command_digest == digest(second_revival_payload)
+
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.bind_v3(*stale_binding[:3])
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.abort_reservation(stale_abort)
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.expire_reservation(second_expiry_command)
+    with pytest.raises(ContextFault, match="stale_state"):
+        engine.expire_reservation(first_expiry_command)
+    assert first_expiry_claim.revision < second_revival_claim.revision
+
+
+def test_v3_reservation_abort_cleanup_and_replay_survive_retention(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    key = "revived-abort"
+    _, _, first_receipt, first_claim = _reservation(
+        engine, authority, clock, key=key
+    )
+    expired = engine.expire_reservation(
+        authority.sign(
+            _expiry_payload(
+                engine, authority, first_claim, first_receipt, clock, key=key
+            )
+        )
+    )
+    revival_payload = ContextReservationCommandV3(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expires_at=clock[0] + 100,
+        expired_reservation_receipt=expired,
+    ).model_dump(mode="json")
+    revival_receipt = engine.reserve_v3(authority.sign(revival_payload))
+    revival_claim = ContextReservationReceiptV3.model_validate(
+        verify(
+            revival_receipt,
+            {engine.signer.key_id: engine.signer.key.public_key()},
+        )
+    )
+    abort_payload = _abort_payload(
+        engine, revival_claim, revival_receipt, clock, key=key
+    )
+    abort_command = authority.sign(abort_payload)
+    aborted = engine.abort_reservation(abort_command)
+    abort_claim = ContextReservationAbortReceiptV1.model_validate(
+        verify(aborted, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    clock[0] = abort_claim.retention_expires_at
+    cleanup_payload = ContextReservationAbortExpiryCommandV1(
+        namespace=NamespaceV1(
+            owner_id="retry-owner",
+            project_id="retry-project",
+            objective_id="retry-objective",
+            context_cycle_id=revival_claim.context_cycle_id,
+        ),
+        idempotency_key="cleanup-" + key,
+        expected_revision=abort_claim.revision,
+        reason_code="policy_expiry",
+        abort_receipt=aborted,
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    ).model_dump(mode="json")
+    cleanup_command = authority.sign(cleanup_payload)
+    deleted = engine.expire_aborted_reservation(cleanup_command)
+    assert deleted["payload"]["checkpoint_durability_mode"] == "unregistered"
+    clock[0] += 101
+    assert engine.expire_aborted_reservation(cleanup_command) == deleted
+    assert engine.abort_reservation(abort_command) == aborted
+
+
+def test_no_dispatch_expiry_rejects_ambiguous_forged_legacy_and_conflicting_proof(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, reservation_receipt, claim = _reservation(engine, authority, clock)
+    payload = _expiry_payload(engine, authority, claim, reservation_receipt, clock)
+    stranger = ReceiptSigner("expiry-stranger", Ed25519PrivateKey.generate())
+
+    with pytest.raises(ContextFault, match="signature_invalid"):
+        engine.expire_reservation(stranger.sign(payload))
+    ambiguous = _no_dispatch_receipt(
+        engine,
+        authority,
+        claim,
+        reservation_receipt,
+        clock,
+        ledger_snapshot_updates={"state": "dispatch_started"},
+    )
+    ambiguous_payload = {
+        **payload,
+        "invocation_no_dispatch_receipt": ambiguous,
+        "invocation_no_dispatch_receipt_digest": digest(ambiguous),
+    }
+    with pytest.raises(ContextFault, match="invocation_no_dispatch_receipt_invalid"):
+        engine.expire_reservation(authority.sign(ambiguous_payload))
+    forged = stranger.sign(payload["invocation_no_dispatch_receipt"]["payload"])
+    forged_payload = {
+        **payload,
+        "invocation_no_dispatch_receipt": forged,
+        "invocation_no_dispatch_receipt_digest": digest(forged),
+    }
+    with pytest.raises(ContextFault, match="invocation_no_dispatch_receipt_invalid"):
+        engine.expire_reservation(authority.sign(forged_payload))
+
+    legacy = engine.reserve(
+        authority.sign(
+            {
+                "operation": "reserve",
+                "owner_id": "retry-owner",
+                "project_id": "retry-project",
+                "idempotency_key": "expiry-legacy",
+                "request_digest": digest("expiry-legacy"),
+                "profile_digest": digest(engine.profile),
+                "expires_at": clock[0] + 100,
+            }
+        )
+    )
+    with pytest.raises(ContextFault, match="reservation_expiry_receipt_invalid"):
+        engine.expire_reservation(
+            authority.sign({**payload, "reservation_receipt": legacy})
+        )
+
+    command = authority.sign(payload)
+    engine.expire_reservation(command)
+    changed_no_dispatch = _no_dispatch_receipt(
+        engine,
+        authority,
+        claim,
+        reservation_receipt,
+        clock,
+        ledger_snapshot_updates={"revision": 8},
+    )
+    changed = {
+        **payload,
+        "invocation_no_dispatch_receipt": changed_no_dispatch,
+        "invocation_no_dispatch_receipt_digest": digest(changed_no_dispatch),
+    }
+    with pytest.raises(ContextFault, match="reservation_expiry_conflict"):
+        engine.expire_reservation(authority.sign(changed))
+
+
+def _reservation_payload_from_claim(engine, claim):
+    return ContextReservationCommandV2(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key="retry-reservation",
+        request_digest=claim.request_digest,
+        profile_digest=digest(engine.profile),
+        expires_at=1,
+        released_revision=None,
+    ).model_dump(mode="json")
+
+
+def test_natural_expiry_accepts_only_fresh_signed_predispatch_proof(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, _, claim = _reservation(
+        engine, authority, clock, key="retry-reservation", ttl=10
+    )
+    clock[0] += 11
+    _reservation(engine, authority, clock, key="expiry-sweep-trigger")
+    with engine.store.connection() as db:
+        expired = db.execute(
+            "SELECT state,revision FROM cycles WHERE id=?", (claim.context_cycle_id,)
+        ).fetchone()
+    assert tuple(expired) == ("EXPIRED", claim.revision + 1)
+
+    payload = _release_payload(
+        engine,
+        claim,
+        clock,
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    )
+    released = engine.release_reservation(authority.sign(payload))
+    assert released["payload"]["revision"] == expired["revision"] + 1
+    fresh = _reservation_payload_from_claim(engine, claim)
+    fresh["expires_at"] = clock[0] + 100
+    fresh["released_revision"] = released["payload"]["revision"]
+    revived = engine.reserve_v2(authority.sign(fresh))
+    assert revived["payload"]["context_cycle_id"] == claim.context_cycle_id
+
+
+@pytest.mark.parametrize(
+    "mutation,error",
+    [
+        ({"dispatch_started": True}, "reservation_release_schema"),
+        ({"unexpected": "field"}, "reservation_release_schema"),
+        ({"owner_id": "other-owner"}, "reservation_release_denied"),
+        ({"issued_at": 1100, "expires_at": 1200}, "reservation_release_expired"),
+    ],
+)
+def test_release_rejects_unclosed_unproven_or_mismatched_commands(
+    hosted, mutation, error  # noqa: F811
+):
+    engine, _, _, _, authority, _, _, clock = hosted
+    _, _, _, claim = _reservation(engine, authority, clock)
+    payload = _release_payload(engine, claim, clock)
+    payload.update(mutation)
+    with pytest.raises(ContextFault, match=error):
+        engine.release_reservation(authority.sign(payload))
+
+    stranger = ReceiptSigner("stranger", Ed25519PrivateKey.generate())
+    with pytest.raises(ContextFault, match="signature_invalid"):
+        engine.release_reservation(stranger.sign(_release_payload(engine, claim, clock)))
+
+
+def test_v1_reservation_receipt_wire_remains_exact(hosted):  # noqa: F811
+    engine, _, _, _, authority, _, _, clock = hosted
+    receipt = engine.reserve(
+        authority.sign(
+            {
+                "operation": "reserve",
+                "owner_id": "legacy-owner",
+                "project_id": "legacy-project",
+                "idempotency_key": "legacy-reservation",
+                "request_digest": digest("legacy-reservation"),
+                "profile_digest": digest(engine.profile),
+                "expires_at": clock[0] + 100,
+            }
+        )
+    )
+    payload = verify(
+        receipt, {engine.signer.key_id: engine.signer.key.public_key()}
+    )
+    assert ContextReservationReceiptV1.model_validate(payload).model_dump(
+        mode="json"
+    ) == payload
+    assert set(payload) == {
+        "schema_version",
+        "context_cycle_id",
+        "context_bucket_id",
+        "request_digest",
+        "profile_digest",
+    }
+
+
+def test_v1_client_can_bind_checkpoint_seal_and_restart_during_drain(hosted):  # noqa: F811
+    engine, _, _, _, authority, proof, make, clock = hosted
+    key = "legacy-drain-flow"
+    receipt = engine.reserve(
+        authority.sign(
+            {
+                "operation": "reserve",
+                "owner_id": "retry-owner",
+                "project_id": "retry-project",
+                "idempotency_key": key,
+                "request_digest": digest(key),
+                "profile_digest": digest(engine.profile),
+                "expires_at": clock[0] + 100,
+            }
+        )
+    )
+    claim = ContextReservationReceiptV1.model_validate(
+        verify(receipt, {engine.signer.key_id: engine.signer.key.public_key()})
+    )
+    namespace = NamespaceV1(
+        owner_id="retry-owner",
+        project_id="retry-project",
+        objective_id="retry-objective",
+        context_cycle_id=claim.context_cycle_id,
+    )
+    authority_payload = {"objective": "legacy drain", "paths": ["src"]}
+    project_snapshot = {
+        "project_id": "retry-project",
+        "graph_id": "legacy-graph",
+        "policy_digest": digest("retry-policy"),
+        "nodes": [],
+    }
+    binding = ContextBindingV1(
+        namespace=namespace,
+        context_bucket_id=claim.context_bucket_id,
+        repository_id="retry-repository",
+        repo_main_sha="a" * 40,
+        project_graph_id="legacy-graph",
+        graph_revision=1,
+        graph_checksum=digest(project_snapshot),
+        plan_digest=digest("legacy-plan"),
+        execution_profile_digest=digest("legacy-execution-profile"),
+        shared_ir_digest=digest("legacy-ir"),
+        authorization_receipt_ref="legacy-authorization",
+        authorization_digest=digest(authority_payload),
+        policy_digest=digest("retry-policy"),
+        redaction_digest=digest("retry-redaction"),
+        profile_digest=digest(engine.profile),
+        captain_binding_id="legacy-captain",
+        created_at=clock[0],
+        expires_at=clock[0] + 1000,
+    )
+    engine.bind(
+        authority.sign(binding.model_dump(mode="json")),
+        authority_payload,
+        project_snapshot,
+    )
+
+    def capability(role):
+        return authority.sign(
+            CapabilityV1(
+                namespace=namespace,
+                principal_id="legacy-worker",
+                lane_id="legacy-lane",
+                task_id="legacy-task",
+                role=role,
+                operations=["checkpoint", "seal", "status"],
+                source_class="tool_observation",
+                binding_digest=digest(binding),
+                policy_digest=binding.policy_digest,
+                profile_digest=digest(engine.profile),
+                fence=1,
+                expires_at=clock[0] + 1000,
+                max_bytes=32768,
+                max_tokens=12000,
+            ).model_dump(mode="json")
+        )
+
+    checkpoint = engine.checkpoint(capability("durability"), "legacy-checkpoint")
+    with engine.store.connection() as db:
+        durability = db.execute(
+            "SELECT checkpoint_durability_mode,checkpoint_durability_legacy,"
+            "reservation_protocol_version FROM cycles WHERE id=?",
+            (claim.context_cycle_id,),
+        ).fetchone()
+    assert tuple(durability) == ("remote_registered", 1, 1)
+    proof_payload = ClosureProofV1(
+        namespace=namespace,
+        binding_digest=digest(binding),
+        final_root="0" * 64,
+        final_cursor=0,
+        execution_dag_digest=digest("legacy-dag"),
+        plan_ir_digest=binding.shared_ir_digest,
+        shared_ir_digest=digest("legacy-final-ir"),
+        repo_main_sha=binding.repo_main_sha,
+        git_head_sha="b" * 40,
+        pr_head_sha="b" * 40,
+        pr_url="https://github.com/org/repo/pull/1",
+        ci_receipt=digest("legacy-ci"),
+        memory_candidate_digest=digest("legacy-memory"),
+        nano_receipt=digest("legacy-nano"),
+        proof_receipt=digest("legacy-proof"),
+        promotion_set_root=digest([]),
+        accepted_record_ids=[],
+        rejected_record_ids=[],
+        expires_at=clock[0] + 100,
+    )
+    sealed = engine.seal(
+        capability("verifier"),
+        proof.sign(proof_payload.model_dump(mode="json")),
+        checkpoint["receipt"],
+    )
+    reopened = make(engine.store.path)
+    assert reopened.status(capability("verifier"))["payload"]["state"] == "SEALED"
+    assert reopened.seal(
+        capability("verifier"),
+        proof.sign(proof_payload.model_dump(mode="json")),
+        checkpoint["receipt"],
+    ) == sealed
+
+    release = ContextReservationReleaseCommandV1(
+        context_cycle_id=claim.context_cycle_id,
+        owner_id="retry-owner",
+        project_id="retry-project",
+        idempotency_key=key,
+        request_digest=digest(key),
+        profile_digest=digest(engine.profile),
+        expected_revision=1,
+        reason_code="pre_dispatch_authorization_failed",
+        dispatch_started=False,
+        authorization_failure_receipt_digest=digest("legacy-denial"),
+        issued_at=clock[0],
+        expires_at=clock[0] + 100,
+    )
+    with pytest.raises(ContextFault, match="reservation_release_denied"):
+        engine.release_reservation(authority.sign(release.model_dump(mode="json")))

--- a/tests/test_retention_scale.py
+++ b/tests/test_retention_scale.py
@@ -1,9 +1,17 @@
 import base64
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
+import json
 import multiprocessing
 import os
+import py_compile
+import shutil
 import sqlite3
+import sys
+import time
+import traceback
 from collections import namedtuple
+from pathlib import Path
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 import pytest
@@ -11,11 +19,25 @@ import pytest
 from aether_context.contracts import (
     AppendRequestV1,
     CapabilityV1,
+    ContextBindingCommandV2,
     ContextBindingV1,
+    ContextCheckpointDurabilityCommandV1,
+    ContextCheckpointDurabilityReceiptV1,
+    ContextCheckpointDurabilityReceiptV2,
+    ContextDeletionReceiptV2,
+    ContextHealthV1,
+    ContextHealthV2,
+    ContextHydrateCommandV2,
+    ContextHydrateReceiptV2,
     ContextProfileV1,
+    ContextReservationCommandV2,
+    ContextReservationReceiptV2,
     HostedScaleReceiptV1,
     NamespaceV1,
+    RetentionCommandV1,
     RetrieveRequestV1,
+    RuntimeEnvironmentV2,
+    canonical,
     digest,
 )
 from aether_context import __version__
@@ -28,8 +50,243 @@ from aether_context.scale import (
     profile_benchmark_digest,
     qualify_scale_receipt,
     run_namespace_isolation,
+    runtime_environment_identity,
     runtime_package_tree_digest,
 )
+
+
+def _live_ipc_scale_worker(root: str, output) -> None:
+    """Isolated Linux worker so VmHWM covers only the live service scenario."""
+
+    try:
+        import aether_context.engine as engine_module
+        from bench.hosted_scale import _UnixServiceClient
+
+        dependencies = [
+            "annotated-types",
+            "cffi",
+            "cryptography",
+            "numpy",
+            "pycparser",
+            "pydantic",
+            "pydantic_core",
+            "typing-inspection",
+            "typing_extensions",
+        ]
+        environment = RuntimeEnvironmentV2(
+            python_implementation="cpython",
+            python_version="3.13.0",
+            python_abi="cp313-live-ipc-test",
+            python_executable_digest=digest("live-ipc-python"),
+            dependency_import_closure=dependencies,
+            dependency_versions={name: "1.0" for name in dependencies},
+            dependency_artifact_digests={
+                name: digest(name) for name in dependencies
+            },
+            sqlite_version=sqlite3.sqlite_version,
+            package_import_root_digest=digest("live-ipc-site-packages"),
+        )
+        package_digest = digest("live-ipc-package-tree")
+        engine_module.runtime_environment_identity = lambda **_: environment
+        engine_module.runtime_package_tree_digest = lambda **_: package_digest
+        build = ReceiptSigner("live-ipc-build", Ed25519PrivateKey.generate())
+        source_revision = "d" * 40
+        build_manifest = build.sign(
+            {
+                "schema_version": "ContextRuntimeBuildManifestV3",
+                "distribution": "aether-context",
+                "version": __version__,
+                "source_revision": source_revision,
+                "package_tree_digest": package_digest,
+                "wheel_digest": digest("live-ipc-wheel"),
+                "recall_dataset_digest": digest("live-ipc-recall"),
+                "data_plane_case_generator_digest": digest("live-ipc-cases"),
+                "built_at": 900,
+                "runtime_environment": environment.model_dump(mode="json"),
+                "locked_environment_digest": digest(environment),
+            }
+        )
+        item = _keyed_cycle(
+            Path(root),
+            reservation_protocol_version=2,
+            runtime_build_manifest=build_manifest,
+            runtime_build_keys={build.key_id: build.key.public_key()},
+            profile_overrides={
+                "max_records": 70,
+                "max_indexed_bytes": 15_500_000,
+                "max_record_bytes": 250_000,
+                "max_checkpoint_bytes": 16_000_000,
+                "max_operations_per_cycle": 256,
+                "max_concurrent_cycles": 4,
+                "max_calls_per_minute": 6000,
+            },
+        )
+        alphabet = bytes(
+            value for value in range(33, 127) if value not in b":=-"
+        )
+        for index in range(61):
+            source = hashlib.shake_256(f"live-ipc-{index}".encode()).digest(
+                248_000
+            )
+            text = bytes(alphabet[value % len(alphabet)] for value in source).decode()
+            item["engine"].append(
+                item["cap"](),
+                AppendRequestV1(
+                    idempotency_key=f"live-ipc-fill-{index}",
+                    text=text,
+                    action_ref=f"live-ipc-fill-{index}",
+                ),
+            )
+        service = ContextService(item["engine"])
+        checkpoint_request = {
+            "operation": "checkpoint",
+            "capability": item["cap"]("durability"),
+            "idempotency_key": "live-ipc-near-bound",
+        }
+        with _UnixServiceClient(service) as client:
+            with ThreadPoolExecutor(max_workers=5) as executor:
+                checkpoint_future = executor.submit(
+                    client.dispatch,
+                    checkpoint_request,
+                    read_chunk_size=16_384,
+                    read_delay_seconds=0.001,
+                )
+                deadline = time.monotonic() + 120
+                while time.monotonic() < deadline:
+                    with item["engine"].store.connection() as db:
+                        if db.execute("SELECT checkpoint FROM cycles").fetchone()[0]:
+                            break
+                    time.sleep(0.01)
+                else:
+                    raise AssertionError("live checkpoint did not commit")
+                small_requests = [
+                    {
+                        "operation": "status",
+                        "capability": item["cap"]("durability"),
+                        "after": 0,
+                    },
+                    {
+                        "operation": "status",
+                        "capability": item["cap"]("durability"),
+                        "after": 0,
+                    },
+                    {
+                        "operation": "retrieve",
+                        "capability": item["cap"](),
+                        "request": RetrieveRequestV1(
+                            turn_id="live-ipc-concurrent-retrieve",
+                            query="unlikely-query",
+                            native_window=32768,
+                            remaining_prompt_budget=4096,
+                        ).model_dump(mode="json"),
+                    },
+                    {
+                        "operation": "append",
+                        "capability": item["cap"](),
+                        "request": AppendRequestV1(
+                            idempotency_key="live-ipc-concurrent-append",
+                            text="concurrent small request",
+                            action_ref="live-ipc-concurrent-append",
+                        ).model_dump(mode="json"),
+                    },
+                ]
+                small = list(executor.map(client.dispatch, small_requests))
+                checkpoint = checkpoint_future.result(timeout=180)
+        assert len(small) == item["profile"].max_concurrent_cycles
+        raw_pack = base64.b64decode(checkpoint["pack"], validate=True)
+        assert (
+            len(raw_pack) * 10
+            >= service.max_live_hydrate_pack_bytes * 9
+        )
+        before = item["engine"].status(item["cap"]("durability"))["payload"]
+        with pytest.raises(ContextFault, match="checkpoint_transport_limit"):
+            item["engine"].checkpoint(
+                item["cap"]("durability"),
+                "live-ipc-near-bound",
+                transport_max_bytes=len(raw_pack) - 1,
+            )
+        after = item["engine"].status(item["cap"]("durability"))["payload"]
+        assert (after["revision"], after["checkpoint_number"]) == (
+            before["revision"],
+            before["checkpoint_number"],
+        )
+
+        claim = checkpoint["receipt"]["payload"]
+        hydrate_command = item["authority"].sign(
+            ContextHydrateCommandV2(
+                namespace=item["namespace"],
+                manifest_checksum=claim["manifest_checksum"],
+                key_ref=claim["key_ref"],
+                key_provider=claim["key_provider"],
+                key_version=claim["key_version"],
+                fence=2,
+                expected_source_revision=source_revision,
+                issued_at=item["clock"][0],
+                expires_at=item["clock"][0] + 900,
+            ).model_dump(mode="json")
+        )
+        replacement = item["make"](Path(root) / "live-ipc-replacement.sqlite3")
+        replacement_service = ContextService(
+            replacement,
+            checkpoint_receipt_keys={
+                item["service"].key_id: item["service"].key.public_key()
+            },
+        )
+        hydrate_request = {
+            "operation": "hydrate",
+            "grant": hydrate_command,
+            "checkpoint_receipt": checkpoint["receipt"],
+            "pack": checkpoint["pack"],
+        }
+        with _UnixServiceClient(replacement_service) as client:
+            hydrated = client.dispatch(hydrate_request)
+            assert client.dispatch(hydrate_request) == hydrated
+        assert hydrated["payload"]["schema_version"] == "ContextHydrateReceiptV2"
+        peak = 0
+        for line in Path("/proc/self/status").read_text().splitlines():
+            if line.startswith("VmHWM:"):
+                peak = int(line.split()[1]) * 1024
+                break
+        assert 0 < peak <= 480 * 1024 * 1024
+        output.put(
+            {
+                "pack_bytes": len(raw_pack),
+                "live_pack_limit_bytes": service.max_live_hydrate_pack_bytes,
+                "peak_rss_bytes": peak,
+                "small_calls": len(small),
+            }
+        )
+    except BaseException:
+        output.put({"error": traceback.format_exc()})
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or os.environ.get("AETHER_LIVE_IPC_SCALE") != "1",
+    reason="dedicated Linux live-IPC memory gate",
+)
+def test_live_unix_ipc_near_cap_memory_and_concurrency_gate(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    output = context.Queue()
+    process = context.Process(
+        target=_live_ipc_scale_worker,
+        args=(str(tmp_path / "live-worker"), output),
+    )
+    process.start()
+    process.join(timeout=300)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=10)
+        pytest.fail("live IPC memory worker timed out")
+    assert process.exitcode == 0
+    result = output.get(timeout=10)
+    print(f"live IPC evidence: {result}")
+    assert "error" not in result, result.get("error")
+    assert (
+        result["pack_bytes"] * 10
+        >= result["live_pack_limit_bytes"] * 9
+    )
+    assert result["peak_rss_bytes"] <= 480 * 1024 * 1024
+    assert result["small_calls"] == 4
 
 
 class ManagedTestCycleKeys(FileCycleKeyProvider):
@@ -84,20 +341,35 @@ def _crash_uncommitted_write(path: str) -> None:
     os._exit(17)
 
 
-def _keyed_cycle(tmp_path, *, managed=True, keyed=True, legacy_binding=False):
+def _keyed_cycle(
+    tmp_path,
+    *,
+    managed=True,
+    keyed=True,
+    legacy_binding=False,
+    durability_mode="remote_registered",
+    register_durability=True,
+    reservation_protocol_version=1,
+    runtime_build_manifest=None,
+    runtime_build_keys=None,
+    profile_overrides=None,
+):
     authority = ReceiptSigner("gateway-retention", Ed25519PrivateKey.generate())
     proof = ReceiptSigner("proof-retention", Ed25519PrivateKey.generate())
     deletion = ReceiptSigner("object-store-deletion", Ed25519PrivateKey.generate())
     provider_authority = ReceiptSigner("key-provider-authority", Ed25519PrivateKey.generate())
     destruction = ReceiptSigner("kms-destruction", Ed25519PrivateKey.generate())
     service = ReceiptSigner("contextd-retention", Ed25519PrivateKey.generate())
-    profile = ContextProfileV1(
+    profile_values = dict(
         index_version=sqlite3.sqlite_version,
         disk_free_floor=0,
         max_records=100,
         max_indexed_bytes=1_000_000,
+        max_checkpoint_bytes=16_000_000,
         retention_seconds=60,
     )
+    profile_values.update(profile_overrides or {})
+    profile = ContextProfileV1(**profile_values)
     clock = [1000]
     global_cipher = EnvelopeCipher(os.urandom(32))
     provider = None
@@ -149,22 +421,29 @@ def _keyed_cycle(tmp_path, *, managed=True, keyed=True, legacy_binding=False):
                 else None
             ),
             key_destruction_keys={destruction.key_id: destruction.key.public_key()},
+            runtime_build_manifest=runtime_build_manifest,
+            runtime_build_keys=runtime_build_keys,
         )
 
     engine = make(tmp_path / "context.sqlite3")
-    reservation = engine.reserve(
-        authority.sign(
-            {
-                "operation": "reserve",
-                "owner_id": "owner-retention",
-                "project_id": "project-retention",
-                "idempotency_key": "request-retention",
-                "request_digest": digest("request-retention"),
-                "profile_digest": digest(profile),
-                "expires_at": 1500,
-            }
-        )
-    )
+    reservation_payload = {
+        "operation": "reserve",
+        "owner_id": "owner-retention",
+        "project_id": "project-retention",
+        "idempotency_key": "request-retention",
+        "request_digest": digest("request-retention"),
+        "profile_digest": digest(profile),
+        "expires_at": 1500,
+    }
+    if reservation_protocol_version == 2:
+        reservation_payload = ContextReservationCommandV2(
+            **reservation_payload
+        ).model_dump(mode="json")
+        reservation = engine.reserve_v2(authority.sign(reservation_payload))
+    elif reservation_protocol_version == 1:
+        reservation = engine.reserve(authority.sign(reservation_payload))
+    else:
+        raise ValueError("unsupported test reservation protocol")
     namespace = NamespaceV1(
         owner_id="owner-retention",
         project_id="project-retention",
@@ -202,7 +481,42 @@ def _keyed_cycle(tmp_path, *, managed=True, keyed=True, legacy_binding=False):
     if legacy_binding:
         binding_payload.pop("retention_class")
     binding_digest = digest(binding_payload)
-    engine.bind(authority.sign(binding_payload), authority_payload, snapshot)
+    if reservation_protocol_version == 2:
+        reservation_claim = ContextReservationReceiptV2.model_validate(
+            verify(reservation, {service.key_id: service.key.public_key()})
+        )
+        engine.bind_v2(
+            authority.sign(
+                ContextBindingCommandV2(
+                    binding=ContextBindingV1.model_validate(binding_payload),
+                    reservation_receipt=reservation,
+                    expected_reservation_revision=reservation_claim.revision,
+                ).model_dump(mode="json")
+            ),
+            authority_payload,
+            snapshot,
+        )
+    else:
+        engine.bind(authority.sign(binding_payload), authority_payload, snapshot)
+    durability_command = None
+    durability_receipt = None
+    if register_durability:
+        with engine.store.connection() as db:
+            durability_revision = db.execute(
+                "SELECT revision FROM cycles WHERE id=?", (namespace.context_cycle_id,)
+            ).fetchone()[0]
+        durability_payload = ContextCheckpointDurabilityCommandV1(
+            namespace=namespace,
+            idempotency_key="checkpoint-durability",
+            expected_revision=durability_revision,
+            mode=durability_mode,
+            issued_at=clock[0],
+            expires_at=clock[0] + 100,
+        ).model_dump(mode="json")
+        durability_command = authority.sign(durability_payload)
+        durability_receipt = engine.register_checkpoint_durability(
+            durability_command
+        )
 
     def cap(role="worker", fence=1, source="tool_observation"):
         return authority.sign(
@@ -227,7 +541,7 @@ def _keyed_cycle(tmp_path, *, managed=True, keyed=True, legacy_binding=False):
                 profile_digest=digest(profile),
                 fence=fence,
                 expires_at=90000,
-                max_bytes=32768,
+                max_bytes=profile.max_record_bytes,
                 max_tokens=12000,
             ).model_dump()
         )
@@ -312,11 +626,20 @@ def _keyed_cycle(tmp_path, *, managed=True, keyed=True, legacy_binding=False):
         "binding_digest": binding_digest,
         "clock": clock,
         "profile": profile,
+        "durability_command": durability_command,
+        "durability_receipt": durability_receipt,
     }
 
 
 def test_retention_default_and_hard_ceiling():
-    assert ContextProfileV1(index_version=sqlite3.sqlite_version).retention_seconds == 86400
+    omitted = ContextProfileV1(index_version=sqlite3.sqlite_version)
+    explicit = ContextProfileV1(
+        index_version=sqlite3.sqlite_version,
+        max_checkpoint_bytes=64_000_000,
+    )
+    assert omitted.retention_seconds == 86400
+    assert omitted.max_checkpoint_bytes == 64_000_000
+    assert digest(omitted) == digest(explicit)
     with pytest.raises(ValueError):
         ContextProfileV1(index_version=sqlite3.sqlite_version, retention_seconds=604801)
 
@@ -347,6 +670,203 @@ def test_storage_v2_additively_migrates_legacy_cycles(tmp_path):
         assert row["cleanup_request_digest"] is None
         assert row["key_ref"] is None
         assert row["snapshot"] is None
+        assert row["checkpoint_durability_mode"] == "remote_registered"
+        assert row["checkpoint_durability_legacy"] == 1
+        assert row["checkpoint_durability_command_digest"] is None
+        assert row["reservation_release_digest"] is None
+        db.execute(
+            "INSERT INTO cycles(id,owner,project,request_key,request_digest,profile,state,root,"
+            "expires) VALUES('old-writer-new','owner','project','key-2','digest','profile',"
+            "'RESERVED',?,2)",
+            ("0" * 64,),
+        )
+        inserted = db.execute(
+            "SELECT checkpoint_durability_mode,checkpoint_durability_legacy FROM cycles "
+            "WHERE id='old-writer-new'"
+        ).fetchone()
+        # A writer that omits reservation_protocol_version is a V1 writer.
+        # The explicit drain path preserves its legacy remote-checkpoint behavior.
+        assert tuple(inserted) == ("remote_registered", 1)
+
+
+@pytest.mark.parametrize("interrupt_after", ["mode", "legacy", "backfill"])
+def test_durability_migration_rolls_back_every_partial_semantic_step(
+    tmp_path, monkeypatch, interrupt_after
+):
+    path = tmp_path / f"legacy-crash-{interrupt_after}.sqlite3"
+    with sqlite3.connect(path) as db:
+        db.execute(
+            "CREATE TABLE cycles (id TEXT PRIMARY KEY,owner TEXT NOT NULL,project TEXT NOT NULL,"
+            "request_key TEXT NOT NULL,request_digest TEXT NOT NULL,profile TEXT NOT NULL,"
+            "state TEXT NOT NULL,revision INTEGER NOT NULL DEFAULT 1,fence INTEGER NOT NULL "
+            "DEFAULT 1,binding TEXT,binding_digest TEXT,authority BLOB,cursor INTEGER NOT NULL "
+            "DEFAULT 0,root TEXT NOT NULL,bytes INTEGER NOT NULL DEFAULT 0,expires INTEGER NOT "
+            "NULL,hold INTEGER NOT NULL DEFAULT 0,checkpoint INTEGER NOT NULL DEFAULT 0,"
+            "UNIQUE(owner,project,request_key))"
+        )
+        db.execute(
+            "INSERT INTO cycles(id,owner,project,request_key,request_digest,profile,state,root,"
+            "expires) VALUES('legacy','owner','project','key','digest','profile','EXPIRED',?,1)",
+            ("0" * 64,),
+        )
+
+    original = SegmentStoreV2._migrate_cycles
+
+    def interrupted(db):
+        db.execute("ALTER TABLE cycles ADD COLUMN snapshot BLOB")
+        db.execute(
+            "ALTER TABLE cycles ADD COLUMN checkpoint_durability_mode "
+            "TEXT NOT NULL DEFAULT 'unregistered'"
+        )
+        if interrupt_after == "mode":
+            raise RuntimeError("simulated migration loss")
+        db.execute(
+            "ALTER TABLE cycles ADD COLUMN checkpoint_durability_legacy "
+            "INTEGER NOT NULL DEFAULT 0"
+        )
+        if interrupt_after == "legacy":
+            raise RuntimeError("simulated migration loss")
+        db.execute(
+            "UPDATE cycles SET checkpoint_durability_mode='remote_registered',"
+            "checkpoint_durability_legacy=1"
+        )
+        raise RuntimeError("simulated migration loss")
+
+    monkeypatch.setattr(SegmentStoreV2, "_migrate_cycles", staticmethod(interrupted))
+    with pytest.raises(RuntimeError, match="simulated migration loss"):
+        SegmentStoreV2(path, 1_048_576)
+    with sqlite3.connect(path) as db:
+        columns = {row[1] for row in db.execute("PRAGMA table_info(cycles)")}
+        assert "snapshot" not in columns
+        assert "checkpoint_durability_mode" not in columns
+        assert "checkpoint_durability_legacy" not in columns
+
+    monkeypatch.setattr(SegmentStoreV2, "_migrate_cycles", staticmethod(original))
+    store = SegmentStoreV2(path, 1_048_576)
+    with store.connection() as db:
+        row = db.execute(
+            "SELECT checkpoint_durability_mode,checkpoint_durability_legacy "
+            "FROM cycles WHERE id='legacy'"
+        ).fetchone()
+        assert tuple(row) == ("remote_registered", 1)
+
+
+def test_checkpoint_durability_registration_is_closed_and_lost_ack_safe(tmp_path):
+    item = _keyed_cycle(tmp_path)
+    receipt = item["durability_receipt"]
+    claim = ContextCheckpointDurabilityReceiptV1.model_validate(
+        verify(
+            receipt,
+            {item["engine"].signer.key_id: item["engine"].signer.key.public_key()},
+        )
+    )
+    assert claim.mode == "remote_registered"
+    checkpoint = item["engine"].checkpoint(
+        item["cap"]("durability"), "durability-registration-checkpoint"
+    )
+    assert "durability_mode" not in checkpoint["receipt"]["payload"]
+    item["clock"][0] += 101
+    assert ContextService(item["engine"]).dispatch(
+        {
+            "operation": "checkpoint_durability",
+            "command": item["durability_command"],
+        }
+    ) == receipt
+
+    conflicting = dict(item["durability_command"]["payload"])
+    conflicting["mode"] = "local_ephemeral"
+    with pytest.raises(ContextFault, match="checkpoint_durability_conflict"):
+        item["engine"].register_checkpoint_durability(
+            item["authority"].sign(conflicting)
+        )
+    extra = dict(item["durability_command"]["payload"])
+    extra["unexpected"] = True
+    with pytest.raises(ContextFault, match="checkpoint_durability_schema"):
+        item["engine"].register_checkpoint_durability(item["authority"].sign(extra))
+
+
+def test_fresh_cycle_cannot_checkpoint_or_claim_remote_before_registration(tmp_path):
+    item = _keyed_cycle(
+        tmp_path, register_durability=False, reservation_protocol_version=2
+    )
+    with item["engine"].store.connection() as db:
+        row = db.execute(
+            "SELECT checkpoint_durability_mode,checkpoint_durability_receipt "
+            "FROM cycles WHERE id=?",
+            (item["namespace"].context_cycle_id,),
+        ).fetchone()
+    assert tuple(row) == ("unregistered", None)
+    with pytest.raises(ContextFault, match="checkpoint_durability_unregistered"):
+        item["engine"].checkpoint(
+            item["cap"]("durability"), "unregistered-checkpoint"
+        )
+
+
+def test_local_ephemeral_checkpoint_expires_without_remote_deletion_proof(tmp_path):
+    item = _keyed_cycle(tmp_path, durability_mode="local_ephemeral")
+    checkpoint, _ = item["seal"]()
+    assert "durability_mode" not in checkpoint["receipt"]["payload"]
+    with item["engine"].store.connection() as db:
+        assert db.execute(
+            "SELECT checkpoint_durability_mode FROM cycles WHERE id=?",
+            (item["namespace"].context_cycle_id,),
+        ).fetchone()[0] == "local_ephemeral"
+    item["clock"][0] = 1061
+    with pytest.raises(ContextFault, match="remote_deletion_proof_mismatch"):
+        item["engine"].retention(
+            item["cap"]("durability"), item["expire_command"](checkpoint)
+        )
+    key_ref = checkpoint["receipt"]["payload"]["key_ref"]
+    item["provider"].cipher(key_ref, item["namespace"].model_dump())
+
+    status = item["engine"].status(item["cap"]("durability"))["payload"]
+    command = item["authority"].sign(
+        RetentionCommandV1(
+            operation="expire",
+            namespace=item["namespace"],
+            idempotency_key="expire-local-ephemeral",
+            expected_revision=status["revision"],
+            reason_code="policy_expiry",
+            remote_deletion_receipt=None,
+            checkpoint_object_ref_digest=None,
+            issued_at=item["clock"][0],
+            expires_at=item["clock"][0] + 100,
+        ).model_dump(mode="json")
+    )
+    deleted = item["engine"].retention(item["cap"]("durability"), command)
+    assert deleted["payload"]["cryptographic_erasure"] is True
+    assert deleted["payload"]["remote_deletion_receipt_digest"] is None
+    assert deleted["payload"]["checkpoint_durability_mode"] == "local_ephemeral"
+    assert (
+        deleted["payload"]["checkpoint_manifest_checksum"]
+        == checkpoint["receipt"]["payload"]["manifest_checksum"]
+    )
+
+
+def test_remote_registered_checkpoint_still_requires_deletion_before_key_destroy(tmp_path):
+    item = _keyed_cycle(tmp_path, durability_mode="remote_registered")
+    checkpoint, _ = item["seal"]()
+    item["clock"][0] = 1061
+    status = item["engine"].status(item["cap"]("durability"))["payload"]
+    missing = item["authority"].sign(
+        RetentionCommandV1(
+            operation="expire",
+            namespace=item["namespace"],
+            idempotency_key="expire-without-remote-proof",
+            expected_revision=status["revision"],
+            reason_code="policy_expiry",
+            remote_deletion_receipt=None,
+            checkpoint_object_ref_digest=None,
+            issued_at=item["clock"][0],
+            expires_at=item["clock"][0] + 100,
+        ).model_dump(mode="json")
+    )
+    with pytest.raises(ContextFault, match="remote_deletion_proof_required"):
+        item["engine"].retention(item["cap"]("durability"), missing)
+    item["provider"].cipher(
+        checkpoint["receipt"]["payload"]["key_ref"],
+        item["namespace"].model_dump(),
+    )
 
 
 def test_v1_legacy_binding_and_checkpoint_round_trip_without_default_digest_rewrite(
@@ -374,6 +894,9 @@ def test_v1_legacy_binding_and_checkpoint_round_trip_without_default_digest_rewr
     snapshot.pop("key_provider")
     snapshot.pop("key_version")
     snapshot.pop("retention_class")
+    snapshot.pop("checkpoint_durability_mode")
+    snapshot.pop("checkpoint_durability_command_digest")
+    snapshot.pop("checkpoint_durability_receipt")
     legacy_pack = item["global_cipher"].encrypt(
         snapshot, {"namespace": namespace, "domain": "checkpoint/v1"}
     )
@@ -392,7 +915,7 @@ def test_v1_legacy_binding_and_checkpoint_round_trip_without_default_digest_rewr
                 "namespace": namespace,
                 "manifest_checksum": legacy_claim["manifest_checksum"],
                 "fence": 2,
-                "expires_at": 2000,
+                "expires_at": 1900,
             }
         ),
         legacy_receipt,
@@ -467,6 +990,123 @@ def test_signed_hold_release_and_due_selection(tmp_path):
     assert checkpoint["receipt"]["payload"]["key_ref"]
 
 
+def test_hold_and_release_lost_ack_replay_survives_later_state_and_restart(tmp_path):
+    item = _keyed_cycle(tmp_path)
+    item["seal"]()
+    engine, cap, authority, namespace, clock = (
+        item["engine"],
+        item["cap"],
+        item["authority"],
+        item["namespace"],
+        item["clock"],
+    )
+
+    def command(operation, reason, key, revision):
+        return authority.sign(
+            RetentionCommandV1(
+                operation=operation,
+                namespace=namespace,
+                idempotency_key=key,
+                expected_revision=revision,
+                reason_code=reason,
+                remote_deletion_receipt=None,
+                checkpoint_object_ref_digest=None,
+                issued_at=clock[0],
+                expires_at=clock[0] + 100,
+            ).model_dump(mode="json")
+        )
+
+    revision = engine.status(cap("durability"))["payload"]["revision"]
+    hold_command = command("hold", "legal_hold", "hold-lost-ack", revision)
+    held = engine.retention(cap("durability"), hold_command)
+    release_command = command(
+        "release", "hold_released", "release-lost-ack", held["payload"]["revision"]
+    )
+    released = engine.retention(cap("durability"), release_command)
+    newer_hold_command = command(
+        "hold", "incident_hold", "hold-after-release", released["payload"]["revision"]
+    )
+    engine.retention(cap("durability"), newer_hold_command)
+
+    # Reconciliation happens after the original authority windows close and
+    # after the current hold state/revision have moved on.
+    clock[0] += 101
+    assert engine.retention(cap("durability"), hold_command) == held
+    assert engine.retention(cap("durability"), release_command) == released
+    reopened = item["make"](engine.store.path)
+    assert reopened.retention(cap("durability"), hold_command) == held
+    assert reopened.retention(cap("durability"), release_command) == released
+
+
+@pytest.mark.parametrize("operation,reason", [("hold", "legal_hold"), ("release", "hold_released")])
+def test_hold_release_replay_rejects_tampered_persisted_result(
+    tmp_path, operation, reason
+):
+    item = _keyed_cycle(tmp_path)
+    item["seal"]()
+    engine, cap, authority, namespace = (
+        item["engine"],
+        item["cap"],
+        item["authority"],
+        item["namespace"],
+    )
+    revision = engine.status(cap("durability"))["payload"]["revision"]
+    if operation == "release":
+        held = engine.retention(
+            cap("durability"),
+            authority.sign(
+                RetentionCommandV1(
+                    operation="hold",
+                    namespace=namespace,
+                    idempotency_key="hold-before-tamper",
+                    expected_revision=revision,
+                    reason_code="legal_hold",
+                    remote_deletion_receipt=None,
+                    checkpoint_object_ref_digest=None,
+                    issued_at=item["clock"][0],
+                    expires_at=item["clock"][0] + 100,
+                ).model_dump(mode="json")
+            ),
+        )
+        revision = held["payload"]["revision"]
+    command = authority.sign(
+        RetentionCommandV1(
+            operation=operation,
+            namespace=namespace,
+            idempotency_key=f"{operation}-tampered-result",
+            expected_revision=revision,
+            reason_code=reason,
+            remote_deletion_receipt=None,
+            checkpoint_object_ref_digest=None,
+            issued_at=item["clock"][0],
+            expires_at=item["clock"][0] + 100,
+        ).model_dump(mode="json")
+    )
+    engine.retention(cap("durability"), command)
+    with engine.store.transaction() as db:
+        stored = json.loads(
+            db.execute(
+                "SELECT result FROM retention_operations WHERE cycle=? AND operation=? "
+                "AND key=?",
+                (namespace.context_cycle_id, operation, f"{operation}-tampered-result"),
+            ).fetchone()[0]
+        )
+        stored["signature"] = "A" * len(stored["signature"])
+        db.execute(
+            "UPDATE retention_operations SET result=? WHERE cycle=? AND operation=? "
+            "AND key=?",
+            (
+                canonical(stored).decode(),
+                namespace.context_cycle_id,
+                operation,
+                f"{operation}-tampered-result",
+            ),
+        )
+    reopened = item["make"](engine.store.path)
+    with pytest.raises(ContextFault, match="integrity_failure"):
+        reopened.retention(cap("durability"), command)
+
+
 def test_stale_release_cannot_clear_a_newer_incident_hold(tmp_path):
     item = _keyed_cycle(tmp_path)
     item["seal"]()
@@ -539,6 +1179,12 @@ def test_secure_expiry_is_idempotent_and_file_provider_never_claims_production_e
         command["payload"]["remote_deletion_receipt"]
     )
     assert engine.retention(cap("durability"), command) == receipt
+    if managed:
+        engine.managed_key_provider_receipts = ()
+        assert engine.retention(cap("durability"), command) == receipt
+        item["provider_receipts"].clear()
+        reopened = item["make"](engine.store.path)
+        assert reopened.retention(cap("durability"), command) == receipt
     with pytest.raises(ContextFault, match="key_destroyed"):
         item["provider"].cipher(
             checkpoint["receipt"]["payload"]["key_ref"],
@@ -549,6 +1195,105 @@ def test_secure_expiry_is_idempotent_and_file_provider_never_claims_production_e
     assert status["payload"]["cleanup_state"] == "COMPLETE"
     with engine.store.connection() as db:
         assert db.execute("SELECT count(*) FROM segments").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("modern", [False, True])
+@pytest.mark.parametrize("tamper_target", ["operation", "cycle"])
+def test_deletion_replay_rejects_tampered_v1_v2_persisted_evidence_after_restart(
+    tmp_path, modern, tamper_target
+):
+    item = _keyed_cycle(
+        tmp_path,
+        managed=modern,
+        register_durability=modern,
+    )
+    checkpoint, _ = item["seal"]()
+    item["clock"][0] = 1061
+    command = item["expire_command"](checkpoint)
+    receipt = item["engine"].retention(item["cap"]("durability"), command)
+    assert receipt["payload"]["schema_version"] == (
+        "ContextDeletionReceiptV2" if modern else "ContextDeletionReceiptV1"
+    )
+    with item["engine"].store.transaction() as db:
+        stored = json.loads(
+            db.execute(
+                "SELECT result FROM retention_operations WHERE cycle=? "
+                "AND operation='expire' AND key=?",
+                (
+                    item["namespace"].context_cycle_id,
+                    command["payload"]["idempotency_key"],
+                ),
+            ).fetchone()[0]
+        )
+        stored["signature"] = "A" * len(stored["signature"])
+        if tamper_target == "operation":
+            db.execute(
+                "UPDATE retention_operations SET result=? WHERE cycle=? "
+                "AND operation='expire' AND key=?",
+                (
+                    canonical(stored).decode(),
+                    item["namespace"].context_cycle_id,
+                    command["payload"]["idempotency_key"],
+                ),
+            )
+        else:
+            db.execute(
+                "UPDATE cycles SET deletion_receipt=? WHERE id=?",
+                (
+                    canonical(stored).decode(),
+                    item["namespace"].context_cycle_id,
+                ),
+            )
+    reopened = item["make"](item["engine"].store.path)
+    with pytest.raises(ContextFault, match="integrity_failure"):
+        reopened.retention(item["cap"]("durability"), command)
+
+
+def test_deletion_v2_rejects_incomplete_or_contradictory_erasure_claims(tmp_path):
+    item = _keyed_cycle(tmp_path)
+    checkpoint, _ = item["seal"]()
+    item["clock"][0] = 1061
+    valid = item["engine"].retention(
+        item["cap"]("durability"), item["expire_command"](checkpoint)
+    )["payload"]
+    assert ContextDeletionReceiptV2.model_validate(valid)
+
+    without_managed_proof = {
+        **valid,
+        "key_destruction_receipt": None,
+        "key_destruction_receipt_digest": None,
+        "managed_key_provider_receipt_digest": None,
+    }
+    with pytest.raises(ValueError, match="cryptographic erasure"):
+        ContextDeletionReceiptV2.model_validate(without_managed_proof)
+
+    incomplete = {**valid, "key_destruction_receipt_digest": None}
+    with pytest.raises(ValueError, match="must be complete"):
+        ContextDeletionReceiptV2.model_validate(incomplete)
+
+    mismatched = {**valid, "key_destruction_receipt_digest": digest("wrong")}
+    with pytest.raises(ValueError, match="receipt digest mismatch"):
+        ContextDeletionReceiptV2.model_validate(mismatched)
+
+    contradictory = {
+        **valid,
+        "local_key_destruction": {
+            "schema_version": "ContextLocalKeyDestructionV1",
+            "provider": "file-wrapped-dek/v1",
+            "key_ref": valid["key_destruction_receipt"]["payload"]["key_ref"],
+            "key_version": valid["key_destruction_receipt"]["payload"]["key_version"],
+            "namespace_digest": digest(item["namespace"]),
+            "wrapped_key_digest": digest("local tombstone"),
+            "destroyed_at": 1061,
+            "verified": True,
+        },
+    }
+    with pytest.raises(ValueError, match="exclusive"):
+        ContextDeletionReceiptV2.model_validate(contradictory)
+
+    false_with_managed_proof = {**valid, "cryptographic_erasure": False}
+    with pytest.raises(ValueError, match="cryptographic erasure"):
+        ContextDeletionReceiptV2.model_validate(false_with_managed_proof)
 
 
 def test_remote_deletion_must_match_before_key_destruction(tmp_path):
@@ -691,6 +1436,56 @@ def test_aborted_cycle_gets_post_terminal_retention_without_remote_proof_if_neve
     assert deleted["payload"]["remote_deletion_receipt_digest"] is None
 
 
+def test_unregistered_aborted_cycle_without_checkpoint_can_be_cleaned_up(tmp_path):
+    item = _keyed_cycle(
+        tmp_path, register_durability=False, reservation_protocol_version=2
+    )
+    status = item["engine"].status(item["cap"]())["payload"]
+    item["engine"].control(
+        item["authority"].sign(
+            {
+                "operation": "abort",
+                "context_cycle_id": item["namespace"].context_cycle_id,
+                "binding_digest": item["binding_digest"],
+                "expected_revision": status["revision"],
+                "fence": status["fence"],
+                "expires_at": 1100,
+            }
+        )
+    )
+    aborted = item["engine"].status(item["cap"]())["payload"]
+    item["clock"][0] = aborted["expires_at"] + 1
+    command = item["authority"].sign(
+        RetentionCommandV1(
+            operation="expire",
+            namespace=item["namespace"],
+            idempotency_key="expire-unregistered-abort",
+            expected_revision=aborted["revision"],
+            reason_code="policy_expiry",
+            remote_deletion_receipt=None,
+            checkpoint_object_ref_digest=None,
+            issued_at=item["clock"][0],
+            expires_at=item["clock"][0] + 100,
+        ).model_dump(mode="json")
+    )
+    deleted = item["engine"].retention(item["cap"]("durability"), command)
+    assert deleted["payload"]["schema_version"] == "ContextDeletionReceiptV2"
+    assert deleted["payload"]["checkpoint_durability_mode"] == "unregistered"
+    assert deleted["payload"]["checkpoint_manifest_checksum"] is None
+    assert deleted["payload"]["remote_deletion_receipt_digest"] is None
+    inconsistent = {
+        **deleted["payload"],
+        "checkpoint_durability_mode": "remote_registered",
+        "checkpoint_durability_registration_receipt_digest": digest("registration"),
+        "remote_deletion_receipt_digest": digest("remote deletion"),
+        "checkpoint_object_ref_digest": digest("remote object"),
+    }
+    with pytest.raises(
+        ValueError, match="without a checkpoint cannot contain deletion evidence"
+    ):
+        ContextDeletionReceiptV2.model_validate(inconsistent)
+
+
 def test_keyed_checkpoint_hydrates_on_replacement_using_opaque_reference(tmp_path):
     item = _keyed_cycle(tmp_path)
     engine, cap, namespace = item["engine"], item["cap"], item["namespace"]
@@ -704,7 +1499,31 @@ def test_keyed_checkpoint_hydrates_on_replacement_using_opaque_reference(tmp_pat
     )
     checkpoint = engine.checkpoint(cap("durability"), "host-replacement-checkpoint")
     claim = checkpoint["receipt"]["payload"]
-    replacement = item["make"](tmp_path / "replacement.sqlite3")
+    replacement_signer = ReceiptSigner(
+        "contextd-replacement", Ed25519PrivateKey.generate()
+    )
+    replacement = ContextEngine(
+        tmp_path / "replacement.sqlite3",
+        item["profile"],
+        item["global_cipher"],
+        replacement_signer,
+        {item["authority"].key_id: item["authority"].key.public_key()},
+        {item["proof"].key_id: item["proof"].key.public_key()},
+        clock=lambda: item["clock"][0],
+        cycle_keys=item["provider"],
+        remote_deletion_keys={
+            item["deletion"].key_id: item["deletion"].key.public_key()
+        },
+        managed_key_provider_receipts=item["provider_receipts"],
+        key_provider_keys={
+            item["provider_authority"].key_id: item[
+                "provider_authority"
+            ].key.public_key()
+        },
+        key_destruction_keys={
+            item["destruction"].key_id: item["destruction"].key.public_key()
+        },
+    )
     grant = item["authority"].sign(
         {
             "operation": "hydrate",
@@ -714,7 +1533,7 @@ def test_keyed_checkpoint_hydrates_on_replacement_using_opaque_reference(tmp_pat
             "key_provider": claim["key_provider"],
             "key_version": claim["key_version"],
             "fence": 2,
-            "expires_at": 2000,
+            "expires_at": 1900,
         }
     )
     hydrate = replacement.hydrate(
@@ -731,6 +1550,28 @@ def test_keyed_checkpoint_hydrates_on_replacement_using_opaque_reference(tmp_pat
     assert hydrate_payload["key_ref"] == claim["key_ref"]
     assert hydrate_payload["key_version"] == claim["key_version"]
     assert hydrate_payload["replay_digest"]
+    with replacement.store.connection() as db:
+        durability = db.execute(
+            "SELECT checkpoint_durability_mode,checkpoint_durability_legacy,"
+            "checkpoint_durability_command_digest,checkpoint_durability_receipt "
+            "FROM cycles"
+        ).fetchone()
+    assert durability["checkpoint_durability_mode"] == "remote_registered"
+    assert durability["checkpoint_durability_legacy"] == 0
+    assert durability["checkpoint_durability_command_digest"] == digest(
+        item["durability_command"]["payload"]
+    )
+    durability_envelope = json.loads(durability["checkpoint_durability_receipt"])
+    durability_payload = verify(
+        durability_envelope,
+        {replacement.signer.key_id: replacement.signer.key.public_key()},
+    )
+    durability_claim = ContextCheckpointDurabilityReceiptV2.model_validate(
+        durability_payload
+    )
+    assert durability_claim.source_registration_receipt_digest == digest(
+        item["durability_receipt"]
+    )
     assert (
         replacement.hydrate(
             grant,
@@ -742,6 +1583,13 @@ def test_keyed_checkpoint_hydrates_on_replacement_using_opaque_reference(tmp_pat
     )
     with replacement.store.transaction() as db:
         db.execute("DELETE FROM postings")
+    with pytest.raises(ContextFault, match="hydrate_conflict"):
+        replacement.hydrate(
+            grant,
+            checkpoint["receipt"],
+            base64.b64decode(checkpoint["pack"], validate=True),
+            {engine.signer.key_id: engine.signer.key.public_key()},
+        )
     empty = replacement.retrieve(
         cap(fence=2),
         RetrieveRequestV1(
@@ -766,6 +1614,421 @@ def test_keyed_checkpoint_hydrates_on_replacement_using_opaque_reference(tmp_pat
         ),
     )
     assert capsule["payload"]["entries"][0]["text"] == "needle replacement evidence"
+    active = replacement.status(cap("durability", fence=2))["payload"]
+    replacement.control(
+        item["authority"].sign(
+            {
+                "operation": "abort",
+                "context_cycle_id": namespace.context_cycle_id,
+                "binding_digest": item["binding_digest"],
+                "expected_revision": active["revision"],
+                "fence": active["fence"],
+                "expires_at": 1100,
+            }
+        )
+    )
+    aborted = replacement.status(cap("durability", fence=2))["payload"]
+    item["clock"][0] = aborted["expires_at"] + 1
+    object_ref = digest("spaces://restored-checkpoint")
+    remote = item["deletion"].sign(
+        {
+            "schema_version": "ContextRemoteDeletionReceiptV1",
+            "namespace": namespace.model_dump(),
+            "manifest_checksum": claim["manifest_checksum"],
+            "object_ref_digest": object_ref,
+            "deleted": True,
+            "issued_at": item["clock"][0],
+            "expires_at": item["clock"][0] + 100,
+        }
+    )
+    retention_command = item["authority"].sign(
+        RetentionCommandV1(
+            operation="expire",
+            namespace=namespace,
+            idempotency_key="expire-restored-checkpoint",
+            expected_revision=aborted["revision"],
+            reason_code="policy_expiry",
+            remote_deletion_receipt=remote,
+            checkpoint_object_ref_digest=object_ref,
+            issued_at=item["clock"][0],
+            expires_at=item["clock"][0] + 100,
+        ).model_dump(mode="json")
+    )
+    deletion = replacement.retention(
+        cap("durability", fence=2), retention_command
+    )
+    assert deletion["payload"]["schema_version"] == "ContextDeletionReceiptV2"
+    assert deletion["payload"]["remote_deletion_receipt_digest"] == digest(remote)
+    assert deletion["payload"]["checkpoint_manifest_checksum"] == claim[
+        "manifest_checksum"
+    ]
+    assert deletion["payload"][
+        "checkpoint_durability_registration_receipt_digest"
+    ] == digest(durability_envelope)
+    without_registration = {
+        **deletion["payload"],
+        "checkpoint_durability_registration_receipt_digest": None,
+    }
+    with pytest.raises(ValueError, match="requires signed durability registration"):
+        ContextDeletionReceiptV2.model_validate(without_registration)
+
+
+def test_v2_hydrate_command_is_source_bound_and_receipt_is_exact(
+    tmp_path, monkeypatch
+):
+    build = ReceiptSigner("hydrate-build", Ed25519PrivateKey.generate())
+    source_revision = "c" * 40
+    dependencies = [
+        "annotated-types",
+        "cffi",
+        "cryptography",
+        "numpy",
+        "pycparser",
+        "pydantic",
+        "pydantic_core",
+        "typing-inspection",
+        "typing_extensions",
+    ]
+    environment = RuntimeEnvironmentV2(
+        python_implementation="cpython",
+        python_version="3.13.0",
+        python_abi="cp313-test",
+        python_executable_digest=digest("hydrate-python"),
+        dependency_import_closure=dependencies,
+        dependency_versions={name: "1.0" for name in dependencies},
+        dependency_artifact_digests={name: digest(name) for name in dependencies},
+        sqlite_version=sqlite3.sqlite_version,
+        package_import_root_digest=digest("hydrate-site-packages"),
+    )
+    package_digest = digest("hydrate-package-tree")
+    build_manifest = build.sign(
+        {
+            "schema_version": "ContextRuntimeBuildManifestV3",
+            "distribution": "aether-context",
+            "version": __version__,
+            "source_revision": source_revision,
+            "package_tree_digest": package_digest,
+            "wheel_digest": digest("hydrate-wheel"),
+            "recall_dataset_digest": digest("hydrate-recall-dataset"),
+            "data_plane_case_generator_digest": digest("hydrate-case-generator"),
+            "built_at": 900,
+            "runtime_environment": environment.model_dump(mode="json"),
+            "locked_environment_digest": digest(environment),
+        }
+    )
+    monkeypatch.setattr(
+        "aether_context.engine.runtime_environment_identity",
+        lambda **_: environment,
+    )
+    monkeypatch.setattr(
+        "aether_context.engine.runtime_package_tree_digest",
+        lambda **_: package_digest,
+    )
+    item = _keyed_cycle(
+        tmp_path,
+        runtime_build_manifest=build_manifest,
+        runtime_build_keys={build.key_id: build.key.public_key()},
+    )
+    environment_measurements = 0
+    package_measurements = 0
+
+    def measured_environment(**_):
+        nonlocal environment_measurements
+        environment_measurements += 1
+        return environment
+
+    def measured_package(**_):
+        nonlocal package_measurements
+        package_measurements += 1
+        return package_digest
+
+    monkeypatch.setattr(
+        "aether_context.engine.runtime_environment_identity", measured_environment
+    )
+    monkeypatch.setattr(
+        "aether_context.engine.runtime_package_tree_digest", measured_package
+    )
+    item["engine"].append(
+        item["cap"](),
+        AppendRequestV1(
+            idempotency_key="v2-hot-path",
+            text="runtime identity remains cached on the write path",
+            action_ref="v2-hot-path",
+        ),
+    )
+    checkpoint = item["engine"].checkpoint(
+        item["cap"]("durability"), "v2-hydrate-checkpoint"
+    )
+    item["engine"].status(item["cap"]("durability"))
+    item["engine"].retrieve(
+        item["cap"](),
+        RetrieveRequestV1(
+            turn_id="v2-hot-path-cached-retrieve",
+            query="cached runtime identity",
+            native_window=32_768,
+            remaining_prompt_budget=4_096,
+        ),
+    )
+    assert (environment_measurements, package_measurements) == (0, 0)
+    item["clock"][0] += 61
+    item["engine"].retrieve(
+        item["cap"](),
+        RetrieveRequestV1(
+            turn_id="v2-hot-path-refreshed-retrieve",
+            query="refreshed runtime identity",
+            native_window=32_768,
+            remaining_prompt_budget=4_096,
+        ),
+    )
+    assert (environment_measurements, package_measurements) == (1, 1)
+    assert item["engine"].health_v2()["runtime_build_ready"] is True
+    assert (environment_measurements, package_measurements) == (2, 2)
+    item["engine"].reserve_v2(
+        item["authority"].sign(
+            ContextReservationCommandV2(
+                owner_id="hot-path-owner",
+                project_id="hot-path-project",
+                idempotency_key="hot-path-admission",
+                request_digest=digest("hot-path-admission"),
+                profile_digest=digest(item["profile"]),
+                expires_at=item["clock"][0] + 100,
+            ).model_dump(mode="json")
+        )
+    )
+    assert (environment_measurements, package_measurements) == (3, 3)
+    claim = checkpoint["receipt"]["payload"]
+    command_payload = ContextHydrateCommandV2(
+        namespace=item["namespace"],
+        manifest_checksum=claim["manifest_checksum"],
+        key_ref=claim["key_ref"],
+        key_provider=claim["key_provider"],
+        key_version=claim["key_version"],
+        fence=2,
+        expected_source_revision=source_revision,
+        issued_at=item["clock"][0],
+        expires_at=item["clock"][0] + 100,
+    ).model_dump(mode="json")
+    command = item["authority"].sign(command_payload)
+    replacement = item["make"](tmp_path / "v2-hydrate-replacement.sqlite3")
+    checkpoint_keys = {
+        item["service"].key_id: item["service"].key.public_key()
+    }
+    hydrate_request = {
+        "operation": "hydrate",
+        "grant": command,
+        "checkpoint_receipt": checkpoint["receipt"],
+        "pack": checkpoint["pack"],
+    }
+    replacement_service = ContextService(
+        replacement, checkpoint_receipt_keys=checkpoint_keys
+    )
+    receipt = replacement_service.dispatch(hydrate_request)
+    with replacement.store.connection() as db:
+        restored = db.execute(
+            "SELECT checkpoint_durability_mode,checkpoint_durability_legacy,"
+            "checkpoint_durability_command_digest FROM cycles"
+        ).fetchone()
+    assert tuple(restored) == (
+        "remote_registered",
+        0,
+        digest(item["durability_command"]["payload"]),
+    )
+    payload = verify(
+        receipt,
+        {replacement.signer.key_id: replacement.signer.key.public_key()},
+    )
+    assert ContextHydrateReceiptV2.model_validate(payload).model_dump(
+        mode="json"
+    ) == payload
+    assert payload["hydrate_command_digest"] == digest(command_payload)
+    assert payload["expected_source_revision"] == source_revision
+    wrong_key = {
+        **command_payload,
+        "key_ref": "wrong-key-ref",
+        "key_provider": "wrong-provider/v1",
+        "key_version": "wrong-key-version",
+    }
+    with pytest.raises(ContextFault, match="hydrate_grant_invalid"):
+        replacement.hydrate(
+            item["authority"].sign(wrong_key),
+            checkpoint["receipt"],
+            base64.b64decode(checkpoint["pack"], validate=True),
+            {item["service"].key_id: item["service"].key.public_key()},
+        )
+    assert replacement_service.dispatch(hydrate_request) == receipt
+
+    # Lost acknowledgements reconcile against the persisted signed result even
+    # after the original grant expires, including concurrent exact retries.
+    item["clock"][0] += 101
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        replayed = list(
+            executor.map(
+                lambda _: replacement_service.dispatch(hydrate_request),
+                range(8),
+            )
+        )
+    assert replayed == [receipt] * 8
+
+    fresh_payload = {
+        **command_payload,
+        "issued_at": item["clock"][0],
+        "expires_at": item["clock"][0] + 100,
+    }
+    with pytest.raises(ContextFault, match="hydrate_conflict"):
+        replacement.hydrate(
+            item["authority"].sign(fresh_payload),
+            checkpoint["receipt"],
+            base64.b64decode(checkpoint["pack"], validate=True),
+            checkpoint_keys,
+        )
+    original_pack = base64.b64decode(checkpoint["pack"], validate=True)
+    with pytest.raises(ContextFault, match="integrity_failure"):
+        replacement.hydrate(
+            command,
+            checkpoint["receipt"],
+            original_pack[:-1] + bytes([original_pack[-1] ^ 1]),
+            checkpoint_keys,
+        )
+    empty_after_expiry = item["make"](
+        tmp_path / "v2-hydrate-expired-first-attempt.sqlite3"
+    )
+    with pytest.raises(ContextFault, match="capability_denied"):
+        empty_after_expiry.hydrate(
+            command,
+            checkpoint["receipt"],
+            original_pack,
+            checkpoint_keys,
+        )
+
+    # A replacement checkpoint embeds a V2 reattestation. The next host
+    # verifies that immediate source but carries the same original signed V1
+    # registration forward instead of growing a nested receipt chain.
+    second_checkpoint = replacement.checkpoint(
+        item["cap"]("durability", fence=2), "v2-second-hop-checkpoint"
+    )
+    second_claim = second_checkpoint["receipt"]["payload"]
+    second_command_payload = ContextHydrateCommandV2(
+        namespace=item["namespace"],
+        manifest_checksum=second_claim["manifest_checksum"],
+        key_ref=second_claim["key_ref"],
+        key_provider=second_claim["key_provider"],
+        key_version=second_claim["key_version"],
+        fence=3,
+        expected_source_revision=source_revision,
+        issued_at=item["clock"][0],
+        expires_at=item["clock"][0] + 100,
+    ).model_dump(mode="json")
+    second_request = {
+        "operation": "hydrate",
+        "grant": item["authority"].sign(second_command_payload),
+        "checkpoint_receipt": second_checkpoint["receipt"],
+        "pack": second_checkpoint["pack"],
+    }
+    second_replacement = item["make"](
+        tmp_path / "v2-hydrate-second-replacement.sqlite3"
+    )
+    second_service = ContextService(
+        second_replacement,
+        checkpoint_receipt_keys={
+            replacement.signer.key_id: replacement.signer.key.public_key()
+        },
+    )
+    second_receipt = second_service.dispatch(second_request)
+    second_payload = verify(
+        second_receipt,
+        {
+            second_replacement.signer.key_id:
+            second_replacement.signer.key.public_key()
+        },
+    )
+    assert (
+        second_payload["checkpoint_durability_registration_receipt"][
+            "payload"
+        ]["source_registration_receipt"]
+        == item["durability_receipt"]
+    )
+    assert second_payload[
+        "checkpoint_durability_registration_receipt"
+    ]["payload"]["source_registration_receipt_digest"] == digest(
+        item["durability_receipt"]
+    )
+    assert second_service.dispatch(second_request) == second_receipt
+
+    active = second_replacement.status(
+        item["cap"]("durability", fence=3)
+    )["payload"]
+    second_replacement.control(
+        item["authority"].sign(
+            {
+                "operation": "abort",
+                "context_cycle_id": item["namespace"].context_cycle_id,
+                "binding_digest": item["binding_digest"],
+                "expected_revision": active["revision"],
+                "fence": active["fence"],
+                "expires_at": item["clock"][0] + 100,
+            }
+        )
+    )
+    aborted = second_replacement.status(
+        item["cap"]("durability", fence=3)
+    )["payload"]
+    item["clock"][0] = aborted["expires_at"] + 1
+    object_ref = digest("spaces://context/v2-second-hop")
+    remote = item["deletion"].sign(
+        {
+            "schema_version": "ContextRemoteDeletionReceiptV1",
+            "namespace": item["namespace"].model_dump(),
+            "manifest_checksum": second_claim["manifest_checksum"],
+            "object_ref_digest": object_ref,
+            "deleted": True,
+            "issued_at": item["clock"][0],
+            "expires_at": item["clock"][0] + 100,
+        }
+    )
+    delete_command = item["authority"].sign(
+        RetentionCommandV1(
+            operation="expire",
+            namespace=item["namespace"],
+            idempotency_key="expire-v2-second-hop",
+            expected_revision=aborted["revision"],
+            reason_code="policy_expiry",
+            remote_deletion_receipt=remote,
+            checkpoint_object_ref_digest=object_ref,
+            issued_at=item["clock"][0],
+            expires_at=item["clock"][0] + 100,
+        ).model_dump(mode="json")
+    )
+    deleted = second_replacement.retention(
+        item["cap"]("durability", fence=3), delete_command
+    )
+    assert deleted["payload"][
+        "checkpoint_durability_registration_receipt_digest"
+    ] == digest(
+        second_payload["checkpoint_durability_registration_receipt"]
+    )
+    assert second_replacement.retention(
+        item["cap"]("durability", fence=3), delete_command
+    ) == deleted
+
+    measurements_before_expiry = (
+        environment_measurements,
+        package_measurements,
+    )
+    item["clock"][0] = 2001
+    with pytest.raises(ContextFault, match="hosted_gate_unready"):
+        item["engine"].retrieve(
+            item["cap"](),
+            RetrieveRequestV1(
+                turn_id="v2-hot-path-expired-evidence",
+                query="expired provider evidence",
+                native_window=32_768,
+                remaining_prompt_budget=4_096,
+            ),
+        )
+    assert (environment_measurements, package_measurements) == (
+        measurements_before_expiry[0] + 1,
+        measurements_before_expiry[1] + 1,
+    )
 
 
 def test_managed_key_rotation_keeps_v1_and_v2_cycles_hydratable_and_expirable(
@@ -825,7 +2088,7 @@ def test_managed_key_rotation_keeps_v1_and_v2_cycles_hydratable_and_expirable(
                     "key_provider": v1_claim["key_provider"],
                     "key_version": v1_claim["key_version"],
                     "fence": 2,
-                    "expires_at": 2000,
+                    "expires_at": 1900,
                 }
             ),
             v1_checkpoint["receipt"],
@@ -913,6 +2176,19 @@ def test_managed_key_rotation_keeps_v1_and_v2_cycles_hydratable_and_expirable(
             ).model_dump()
         )
 
+    durability_status = engine.status(cap_v2("durability"))["payload"]
+    engine.register_checkpoint_durability(
+        item["authority"].sign(
+            ContextCheckpointDurabilityCommandV1(
+                namespace=namespace_v2,
+                idempotency_key="register-rotation-v2",
+                expected_revision=durability_status["revision"],
+                mode="remote_registered",
+                issued_at=item["clock"][0],
+                expires_at=item["clock"][0] + 100,
+            ).model_dump(mode="json")
+        )
+    )
     engine.append(
         cap_v2(),
         AppendRequestV1(
@@ -945,7 +2221,7 @@ def test_managed_key_rotation_keeps_v1_and_v2_cycles_hydratable_and_expirable(
                     "key_provider": claim["key_provider"],
                     "key_version": claim["key_version"],
                     "fence": 2,
-                    "expires_at": 2000,
+                    "expires_at": 1900,
                 }
             ),
             checkpoint["receipt"],
@@ -1064,7 +2340,7 @@ def test_hydrate_receipts_distinguish_checkpoints_with_the_same_root(tmp_path):
                     "key_provider": claim["key_provider"],
                     "key_version": claim["key_version"],
                     "fence": 2,
-                    "expires_at": 2000,
+                    "expires_at": 1900,
                 }
             ),
             checkpoint["receipt"],
@@ -1206,7 +2482,7 @@ def _scale_evidence():
             "schema_version": "ContextExecutorStabilityReceiptV1",
             "source_revision": revision,
             "profile_benchmark_digest": profile_benchmark_digest(provisional),
-            "target_concurrency": 8,
+            "target_concurrency": provisional.max_concurrent_cycles,
             "ci_receipt_digest": digest("executor-ci-observation"),
             "executor_stable": True,
             "started_at": 800,
@@ -1230,7 +2506,7 @@ def _scale_evidence():
         reachable_tokens=2_250,
         resident_peak_bytes=100_000_000,
         retrieval_samples=20,
-        target_concurrency=8,
+        target_concurrency=provisional.max_concurrent_cycles,
         retrieval_p50_ms=10,
         retrieval_p95_ms=20,
         retrieval_p99_ms=30,
@@ -1295,6 +2571,34 @@ def test_scale_receipt_enables_reach_only_for_exact_signed_build():
     )
     assert qualified.valid is True
     assert qualified.reachable_tokens == 2250
+    under_target_stability = stability.sign(
+        {
+            **envelope["payload"]["executor_stability_receipt"]["payload"],
+            "target_concurrency": 1,
+        }
+    )
+    under_target = benchmark.sign(
+        {
+            **envelope["payload"],
+            "target_concurrency": 1,
+            "executor_stability_receipt": under_target_stability,
+        }
+    )
+    under_target_profile = profile.model_copy(
+        update={"benchmark_receipt": digest(under_target)}
+    )
+    with pytest.raises(ContextFault, match="benchmark_profile_mismatch"):
+        qualify_scale_receipt(
+            under_target_profile,
+            under_target,
+            keys,
+            now=1000,
+            expected_source_revision=revision,
+            expected_recall_dataset_digest=dataset_digest,
+            expected_data_plane_case_generator_digest=generator_digest,
+            executor_stability_keys=stability_keys,
+            data_plane_isolation_keys=isolation_keys,
+        )
     wrong_build = qualify_scale_receipt(
         profile,
         envelope,
@@ -1413,19 +2717,24 @@ def test_hosted_reach_claim_stays_off_when_managed_retention_is_not_ready(tmp_pa
     provider_authority = ReceiptSigner("health-kms-authority", Ed25519PrivateKey.generate())
     build = ReceiptSigner("health-build", Ed25519PrivateKey.generate())
     clock = [1000]
+    runtime_environment = runtime_environment_identity()
     build_manifest = build.sign(
         {
-            "schema_version": "ContextRuntimeBuildManifestV1",
+            "schema_version": "ContextRuntimeBuildManifestV3",
             "distribution": "aether-context",
             "version": __version__,
             "source_revision": revision,
-            "package_tree_digest": runtime_package_tree_digest(),
+            "package_tree_digest": runtime_package_tree_digest(
+                require_source_only=True
+            ),
             "wheel_digest": digest("exact-built-wheel"),
             "recall_dataset_digest": dataset_digest,
             "data_plane_case_generator_digest": digest(
                 "randomized-data-plane-cases/v1"
             ),
             "built_at": 800,
+            "runtime_environment": runtime_environment.model_dump(mode="json"),
+            "locked_environment_digest": digest(runtime_environment),
         }
     )
     common = {
@@ -1475,9 +2784,33 @@ def test_hosted_reach_claim_stays_off_when_managed_retention_is_not_ready(tmp_pa
     )
     healthy_engine = make(tmp_path / "healthy.sqlite3", managed, provider_receipt)
     healthy = healthy_engine.health()
+    assert ContextHealthV1.model_validate(healthy).model_dump(mode="json") == healthy
+    assert "runtime_package_tree_digest" not in healthy
     assert healthy["ready"] is True
     assert healthy["reach_claim_enabled"] is True
+    healthy_v2 = healthy_engine.health_v2()
+    assert ContextHealthV2.model_validate(healthy_v2).model_dump(mode="json") == healthy_v2
+    assert (
+        healthy_v2["runtime_package_tree_digest"]
+        == build_manifest["payload"]["package_tree_digest"]
+        == runtime_package_tree_digest(require_source_only=True)
+    )
+    assert healthy_v2["runtime_locked_environment_digest"] == digest(
+        runtime_environment
+    )
+    assert healthy_v2["runtime_python_abi"] == runtime_environment.python_abi
+    assert (
+        healthy_v2["runtime_dependency_versions"]
+        == runtime_environment.dependency_versions
+    )
+    assert (
+        healthy_v2["runtime_dependency_artifact_digests"]
+        == runtime_environment.dependency_artifact_digests
+    )
     legacy_build_payload = build_manifest["payload"].copy()
+    legacy_build_payload["schema_version"] = "ContextRuntimeBuildManifestV1"
+    legacy_build_payload.pop("runtime_environment")
+    legacy_build_payload.pop("locked_environment_digest")
     legacy_build_payload.pop("data_plane_case_generator_digest")
     legacy_build_common = {
         **common,
@@ -1504,6 +2837,9 @@ def test_hosted_reach_claim_stays_off_when_managed_retention_is_not_ready(tmp_pa
         "data_plane_case_generator_unbound"
         in legacy_build_health["benchmark_failures"]
     )
+    assert "runtime_environment_unbound" in legacy_build_health[
+        "runtime_build_failures"
+    ]
     clock[0] = 1200
     expired = healthy_engine.health()
     assert expired["ready"] is False
@@ -1542,6 +2878,41 @@ def test_hosted_reach_claim_stays_off_when_managed_retention_is_not_ready(tmp_pa
     assert build_blocked["reach_claim_enabled"] is False
     assert "runtime_package_tree_mismatch" in build_blocked["runtime_build_failures"]
 
+    changed_environment = runtime_environment.model_copy(
+        update={
+            "dependency_versions": {
+                **runtime_environment.dependency_versions,
+                "pydantic": "0.0.0-mismatch",
+            }
+        }
+    )
+    wrong_environment_manifest = build.sign(
+        {
+            **build_manifest["payload"],
+            "runtime_environment": changed_environment.model_dump(mode="json"),
+            "locked_environment_digest": digest(changed_environment),
+        }
+    )
+    environment_blocked = ContextEngine(
+        tmp_path / "wrong-environment.sqlite3",
+        profile,
+        EnvelopeCipher(os.urandom(32)),
+        service,
+        {authority.key_id: authority.key.public_key()},
+        {proof.key_id: proof.key.public_key()},
+        clock=lambda: clock[0],
+        cycle_keys=managed,
+        managed_key_provider_receipt=provider_receipt,
+        key_provider_keys={
+            provider_authority.key_id: provider_authority.key.public_key()
+        },
+        **{**common, "runtime_build_manifest": wrong_environment_manifest},
+    ).health_v2()
+    assert environment_blocked["ready"] is False
+    assert "runtime_environment_mismatch" in environment_blocked[
+        "runtime_build_failures"
+    ]
+
 
 def test_million_case_namespace_isolation_is_deterministic():
     result = run_namespace_isolation()
@@ -1550,6 +2921,57 @@ def test_million_case_namespace_isolation_is_deterministic():
     assert result["result_digest"] == (
         "dae81f9acfb516a098fa758d7d31be4390ff4cb256b0fda8efb9316906851036"
     )
+
+
+def test_source_only_digest_rejects_timestamp_pyc_and_native_shadow_artifacts(
+    tmp_path, monkeypatch
+):
+    package = tmp_path / "aether_context"
+    package.mkdir()
+    source = package / "engine.py"
+    benign = "VALUE = 'SAFE'\n"
+    malicious = "VALUE = 'PWN!'\n"
+    assert len(benign) == len(malicious)
+    source.write_text(benign)
+    baseline = runtime_package_tree_digest(package)
+    source.write_text(malicious)
+    timestamp = 1_700_000_000
+    os.utime(source, (timestamp, timestamp))
+    py_compile.compile(
+        str(source),
+        doraise=True,
+        invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP,
+    )
+    source.write_text(benign)
+    os.utime(source, (timestamp, timestamp))
+    assert runtime_package_tree_digest(package) == baseline
+    monkeypatch.setattr(sys, "dont_write_bytecode", True)
+    with pytest.raises(ContextFault, match="runtime_import_artifact"):
+        runtime_package_tree_digest(package, require_source_only=True)
+
+    shutil.rmtree(package / "__pycache__")
+    for suffix in (".pyd", ".so"):
+        shadow = package / ("engine" + suffix)
+        shadow.write_bytes(b"native-shadow")
+        with pytest.raises(ContextFault, match="runtime_import_artifact"):
+            runtime_package_tree_digest(package, require_source_only=True)
+        shadow.unlink()
+
+
+def test_health_v2_returns_closed_unready_projection_when_rehash_fails(
+    tmp_path, monkeypatch
+):
+    item = _keyed_cycle(tmp_path)
+
+    def unavailable(*_args, **_kwargs):
+        raise ContextFault("context_runtime_build_invalid")
+
+    monkeypatch.setattr("aether_context.engine.runtime_package_tree_digest", unavailable)
+    health = item["engine"].health_v2()
+    assert ContextHealthV2.model_validate(health).model_dump(mode="json") == health
+    assert health["ready"] is False
+    assert health["runtime_package_tree_digest"] is None
+    assert "runtime_package_tree_unavailable" in health["runtime_build_failures"]
 
 
 def test_sqlite_wal_discards_uncommitted_process_crash(tmp_path):


### PR DESCRIPTION
Cloud host replacement and retention retries need an exact, durable result instead of reissuing effects against short-lived runtime configuration. This adds revisioned reservation release/revival and bind commands, signed checkpoint-durability registration, V2 hydrate/re-attestation with atomic startup result publication, and replay-safe expiry evidence while preserving the existing V1 compatibility path.

The hosted boundary now starts through a source-only pre-import guard, reports measured `ContextHealthV3` capabilities, caps live checkpoint packs at 13,000,000 bytes and decompressed snapshots at 16,000,000 bytes, and includes a required Linux Unix-socket memory gate. The measured near-cap run moved 12,775,155 bytes (98.27% of the advertised cap), served 4/4 concurrent small calls, rejected an exact one-byte replay mismatch without mutation, and peaked at 378,978,304 bytes under the service limit. Retention tests cover restart and provider-retirement replay, remote deletion ordering, and immutable receipts.

Validation: 707 passed, 9 skipped on the exact commit; Ruff clean; mypy clean across 24 source files; hosted schema export/reproducibility clean; Windows restore 15 passed/3 POSIX skips; WSL restore 19 passed; reservation lifecycle 25 passed; independent review found no P0/P1 issues.

This is source hardening only. Runtime reach claims remain disabled, and Gate 0, Gate 8, production deployment, live-provider canary, and one-billion-token reach remain unproven pending deployment-supplied evidence.
